### PR TITLE
Add InterpreterStorage trait to encapsulate VM req

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -28,6 +28,10 @@ where
     fn contains_key(&self, key: &K) -> Result<bool, DataError>;
 }
 
+/// When this trait is implemented, the underlying interpreter is guaranteed to
+/// have full functionality
+pub trait InterpreterStorage: Storage<ContractAddress, Contract> + Storage<Color, Word> {}
+
 // Provisory implementation that will cover ID definitions until client backend
 // is implemented
 impl Key for Color {}

--- a/src/data/memory.rs
+++ b/src/data/memory.rs
@@ -1,4 +1,4 @@
-use super::{DataError, Storage};
+use super::{DataError, InterpreterStorage, Storage};
 use crate::interpreter::Contract;
 
 use fuel_asm::Word;
@@ -47,3 +47,5 @@ impl Storage<Color, Word> for MemoryStorage {
         Ok(self.color_balances.contains_key(key))
     }
 }
+
+impl InterpreterStorage for MemoryStorage {}

--- a/src/interpreter/blockchain.rs
+++ b/src/interpreter/blockchain.rs
@@ -1,6 +1,6 @@
-use super::{Contract, Interpreter, MemoryRange};
+use super::{Interpreter, MemoryRange};
 use crate::consts::*;
-use crate::data::Storage;
+use crate::data::InterpreterStorage;
 
 use fuel_asm::Word;
 use fuel_tx::{Address, Color, ContractAddress, Input};
@@ -9,7 +9,7 @@ use std::convert::TryFrom;
 
 impl<S> Interpreter<S>
 where
-    S: Storage<ContractAddress, Contract> + Storage<Color, Word>,
+    S: InterpreterStorage,
 {
     pub fn burn(&mut self, a: Word) -> bool {
         let (x, overflow) = self.registers[REG_FP].overflowing_add(Address::size_of() as Word);

--- a/src/interpreter/contract.rs
+++ b/src/interpreter/contract.rs
@@ -1,7 +1,7 @@
 use super::{ExecuteError, Interpreter, MemoryRange};
 use crate::consts::*;
 use crate::crypto;
-use crate::data::Storage;
+use crate::data::InterpreterStorage;
 
 use fuel_asm::{Opcode, Word};
 use fuel_tx::bytes::{SerializableVec, SizedBytes};
@@ -86,7 +86,7 @@ impl Contract {
 
 impl<S> Interpreter<S>
 where
-    S: Storage<ContractAddress, Contract> + Storage<Color, Word>,
+    S: InterpreterStorage,
 {
     pub fn contract(&self, address: &ContractAddress) -> Result<Option<Contract>, ExecuteError> {
         Ok(self.storage.get(address)?)

--- a/src/interpreter/execution.rs
+++ b/src/interpreter/execution.rs
@@ -1,15 +1,14 @@
-use super::{Contract, ExecuteError, Interpreter};
-use crate::data::Storage;
+use super::{ExecuteError, Interpreter};
+use crate::data::InterpreterStorage;
 
 use fuel_asm::{Opcode, RegisterId, Word};
-use fuel_tx::{Color, ContractAddress};
 use tracing::debug;
 
 use std::ops::Div;
 
 impl<S> Interpreter<S>
 where
-    S: Storage<ContractAddress, Contract> + Storage<Color, Word>,
+    S: InterpreterStorage,
 {
     pub fn execute(&mut self, op: Opcode) -> Result<(), ExecuteError> {
         let mut result = Ok(());

--- a/src/interpreter/executors.rs
+++ b/src/interpreter/executors.rs
@@ -1,13 +1,12 @@
-use super::{Contract, ExecuteError, Interpreter};
-use crate::data::Storage;
+use super::{ExecuteError, Interpreter};
+use crate::data::InterpreterStorage;
 
-use fuel_asm::Word;
 use fuel_tx::bytes::Deserializable;
-use fuel_tx::{Color, ContractAddress, Transaction};
+use fuel_tx::Transaction;
 
 impl<S> Interpreter<S>
 where
-    S: Storage<ContractAddress, Contract> + Storage<Color, Word>,
+    S: InterpreterStorage,
 {
     pub fn execute_tx_bytes(storage: S, bytes: &[u8]) -> Result<Self, ExecuteError> {
         let tx = Transaction::from_bytes(bytes)?;

--- a/src/interpreter/flow.rs
+++ b/src/interpreter/flow.rs
@@ -1,17 +1,17 @@
-use super::{Call, Contract, Interpreter};
+use super::{Call, Interpreter};
 use crate::consts::*;
-use crate::data::Storage;
+use crate::data::InterpreterStorage;
 
 use fuel_asm::{RegisterId, Word};
 use fuel_tx::bytes::SerializableVec;
-use fuel_tx::{Color, ContractAddress, Input};
+use fuel_tx::{Color, Input};
 
 use std::convert::TryFrom;
 use std::io::Write;
 
 impl<S> Interpreter<S>
 where
-    S: Storage<ContractAddress, Contract> + Storage<Color, Word>,
+    S: InterpreterStorage,
 {
     // TODO add CIMV tests
     pub fn check_input_maturity(&mut self, ra: RegisterId, b: Word, c: Word) -> bool {

--- a/src/interpreter/frame.rs
+++ b/src/interpreter/frame.rs
@@ -1,6 +1,6 @@
 use super::{Contract, ExecuteError, Interpreter, MemoryRange};
 use crate::consts::*;
-use crate::data::Storage;
+use crate::data::InterpreterStorage;
 
 use fuel_asm::Word;
 use fuel_tx::bytes::SizedBytes;
@@ -275,7 +275,7 @@ impl io::Write for CallFrame {
 
 impl<S> Interpreter<S>
 where
-    S: Storage<ContractAddress, Contract> + Storage<Color, Word>,
+    S: InterpreterStorage,
 {
     pub fn call_frame(&self, call: Call, color: Color) -> Result<CallFrame, ExecuteError> {
         let (to, inputs, outputs) = call.into_inner();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub mod data;
 pub mod interpreter;
 
 pub mod prelude {
-    pub use crate::data::{MemoryStorage, Storage};
+    pub use crate::data::{InterpreterStorage, MemoryStorage, Storage};
     pub use crate::interpreter::{Call, CallFrame, Contract, ExecuteError, Interpreter, LogEvent, MemoryRange};
     pub use fuel_asm::{Immediate06, Immediate12, Immediate18, Immediate24, Opcode, RegisterId, Word};
     pub use fuel_tx::{

--- a/tests/interpreter/mod.rs
+++ b/tests/interpreter/mod.rs
@@ -26,7 +26,7 @@ pub fn deploy_contract<S>(
     program: &[Opcode],
 ) -> ContractAddress
 where
-    S: Storage<ContractAddress, Contract> + Storage<Color, Word>,
+    S: InterpreterStorage,
 {
     let salt: Salt = common::r();
     let program = Witness::from(program_to_bytes(program));


### PR DESCRIPTION
The users of this library must be agnostic of the internal requirements
of the VM.

This way, a trait encapsulating all these implementations required from
the storage is needed to provide a fully implemented Interpreter.

Following the same pattern, if we need to introduce an ALU-only storage
implementation, we may create the AluStorage trait with the required
signatures.