### PR TITLE
Add `gas_charge` function to the interpreter

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -164,6 +164,10 @@ impl<S> Interpreter<S> {
         self.context().is_external()
     }
 
+    pub const fn is_predicate(&self) -> bool {
+        matches!(self.context, Context::Predicate)
+    }
+
     pub const fn is_unsafe_math(&self) -> bool {
         self.registers[REG_FLAG] & 0x01 == 0x01
     }

--- a/src/interpreter/error.rs
+++ b/src/interpreter/error.rs
@@ -24,6 +24,7 @@ pub enum ExecuteError {
     NotEnoughBalance,
     ExpectedInternalContext,
     ExternalColorNotFound,
+    OutOfGas,
 
     #[cfg(feature = "debug")]
     DebugStateNotInitialized,

--- a/src/interpreter/executors.rs
+++ b/src/interpreter/executors.rs
@@ -148,6 +148,11 @@ where
 
         let tx_size = tx.serialized_size() as Word;
 
+        if tx.is_script() {
+            self.registers[REG_GGAS] = tx.gas_limit();
+            self.registers[REG_CGAS] = tx.gas_limit();
+        }
+
         self.push_stack(&tx_size.to_be_bytes())?;
         self.push_stack(tx.to_bytes().as_slice())?;
 
@@ -356,238 +361,274 @@ where
         }
 
         match op {
-            Opcode::ADD(ra, rb, rc) if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op) => {
+            Opcode::ADD(ra, rb, rc)
+                if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op).is_ok() =>
+            {
                 self.alu_overflow(ra, Word::overflowing_add, self.registers[rb], self.registers[rc])
             }
 
-            Opcode::ADDI(ra, rb, imm) if Self::is_valid_register_couple_alu(ra, rb) && self.gas_charge(&op) => {
+            Opcode::ADDI(ra, rb, imm) if Self::is_valid_register_couple_alu(ra, rb) && self.gas_charge(&op).is_ok() => {
                 self.alu_overflow(ra, Word::overflowing_add, self.registers[rb], imm as Word)
             }
 
-            Opcode::AND(ra, rb, rc) if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op) => {
+            Opcode::AND(ra, rb, rc)
+                if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op).is_ok() =>
+            {
                 self.alu_set(ra, self.registers[rb] & self.registers[rc])
             }
 
-            Opcode::ANDI(ra, rb, imm) if Self::is_valid_register_couple_alu(ra, rb) && self.gas_charge(&op) => {
+            Opcode::ANDI(ra, rb, imm) if Self::is_valid_register_couple_alu(ra, rb) && self.gas_charge(&op).is_ok() => {
                 self.alu_set(ra, self.registers[rb] & (imm as Word))
             }
 
-            Opcode::DIV(ra, rb, rc) if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op) => self
-                .alu_error(
+            Opcode::DIV(ra, rb, rc)
+                if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op).is_ok() =>
+            {
+                self.alu_error(
                     ra,
                     Word::div,
                     self.registers[rb],
                     self.registers[rc],
                     self.registers[rc] == 0,
-                ),
+                )
+            }
 
-            Opcode::DIVI(ra, rb, imm) if Self::is_valid_register_couple_alu(ra, rb) && self.gas_charge(&op) => {
+            Opcode::DIVI(ra, rb, imm) if Self::is_valid_register_couple_alu(ra, rb) && self.gas_charge(&op).is_ok() => {
                 self.alu_error(ra, Word::div, self.registers[rb], imm as Word, imm == 0)
             }
 
-            Opcode::EQ(ra, rb, rc) if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op) => {
+            Opcode::EQ(ra, rb, rc)
+                if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op).is_ok() =>
+            {
                 self.alu_set(ra, (self.registers[rb] == self.registers[rc]) as Word)
             }
 
-            Opcode::EXP(ra, rb, rc) if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op) => {
+            Opcode::EXP(ra, rb, rc)
+                if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op).is_ok() =>
+            {
                 self.alu_overflow(ra, Word::overflowing_pow, self.registers[rb], self.registers[rc] as u32)
             }
 
