### PR TITLE
Add `StackHeapCollision` error

### DIFF
--- a/src/interpreter/error.rs
+++ b/src/interpreter/error.rs
@@ -15,6 +15,7 @@ pub enum ExecuteError {
     TransactionCreateIdNotInTx,
     ArithmeticOverflow,
     StackOverflow,
+    StackHeapCollision,
     PredicateOverflow,
     ProgramOverflow,
     PredicateFailure,

--- a/src/interpreter/flow.rs
+++ b/src/interpreter/flow.rs
@@ -86,7 +86,7 @@ where
         let len = stack.len() as Word;
 
         if len > self.registers[REG_HP] || self.registers[REG_SP] > self.registers[REG_HP] - len {
-            return Err(ExecuteError::StackOverflow);
+            return Err(ExecuteError::StackHeapCollision);
         }
 
         self.registers[REG_FP] = self.registers[REG_SP];


### PR DESCRIPTION
If an attempt to increase the stack space results in memory intersection
with the heap, then `ExecuteError::StackHeapCollision` should be
returned

Resolves #19