-            Opcode::EXPI(ra, rb, imm) if Self::is_valid_register_couple_alu(ra, rb) && self.gas_charge(&op) => {
+            Opcode::EXPI(ra, rb, imm) if Self::is_valid_register_couple_alu(ra, rb) && self.gas_charge(&op).is_ok() => {
                 self.alu_overflow(ra, Word::overflowing_pow, self.registers[rb], imm as u32)
             }
 
-            Opcode::GT(ra, rb, rc) if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op) => {
+            Opcode::GT(ra, rb, rc)
+                if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op).is_ok() =>
+            {
                 self.alu_set(ra, (self.registers[rb] > self.registers[rc]) as Word)
             }
 
-            Opcode::MLOG(ra, rb, rc) if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op) => self
-                .alu_error(
+            Opcode::MLOG(ra, rb, rc)
+                if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op).is_ok() =>
+            {
+                self.alu_error(
                     ra,
                     |b, c| (b as f64).log(c as f64).trunc() as Word,
                     self.registers[rb],
                     self.registers[rc],
                     self.registers[rb] == 0 || self.registers[rc] <= 1,
-                ),
+                )
+            }
 
-            Opcode::MROO(ra, rb, rc) if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op) => self
-                .alu_error(
+            Opcode::MROO(ra, rb, rc)
+                if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op).is_ok() =>
+            {
+                self.alu_error(
                     ra,
                     |b, c| (b as f64).powf((c as f64).recip()).trunc() as Word,
                     self.registers[rb],
                     self.registers[rc],
                     self.registers[rc] == 0,
-                ),
+                )
+            }
 
-            Opcode::MOD(ra, rb, rc) if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op) => self
-                .alu_error(
+            Opcode::MOD(ra, rb, rc)
+                if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op).is_ok() =>
+            {
+                self.alu_error(
                     ra,
                     Word::wrapping_rem,
                     self.registers[rb],
                     self.registers[rc],
                     self.registers[rc] == 0,
-                ),
+                )
+            }
 
-            Opcode::MODI(ra, rb, imm) if Self::is_valid_register_couple_alu(ra, rb) && self.gas_charge(&op) => {
+            Opcode::MODI(ra, rb, imm) if Self::is_valid_register_couple_alu(ra, rb) && self.gas_charge(&op).is_ok() => {
                 self.alu_error(ra, Word::wrapping_rem, self.registers[rb], imm as Word, imm == 0)
             }
 
-            Opcode::MOVE(ra, rb) if Self::is_valid_register_couple_alu(ra, rb) && self.gas_charge(&op) => {
+            Opcode::MOVE(ra, rb) if Self::is_valid_register_couple_alu(ra, rb) && self.gas_charge(&op).is_ok() => {
                 self.alu_set(ra, self.registers[rb])
             }
 
-            Opcode::MUL(ra, rb, rc) if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op) => {
+            Opcode::MUL(ra, rb, rc)
+                if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op).is_ok() =>
+            {
                 self.alu_overflow(ra, Word::overflowing_mul, self.registers[rb], self.registers[rc])
             }
 
-            Opcode::MULI(ra, rb, imm) if Self::is_valid_register_couple_alu(ra, rb) && self.gas_charge(&op) => {
+            Opcode::MULI(ra, rb, imm) if Self::is_valid_register_couple_alu(ra, rb) && self.gas_charge(&op).is_ok() => {
                 self.alu_overflow(ra, Word::overflowing_mul, self.registers[rb], imm as Word)
             }
 
-            Opcode::NOOP if self.gas_charge(&op) => self.alu_clear(),
+            Opcode::NOOP if self.gas_charge(&op).is_ok() => self.alu_clear(),
 
-            Opcode::NOT(ra, rb) if Self::is_valid_register_couple_alu(ra, rb) && self.gas_charge(&op) => {
+            Opcode::NOT(ra, rb) if Self::is_valid_register_couple_alu(ra, rb) && self.gas_charge(&op).is_ok() => {
                 self.alu_set(ra, !self.registers[rb])
             }
 
-            Opcode::OR(ra, rb, rc) if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op) => {
+            Opcode::OR(ra, rb, rc)
+                if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op).is_ok() =>
+            {
                 self.alu_set(ra, self.registers[rb] | self.registers[rc])
             }
 
-            Opcode::ORI(ra, rb, imm) if Self::is_valid_register_couple_alu(ra, rb) && self.gas_charge(&op) => {
+            Opcode::ORI(ra, rb, imm) if Self::is_valid_register_couple_alu(ra, rb) && self.gas_charge(&op).is_ok() => {
                 self.alu_set(ra, self.registers[rb] | (imm as Word))
             }
 
-            Opcode::SLL(ra, rb, rc) if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op) => {
+            Opcode::SLL(ra, rb, rc)
+                if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op).is_ok() =>
+            {
                 self.alu_overflow(ra, Word::overflowing_shl, self.registers[rb], self.registers[rc] as u32)
             }
 
-            Opcode::SLLI(ra, rb, imm) if Self::is_valid_register_couple_alu(ra, rb) && self.gas_charge(&op) => {
+            Opcode::SLLI(ra, rb, imm) if Self::is_valid_register_couple_alu(ra, rb) && self.gas_charge(&op).is_ok() => {
                 self.alu_overflow(ra, Word::overflowing_shl, self.registers[rb], imm as u32)
             }
 
-            Opcode::SRL(ra, rb, rc) if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op) => {
+            Opcode::SRL(ra, rb, rc)
+                if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op).is_ok() =>
+            {
                 self.alu_overflow(ra, Word::overflowing_shr, self.registers[rb], self.registers[rc] as u32)
             }
 
-            Opcode::SRLI(ra, rb, imm) if Self::is_valid_register_couple_alu(ra, rb) && self.gas_charge(&op) => {
+            Opcode::SRLI(ra, rb, imm) if Self::is_valid_register_couple_alu(ra, rb) && self.gas_charge(&op).is_ok() => {
                 self.alu_overflow(ra, Word::overflowing_shr, self.registers[rb], imm as u32)
             }
 
-            Opcode::SUB(ra, rb, rc) if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op) => {
+            Opcode::SUB(ra, rb, rc)
+                if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op).is_ok() =>
+            {
                 self.alu_overflow(ra, Word::overflowing_sub, self.registers[rb], self.registers[rc])
             }
 
-            Opcode::SUBI(ra, rb, imm) if Self::is_valid_register_couple_alu(ra, rb) && self.gas_charge(&op) => {
+            Opcode::SUBI(ra, rb, imm) if Self::is_valid_register_couple_alu(ra, rb) && self.gas_charge(&op).is_ok() => {
                 self.alu_overflow(ra, Word::overflowing_sub, self.registers[rb], imm as Word)
             }
 
-            Opcode::XOR(ra, rb, rc) if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op) => {
+            Opcode::XOR(ra, rb, rc)
+                if Self::is_valid_register_triple_alu(ra, rb, rc) && self.gas_charge(&op).is_ok() =>
+            {
                 self.alu_set(ra, self.registers[rb] ^ self.registers[rc])
             }
 
-            Opcode::XORI(ra, rb, imm) if Self::is_valid_register_couple_alu(ra, rb) && self.gas_charge(&op) => {
+            Opcode::XORI(ra, rb, imm) if Self::is_valid_register_couple_alu(ra, rb) && self.gas_charge(&op).is_ok() => {
                 self.alu_set(ra, self.registers[rb] ^ (imm as Word))
             }
 
             Opcode::CIMV(ra, rb, rc)
                 if Self::is_valid_register_triple_alu(ra, rb, rc)
-                    && self.gas_charge(&op)
+                    && self.gas_charge(&op).is_ok()
                     && self.check_input_maturity(ra, self.registers[rb], self.registers[rc])
                     && self.inc_pc() => {}
 
             Opcode::CTMV(ra, rb)
                 if Self::is_valid_register_couple_alu(ra, rb)
-                    && self.gas_charge(&op)
+                    && self.gas_charge(&op).is_ok()
                     && self.check_tx_maturity(ra, self.registers[rb])
                     && self.inc_pc() => {}
 
-            Opcode::JI(imm) if self.gas_charge(&op) && self.jump(imm as Word) => {}
+            Opcode::JI(imm) if self.gas_charge(&op).is_ok() && self.jump(imm as Word) => {}
 
             Opcode::JNEI(ra, rb, imm)
                 if Self::is_valid_register_couple(ra, rb)
-                    && self.gas_charge(&op)
+                    && self.gas_charge(&op).is_ok()
                     && self.jump_not_equal_imm(self.registers[ra], self.registers[rb], imm as Word) => {}
 
-            Opcode::RET(ra) if Self::is_valid_register(ra) && self.gas_charge(&op) && self.ret(ra) && self.inc_pc() => {
+            Opcode::RET(ra)
+                if Self::is_valid_register(ra) && self.gas_charge(&op).is_ok() && self.ret(ra) && self.inc_pc() =>
+            {
                 result = Ok(ExecuteState::Return(self.registers[ra]));
             }
 
             Opcode::ALOC(ra)
                 if Self::is_valid_register(ra)
-                    && self.gas_charge(&op)
+                    && self.gas_charge(&op).is_ok()
                     && self.malloc(self.registers[ra])
                     && self.inc_pc() => {}
 
             Opcode::CFEI(imm)
-                if self.gas_charge(&op)
+                if self.gas_charge(&op).is_ok()
                     && self.stack_pointer_overflow(Word::overflowing_add, imm as Word)
                     && self.inc_pc() => {}
 
             Opcode::CFSI(imm)
-                if self.gas_charge(&op)
+                if self.gas_charge(&op).is_ok()
                     && self.stack_pointer_overflow(Word::overflowing_sub, imm as Word)
                     && self.inc_pc() => {}
 
             Opcode::LB(ra, rb, imm)
                 if Self::is_valid_register_couple_alu(ra, rb)
-                    && self.gas_charge(&op)
+                    && self.gas_charge(&op).is_ok()
                     && self.load_byte(ra, rb, imm as Word)
                     && self.inc_pc() => {}
 
             Opcode::LW(ra, rb, imm)
                 if Self::is_valid_register_couple_alu(ra, rb)
-                    && self.gas_charge(&op)
+                    && self.gas_charge(&op).is_ok()
                     && self.load_word(ra, self.registers[rb], imm as Word)
                     && self.inc_pc() => {}
 
             Opcode::MCL(ra, rb)
                 if Self::is_valid_register_couple(ra, rb)
-                    && self.gas_charge(&op)
+                    && self.gas_charge(&op).is_ok()
                     && self.memclear(self.registers[ra], self.registers[rb])
                     && self.inc_pc() => {}
 
             Opcode::MCLI(ra, imm)
                 if Self::is_valid_register(ra)
-                    && self.gas_charge(&op)
+                    && self.gas_charge(&op).is_ok()
                     && self.memclear(self.registers[ra], imm as Word)
                     && self.inc_pc() => {}
 
             Opcode::MCP(ra, rb, rc)
                 if Self::is_valid_register_triple(ra, rb, rc)
-                    && self.gas_charge(&op)
+                    && self.gas_charge(&op).is_ok()
                     && self.memcopy(self.registers[ra], self.registers[rb], self.registers[rc])
                     && self.inc_pc() => {}
 
             Opcode::MEQ(ra, rb, rc, rd)
                 if Self::is_valid_register_quadruple_alu(ra, rb, rc, rd)
-                    && self.gas_charge(&op)
+                    && self.gas_charge(&op).is_ok()
                     && self.memeq(ra, self.registers[rb], self.registers[rc], self.registers[rd])
                     && self.inc_pc() => {}
 
             Opcode::SB(ra, rb, imm)
                 if Self::is_valid_register_couple(ra, rb)
-                    && self.gas_charge(&op)
+                    && self.gas_charge(&op).is_ok()
                     && self.store_byte(self.registers[ra], self.registers[rb], imm as Word)
                     && self.inc_pc() => {}
 
             Opcode::SW(ra, rb, imm)
                 if Self::is_valid_register_couple(ra, rb)
-                    && self.gas_charge(&op)
+                    && self.gas_charge(&op).is_ok()
                     && self.store_word(self.registers[ra], self.registers[rb], imm as Word)
                     && self.inc_pc() => {}
 
-            Opcode::BHEI(ra) if Self::is_valid_register_alu(ra) && self.gas_charge(&op) && self.inc_pc() => {
+            Opcode::BHEI(ra) if Self::is_valid_register_alu(ra) && self.gas_charge(&op).is_ok() && self.inc_pc() => {
                 self.registers[ra] = self.block_height() as Word
             }
 
             // TODO BLOCKHASH: Block hash
             Opcode::BURN(ra)
-                if Self::is_valid_register(ra) && self.gas_charge(&op) && self.burn(self.registers[ra])? => {}
+                if Self::is_valid_register(ra) && self.gas_charge(&op).is_ok() && self.burn(self.registers[ra])? => {}
 
             Opcode::CALL(ra, rb, rc, rd)
                 if Self::is_valid_register_quadruple(ra, rb, rc, rd)
-                    && self.gas_charge(&op)
+                    && self.gas_charge(&op).is_ok()
                     && self
                         .call(
                             self.registers[ra],
@@ -599,7 +640,7 @@ where
 
             Opcode::CCP(ra, rb, rc, rd)
                 if Self::is_valid_register_quadruple(ra, rb, rc, rd)
-                    && self.gas_charge(&op)
+                    && self.gas_charge(&op).is_ok()
                     && self.code_copy(
                         self.registers[ra],
                         self.registers[rb],
@@ -614,12 +655,12 @@ where
             // TODO LOADCODE: Load code from an external contract
             Opcode::LOG(ra, rb, rc, rd)
                 if Self::is_valid_register_quadruple(ra, rb, rc, rd)
-                    && self.gas_charge(&op)
+                    && self.gas_charge(&op).is_ok()
                     && self.log_append(&[ra, rb, rc, rd])
                     && self.inc_pc() => {}
 
             Opcode::MINT(ra)
-                if Self::is_valid_register(ra) && self.gas_charge(&op) && self.mint(self.registers[ra])? => {}
+                if Self::is_valid_register(ra) && self.gas_charge(&op).is_ok() && self.mint(self.registers[ra])? => {}
 
             // TODO REVERT: Revert
             // TODO SLOADCODE: Load code from static list
@@ -631,23 +672,23 @@ where
             // TODO TRANSFEROUT: Transfer coins to output
             Opcode::ECR(ra, rb, rc)
                 if Self::is_valid_register_triple(ra, rb, rc)
-                    && self.gas_charge(&op)
+                    && self.gas_charge(&op).is_ok()
                     && self.ecrecover(self.registers[ra], self.registers[rb], self.registers[rc])
                     && self.inc_pc() => {}
 
             Opcode::K256(ra, rb, rc)
                 if Self::is_valid_register_triple(ra, rb, rc)
-                    && self.gas_charge(&op)
+                    && self.gas_charge(&op).is_ok()
                     && self.keccak256(self.registers[ra], self.registers[rb], self.registers[rc])
                     && self.inc_pc() => {}
 
             Opcode::S256(ra, rb, rc)
                 if Self::is_valid_register_triple(ra, rb, rc)
-                    && self.gas_charge(&op)
+                    && self.gas_charge(&op).is_ok()
                     && self.sha256(self.registers[ra], self.registers[rb], self.registers[rc])
                     && self.inc_pc() => {}
 
-            Opcode::FLAG(ra) if Self::is_valid_register(ra) && self.gas_charge(&op) && self.inc_pc() => {
+            Opcode::FLAG(ra) if Self::is_valid_register(ra) && self.gas_charge(&op).is_ok() && self.inc_pc() => {
                 self.set_flag(self.registers[ra])
             }
 

--- a/src/interpreter/frame.rs
+++ b/src/interpreter/frame.rs
@@ -156,6 +156,10 @@ impl CallFrame {
     pub const fn b(&self) -> Word {
         self.b
     }
+
+    pub const fn context_gas(&self) -> Word {
+        self.registers[REG_CGAS]
+    }
 }
 
 impl SizedBytes for CallFrame {


### PR DESCRIPTION
The gas cost for every opcode is expected to be decomposed into atomic
`GasUnits`.

These will represent individual operations performed while executing the
opcode. Some examples are:

Arithmetic
Branching
MemoryOwnership
MemoryWrite(bytes)
RegisterRead
RegisterWrite

All these atomic operations are associated with a constant gas cost.
Having a mapping between a given opcode + VM state -> decomposed gas
units, it is trivial to calculate the gas cost for any code execution.

Currently, the opcode decomposition into gas units is performed
manually. It can, however, and trivially, be converted into build-time
opcode execution syntax tree conversion into gas units.