### PR TITLE
Refactor interpreter instructions to return Result

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -29,6 +29,7 @@ pub enum InterpreterError {
     InputNotFound,
     OutputNotFound,
     WitnessNotFound,
+    TxMaturity,
 
     #[cfg(feature = "debug")]
     DebugStateNotInitialized,

--- a/src/interpreter/alu.rs
+++ b/src/interpreter/alu.rs
@@ -1,10 +1,17 @@
 use super::Interpreter;
 use crate::consts::*;
+use crate::error::InterpreterError;
 
 use fuel_types::{RegisterId, Word};
 
 impl<S> Interpreter<S> {
-    pub(crate) fn alu_overflow<B, C>(&mut self, ra: RegisterId, f: fn(B, C) -> (Word, bool), b: B, c: C) {
+    pub(crate) fn alu_overflow<B, C>(
+        &mut self,
+        ra: RegisterId,
+        f: fn(B, C) -> (Word, bool),
+        b: B,
+        c: C,
+    ) -> Result<(), InterpreterError> {
         let (result, overflow) = f(b, c);
 
         // TODO If the F_UNSAFEMATH flag is unset, an operation that would have set $err
@@ -18,31 +25,38 @@ impl<S> Interpreter<S> {
 
         self.registers[ra] = result;
 
-        self.inc_pc();
+        self.inc_pc()
     }
 
-    pub(crate) fn alu_error<B, C>(&mut self, ra: RegisterId, f: fn(B, C) -> Word, b: B, c: C, err: bool) {
+    pub(crate) fn alu_error<B, C>(
+        &mut self,
+        ra: RegisterId,
+        f: fn(B, C) -> Word,
+        b: B,
+        c: C,
+        err: bool,
+    ) -> Result<(), InterpreterError> {
         self.registers[REG_OF] = 0;
         self.registers[REG_ERR] = err as Word;
 
         self.registers[ra] = if err { 0 } else { f(b, c) };
 
-        self.inc_pc();
+        self.inc_pc()
     }
 
-    pub(crate) fn alu_set(&mut self, ra: RegisterId, b: Word) {
+    pub(crate) fn alu_set(&mut self, ra: RegisterId, b: Word) -> Result<(), InterpreterError> {
         self.registers[REG_OF] = 0;
         self.registers[REG_ERR] = 0;
 
         self.registers[ra] = b;
 
-        self.inc_pc();
+        self.inc_pc()
     }
 
-    pub(crate) fn alu_clear(&mut self) {
+    pub(crate) fn alu_clear(&mut self) -> Result<(), InterpreterError> {
         self.registers[REG_OF] = 0;
         self.registers[REG_ERR] = 0;
 
-        self.inc_pc();
+        self.inc_pc()
     }
 }

--- a/src/interpreter/blockchain.rs
+++ b/src/interpreter/blockchain.rs
@@ -31,9 +31,7 @@ where
         self.storage
             .merkle_contract_color_balance_insert(contract, color, balance)?;
 
-        self.inc_pc();
-
-        Ok(())
+        self.inc_pc()
     }
 
     pub(crate) fn mint(&mut self, a: Word) -> Result<(), InterpreterError> {
@@ -49,9 +47,7 @@ where
         self.storage
             .merkle_contract_color_balance_insert(contract, color, balance)?;
 
-        self.inc_pc();
-
-        Ok(())
+        self.inc_pc()
     }
 
     pub(crate) fn code_copy(&mut self, a: Word, b: Word, c: Word, d: Word) -> Result<(), InterpreterError> {
@@ -88,9 +84,7 @@ where
             self.try_mem_write(a, &contract.as_ref()[c..cd])?;
         }
 
-        self.inc_pc();
-
-        Ok(())
+        self.inc_pc()
     }
 
     pub(crate) fn block_hash(&mut self, a: Word, b: Word) -> Result<(), InterpreterError> {
@@ -98,18 +92,14 @@ where
 
         self.try_mem_write(a as usize, hash.as_ref())?;
 
-        self.inc_pc();
-
-        Ok(())
+        self.inc_pc()
     }
 
     pub(crate) fn block_proposer(&mut self, a: Word) -> Result<(), InterpreterError> {
         self.coinbase()
             .and_then(|data| self.try_mem_write(a as usize, data.as_ref()))?;
 
-        self.inc_pc();
-
-        Ok(())
+        self.inc_pc()
     }
 
     pub(crate) fn code_root(&mut self, a: Word, b: Word) -> Result<(), InterpreterError> {
@@ -131,9 +121,7 @@ where
 
         self.try_mem_write(a, root.as_ref())?;
 
-        self.inc_pc();
-
-        Ok(())
+        self.inc_pc()
     }
 
     pub(crate) fn code_size(&mut self, ra: RegisterId, b: Word) -> Result<(), InterpreterError> {
@@ -148,9 +136,7 @@ where
 
         self.registers[ra] = self.contract(contract_id)?.as_ref().as_ref().len() as Word;
 
-        self.inc_pc();
-
-        Ok(())
+        self.inc_pc()
     }
 
     pub(crate) fn state_read_word(&mut self, ra: RegisterId, b: Word) -> Result<(), InterpreterError> {
@@ -172,9 +158,7 @@ where
             .map(Word::from_be_bytes)
             .unwrap_or(0);
 
-        self.inc_pc();
-
-        Ok(())
+        self.inc_pc()
     }
 
     pub(crate) fn state_read_qword(&mut self, a: Word, b: Word) -> Result<(), InterpreterError> {
@@ -197,9 +181,7 @@ where
 
         self.try_mem_write(a, state.as_ref())?;
 
-        self.inc_pc();
-
-        Ok(())
+        self.inc_pc()
     }
 
     pub(crate) fn state_write_word(&mut self, a: Word, b: Word) -> Result<(), InterpreterError> {
@@ -220,9 +202,7 @@ where
 
         self.storage.merkle_contract_state_insert(contract, key, &value)?;
 
-        self.inc_pc();
-
-        Ok(())
+        self.inc_pc()
     }
 
     pub(crate) fn state_write_qword(&mut self, a: Word, b: Word) -> Result<(), InterpreterError> {
@@ -240,8 +220,6 @@ where
 
         self.storage.merkle_contract_state_insert(contract, key, value)?;
 
-        self.inc_pc();
-
-        Ok(())
+        self.inc_pc()
     }
 }

--- a/src/interpreter/crypto.rs
+++ b/src/interpreter/crypto.rs
@@ -35,9 +35,7 @@ impl<S> Interpreter<S> {
             }
         }
 
-        self.inc_pc();
-
-        Ok(())
+        self.inc_pc()
     }
 
     pub(crate) fn keccak256(&mut self, a: Word, b: Word, c: Word) -> Result<(), InterpreterError> {
@@ -56,9 +54,7 @@ impl<S> Interpreter<S> {
 
         self.try_mem_write(a, h.finalize().as_slice())?;
 
-        self.inc_pc();
-
-        Ok(())
+        self.inc_pc()
     }
 
     pub(crate) fn sha256(&mut self, a: Word, b: Word, c: Word) -> Result<(), InterpreterError> {
@@ -71,8 +67,6 @@ impl<S> Interpreter<S> {
 
         self.try_mem_write(a, Hasher::hash(&self.memory[b..bc]).as_ref())?;
 
-        self.inc_pc();
-
-        Ok(())
+        self.inc_pc()
     }
 }

--- a/src/interpreter/executors/instruction.rs
+++ b/src/interpreter/executors/instruction.rs
@@ -26,170 +26,245 @@ where
         // TODO catch panic receipt
 
         match op {
-            Opcode::ADD(ra, rb, rc) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() => {
-                self.alu_overflow(ra, Word::overflowing_add, self.registers[rb], self.registers[rc])
-            }
+            Opcode::ADD(ra, rb, rc)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self
+                        .alu_overflow(ra, Word::overflowing_add, self.registers[rb], self.registers[rc])
+                        .is_ok() => {}
 
-            Opcode::ADDI(ra, rb, imm) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() => {
-                self.alu_overflow(ra, Word::overflowing_add, self.registers[rb], imm as Word)
-            }
+            Opcode::ADDI(ra, rb, imm)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self
+                        .alu_overflow(ra, Word::overflowing_add, self.registers[rb], imm as Word)
+                        .is_ok() => {}
 
-            Opcode::AND(ra, rb, rc) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() => {
-                self.alu_set(ra, self.registers[rb] & self.registers[rc])
-            }
+            Opcode::AND(ra, rb, rc)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self.alu_set(ra, self.registers[rb] & self.registers[rc]).is_ok() => {}
 
-            Opcode::ANDI(ra, rb, imm) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() => {
-                self.alu_set(ra, self.registers[rb] & (imm as Word))
-            }
+            Opcode::ANDI(ra, rb, imm)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self.alu_set(ra, self.registers[rb] & (imm as Word)).is_ok() => {}
 
-            Opcode::DIV(ra, rb, rc) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() => self
-                .alu_error(
-                    ra,
-                    Word::div,
-                    self.registers[rb],
-                    self.registers[rc],
-                    self.registers[rc] == 0,
-                ),
+            Opcode::DIV(ra, rb, rc)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self
+                        .alu_error(
+                            ra,
+                            Word::div,
+                            self.registers[rb],
+                            self.registers[rc],
+                            self.registers[rc] == 0,
+                        )
+                        .is_ok() => {}
 
-            Opcode::DIVI(ra, rb, imm) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() => {
-                self.alu_error(ra, Word::div, self.registers[rb], imm as Word, imm == 0)
-            }
+            Opcode::DIVI(ra, rb, imm)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self
+                        .alu_error(ra, Word::div, self.registers[rb], imm as Word, imm == 0)
+                        .is_ok() => {}
 
-            Opcode::EQ(ra, rb, rc) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() => {
-                self.alu_set(ra, (self.registers[rb] == self.registers[rc]) as Word)
-            }
+            Opcode::EQ(ra, rb, rc)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self
+                        .alu_set(ra, (self.registers[rb] == self.registers[rc]) as Word)
+                        .is_ok() => {}
 
-            Opcode::EXP(ra, rb, rc) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() => {
-                self.alu_overflow(ra, Word::overflowing_pow, self.registers[rb], self.registers[rc] as u32)
-            }
+            Opcode::EXP(ra, rb, rc)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self
+                        .alu_overflow(ra, Word::overflowing_pow, self.registers[rb], self.registers[rc] as u32)
+                        .is_ok() => {}
 
-            Opcode::EXPI(ra, rb, imm) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() => {
-                self.alu_overflow(ra, Word::overflowing_pow, self.registers[rb], imm as u32)
-            }
+            Opcode::EXPI(ra, rb, imm)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self
+                        .alu_overflow(ra, Word::overflowing_pow, self.registers[rb], imm as u32)
+                        .is_ok() => {}
 
-            Opcode::GT(ra, rb, rc) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() => {
-                self.alu_set(ra, (self.registers[rb] > self.registers[rc]) as Word)
-            }
+            Opcode::GT(ra, rb, rc)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self
+                        .alu_set(ra, (self.registers[rb] > self.registers[rc]) as Word)
+                        .is_ok() => {}
 
-            Opcode::LT(ra, rb, rc) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() => {
-                self.alu_set(ra, (self.registers[rb] < self.registers[rc]) as Word)
-            }
+            Opcode::LT(ra, rb, rc)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self
+                        .alu_set(ra, (self.registers[rb] < self.registers[rc]) as Word)
+                        .is_ok() => {}
 
-            Opcode::MLOG(ra, rb, rc) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() => self
-                .alu_error(
-                    ra,
-                    |b, c| (b as f64).log(c as f64).trunc() as Word,
-                    self.registers[rb],
-                    self.registers[rc],
-                    self.registers[rb] == 0 || self.registers[rc] <= 1,
-                ),
+            Opcode::MLOG(ra, rb, rc)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self
+                        .alu_error(
+                            ra,
+                            |b, c| (b as f64).log(c as f64).trunc() as Word,
+                            self.registers[rb],
+                            self.registers[rc],
+                            self.registers[rb] == 0 || self.registers[rc] <= 1,
+                        )
+                        .is_ok() => {}
 
-            Opcode::MOD(ra, rb, rc) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() => self
-                .alu_error(
-                    ra,
-                    Word::wrapping_rem,
-                    self.registers[rb],
-                    self.registers[rc],
-                    self.registers[rc] == 0,
-                ),
+            Opcode::MOD(ra, rb, rc)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self
+                        .alu_error(
+                            ra,
+                            Word::wrapping_rem,
+                            self.registers[rb],
+                            self.registers[rc],
+                            self.registers[rc] == 0,
+                        )
+                        .is_ok() => {}
 
-            Opcode::MODI(ra, rb, imm) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() => {
-                self.alu_error(ra, Word::wrapping_rem, self.registers[rb], imm as Word, imm == 0)
-            }
+            Opcode::MODI(ra, rb, imm)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self
+                        .alu_error(ra, Word::wrapping_rem, self.registers[rb], imm as Word, imm == 0)
+                        .is_ok() => {}
 
-            Opcode::MOVE(ra, rb) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() => {
-                self.alu_set(ra, self.registers[rb])
-            }
+            Opcode::MOVE(ra, rb)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self.alu_set(ra, self.registers[rb]).is_ok() => {}
 
-            Opcode::MROO(ra, rb, rc) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() => self
-                .alu_error(
-                    ra,
-                    |b, c| (b as f64).powf((c as f64).recip()).trunc() as Word,
-                    self.registers[rb],
-                    self.registers[rc],
-                    self.registers[rc] == 0,
-                ),
+            Opcode::MROO(ra, rb, rc)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self
+                        .alu_error(
+                            ra,
+                            |b, c| (b as f64).powf((c as f64).recip()).trunc() as Word,
+                            self.registers[rb],
+                            self.registers[rc],
+                            self.registers[rc] == 0,
+                        )
+                        .is_ok() => {}
 
-            Opcode::MUL(ra, rb, rc) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() => {
-                self.alu_overflow(ra, Word::overflowing_mul, self.registers[rb], self.registers[rc])
-            }
+            Opcode::MUL(ra, rb, rc)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self
+                        .alu_overflow(ra, Word::overflowing_mul, self.registers[rb], self.registers[rc])
+                        .is_ok() => {}
 
-            Opcode::MULI(ra, rb, imm) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() => {
-                self.alu_overflow(ra, Word::overflowing_mul, self.registers[rb], imm as Word)
-            }
+            Opcode::MULI(ra, rb, imm)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self
+                        .alu_overflow(ra, Word::overflowing_mul, self.registers[rb], imm as Word)
+                        .is_ok() => {}
 
-            Opcode::NOOP if self.gas_charge(&op).is_ok() => self.alu_clear(),
+            Opcode::NOOP if self.gas_charge(&op).is_ok() && self.alu_clear().is_ok() => {}
 
-            Opcode::NOT(ra, rb) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() => {
-                self.alu_set(ra, !self.registers[rb])
-            }
+            Opcode::NOT(ra, rb)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self.alu_set(ra, !self.registers[rb]).is_ok() => {}
 
-            Opcode::OR(ra, rb, rc) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() => {
-                self.alu_set(ra, self.registers[rb] | self.registers[rc])
-            }
+            Opcode::OR(ra, rb, rc)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self.alu_set(ra, self.registers[rb] | self.registers[rc]).is_ok() => {}
 
-            Opcode::ORI(ra, rb, imm) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() => {
-                self.alu_set(ra, self.registers[rb] | (imm as Word))
-            }
+            Opcode::ORI(ra, rb, imm)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self.alu_set(ra, self.registers[rb] | (imm as Word)).is_ok() => {}
 
-            Opcode::SLL(ra, rb, rc) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() => {
-                self.alu_overflow(ra, Word::overflowing_shl, self.registers[rb], self.registers[rc] as u32)
-            }
+            Opcode::SLL(ra, rb, rc)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self
+                        .alu_overflow(ra, Word::overflowing_shl, self.registers[rb], self.registers[rc] as u32)
+                        .is_ok() => {}
 
-            Opcode::SLLI(ra, rb, imm) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() => {
-                self.alu_overflow(ra, Word::overflowing_shl, self.registers[rb], imm as u32)
-            }
+            Opcode::SLLI(ra, rb, imm)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self
+                        .alu_overflow(ra, Word::overflowing_shl, self.registers[rb], imm as u32)
+                        .is_ok() => {}
 
-            Opcode::SRL(ra, rb, rc) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() => {
-                self.alu_overflow(ra, Word::overflowing_shr, self.registers[rb], self.registers[rc] as u32)
-            }
+            Opcode::SRL(ra, rb, rc)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self
+                        .alu_overflow(ra, Word::overflowing_shr, self.registers[rb], self.registers[rc] as u32)
+                        .is_ok() => {}
 
-            Opcode::SRLI(ra, rb, imm) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() => {
-                self.alu_overflow(ra, Word::overflowing_shr, self.registers[rb], imm as u32)
-            }
+            Opcode::SRLI(ra, rb, imm)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self
+                        .alu_overflow(ra, Word::overflowing_shr, self.registers[rb], imm as u32)
+                        .is_ok() => {}
 
-            Opcode::SUB(ra, rb, rc) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() => {
-                self.alu_overflow(ra, Word::overflowing_sub, self.registers[rb], self.registers[rc])
-            }
+            Opcode::SUB(ra, rb, rc)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self
+                        .alu_overflow(ra, Word::overflowing_sub, self.registers[rb], self.registers[rc])
+                        .is_ok() => {}
 
-            Opcode::SUBI(ra, rb, imm) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() => {
-                self.alu_overflow(ra, Word::overflowing_sub, self.registers[rb], imm as Word)
-            }
+            Opcode::SUBI(ra, rb, imm)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self
+                        .alu_overflow(ra, Word::overflowing_sub, self.registers[rb], imm as Word)
+                        .is_ok() => {}
 
-            Opcode::XOR(ra, rb, rc) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() => {
-                self.alu_set(ra, self.registers[rb] ^ self.registers[rc])
-            }
+            Opcode::XOR(ra, rb, rc)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self.alu_set(ra, self.registers[rb] ^ self.registers[rc]).is_ok() => {}
 
-            Opcode::XORI(ra, rb, imm) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() => {
-                self.alu_set(ra, self.registers[rb] ^ (imm as Word))
-            }
+            Opcode::XORI(ra, rb, imm)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self.alu_set(ra, self.registers[rb] ^ (imm as Word)).is_ok() => {}
 
             Opcode::CIMV(ra, rb, rc)
                 if Self::is_register_writable(ra)
                     && self.gas_charge(&op).is_ok()
-                    && self.check_input_maturity(ra, self.registers[rb], self.registers[rc])
-                    && self.inc_pc() => {}
+                    && self
+                        .check_input_maturity(ra, self.registers[rb], self.registers[rc])
+                        .is_ok() => {}
 
             Opcode::CTMV(ra, rb)
                 if Self::is_register_writable(ra)
                     && self.gas_charge(&op).is_ok()
-                    && self.check_tx_maturity(ra, self.registers[rb])
-                    && self.inc_pc() => {}
+                    && self.check_tx_maturity(ra, self.registers[rb]).is_ok() => {}
 
-            Opcode::JI(imm) if self.gas_charge(&op).is_ok() && self.jump(imm as Word) => {}
+            Opcode::JI(imm) if self.gas_charge(&op).is_ok() && self.jump(imm as Word).is_ok() => {}
 
             Opcode::JNEI(ra, rb, imm)
                 if self.gas_charge(&op).is_ok()
-                    && self.jump_not_equal_imm(self.registers[ra], self.registers[rb], imm as Word) => {}
+                    && self
+                        .jump_not_equal_imm(self.registers[ra], self.registers[rb], imm as Word)
+                        .is_ok() => {}
 
-            Opcode::RET(ra) if self.gas_charge(&op).is_ok() && self.ret(self.registers[ra]) && self.inc_pc() => {
+            Opcode::RET(ra) if self.gas_charge(&op).is_ok() && self.ret(self.registers[ra]).is_ok() => {
                 result = Ok(ExecuteState::Return(self.registers[ra]));
             }
 
             Opcode::RETD(ra, rb)
-                if self.gas_charge(&op).is_ok()
-                    && self.ret_data(self.registers[ra], self.registers[rb])
-                    && self.inc_pc() =>
+                if self.gas_charge(&op).is_ok() && self.ret_data(self.registers[ra], self.registers[rb]).is_ok() =>
             {
                 // TODO optimize after execute refactor
                 let digest = *self
@@ -202,62 +277,61 @@ where
                 result = Ok(ExecuteState::ReturnData(digest));
             }
 
-            Opcode::ALOC(ra) if self.gas_charge(&op).is_ok() && self.malloc(self.registers[ra]) && self.inc_pc() => {}
+            Opcode::ALOC(ra) if self.gas_charge(&op).is_ok() && self.malloc(self.registers[ra]).is_ok() => {}
 
             Opcode::CFEI(imm)
                 if self.gas_charge(&op).is_ok()
-                    && self.stack_pointer_overflow(Word::overflowing_add, imm as Word)
-                    && self.inc_pc() => {}
+                    && self.stack_pointer_overflow(Word::overflowing_add, imm as Word).is_ok() => {}
 
             Opcode::CFSI(imm)
                 if self.gas_charge(&op).is_ok()
-                    && self.stack_pointer_overflow(Word::overflowing_sub, imm as Word)
-                    && self.inc_pc() => {}
+                    && self.stack_pointer_overflow(Word::overflowing_sub, imm as Word).is_ok() => {}
 
             Opcode::LB(ra, rb, imm)
                 if Self::is_register_writable(ra)
                     && self.gas_charge(&op).is_ok()
-                    && self.load_byte(ra, rb, imm as Word)
-                    && self.inc_pc() => {}
+                    && self.load_byte(ra, rb, imm as Word).is_ok() => {}
 
             Opcode::LW(ra, rb, imm)
                 if Self::is_register_writable(ra)
                     && self.gas_charge(&op).is_ok()
-                    && self.load_word(ra, self.registers[rb], imm as Word)
-                    && self.inc_pc() => {}
+                    && self.load_word(ra, self.registers[rb], imm as Word).is_ok() => {}
 
             Opcode::MCL(ra, rb)
-                if self.gas_charge(&op).is_ok()
-                    && self.memclear(self.registers[ra], self.registers[rb])
-                    && self.inc_pc() => {}
+                if self.gas_charge(&op).is_ok() && self.memclear(self.registers[ra], self.registers[rb]).is_ok() => {}
 
             Opcode::MCLI(ra, imm)
-                if self.gas_charge(&op).is_ok() && self.memclear(self.registers[ra], imm as Word) && self.inc_pc() => {}
+                if self.gas_charge(&op).is_ok() && self.memclear(self.registers[ra], imm as Word).is_ok() => {}
 
             Opcode::MCP(ra, rb, rc)
                 if self.gas_charge(&op).is_ok()
-                    && self.memcopy(self.registers[ra], self.registers[rb], self.registers[rc])
-                    && self.inc_pc() => {}
+                    && self
+                        .memcopy(self.registers[ra], self.registers[rb], self.registers[rc])
+                        .is_ok() => {}
 
             Opcode::MEQ(ra, rb, rc, rd)
                 if Self::is_register_writable(ra)
                     && self.gas_charge(&op).is_ok()
-                    && self.memeq(ra, self.registers[rb], self.registers[rc], self.registers[rd])
-                    && self.inc_pc() => {}
+                    && self
+                        .memeq(ra, self.registers[rb], self.registers[rc], self.registers[rd])
+                        .is_ok() => {}
 
             Opcode::SB(ra, rb, imm)
                 if self.gas_charge(&op).is_ok()
-                    && self.store_byte(self.registers[ra], self.registers[rb], imm as Word)
-                    && self.inc_pc() => {}
+                    && self
+                        .store_byte(self.registers[ra], self.registers[rb], imm as Word)
+                        .is_ok() => {}
 
             Opcode::SW(ra, rb, imm)
                 if self.gas_charge(&op).is_ok()
-                    && self.store_word(self.registers[ra], self.registers[rb], imm as Word)
-                    && self.inc_pc() => {}
+                    && self
+                        .store_word(self.registers[ra], self.registers[rb], imm as Word)
+                        .is_ok() => {}
 
-            Opcode::BHEI(ra) if Self::is_register_writable(ra) && self.gas_charge(&op).is_ok() && self.inc_pc() => {
-                self.registers[ra] = self.block_height() as Word
-            }
+            Opcode::BHEI(ra)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self.alu_set(ra, self.block_height() as Word).is_ok() => {}
 
             Opcode::BHSH(ra, rb)
                 if self.gas_charge(&op).is_ok() && self.block_hash(self.registers[ra], self.registers[rb]).is_ok() => {}
@@ -298,23 +372,25 @@ where
 
             Opcode::LOG(ra, rb, rc, rd)
                 if self.gas_charge(&op).is_ok()
-                    && self.log(
-                        self.registers[ra],
-                        self.registers[rb],
-                        self.registers[rc],
-                        self.registers[rd],
-                    )
-                    && self.inc_pc() => {}
+                    && self
+                        .log(
+                            self.registers[ra],
+                            self.registers[rb],
+                            self.registers[rc],
+                            self.registers[rd],
+                        )
+                        .is_ok() => {}
 
             Opcode::LOGD(ra, rb, rc, rd)
                 if self.gas_charge(&op).is_ok()
-                    && self.log_data(
-                        self.registers[ra],
-                        self.registers[rb],
-                        self.registers[rc],
-                        self.registers[rd],
-                    )
-                    && self.inc_pc() => {}
+                    && self
+                        .log_data(
+                            self.registers[ra],
+                            self.registers[rb],
+                            self.registers[rc],
+                            self.registers[rd],
+                        )
+                        .is_ok() => {}
 
             Opcode::MINT(ra) if self.gas_charge(&op).is_ok() && self.mint(self.registers[ra]).is_ok() => {}
 
@@ -353,43 +429,37 @@ where
                         .sha256(self.registers[ra], self.registers[rb], self.registers[rc])
                         .is_ok() => {}
 
-            Opcode::XIL(ra, rb) if self.gas_charge(&op).is_ok() && self.inc_pc() => {
-                result = self
-                    .transaction_input_length(ra, self.registers[rb])
-                    .map(|_| ExecuteState::Proceed)
-            }
+            Opcode::XIL(ra, rb)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self.transaction_input_length(ra, self.registers[rb]).is_ok() => {}
 
-            Opcode::XIS(ra, rb) if self.gas_charge(&op).is_ok() && self.inc_pc() => {
-                result = self
-                    .transaction_input_start(ra, self.registers[rb])
-                    .map(|_| ExecuteState::Proceed)
-            }
+            Opcode::XIS(ra, rb)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self.transaction_input_start(ra, self.registers[rb]).is_ok() => {}
 
-            Opcode::XOL(ra, rb) if self.gas_charge(&op).is_ok() && self.inc_pc() => {
-                result = self
-                    .transaction_output_length(ra, self.registers[rb])
-                    .map(|_| ExecuteState::Proceed)
-            }
+            Opcode::XOL(ra, rb)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self.transaction_output_length(ra, self.registers[rb]).is_ok() => {}
 
-            Opcode::XOS(ra, rb) if self.gas_charge(&op).is_ok() && self.inc_pc() => {
-                result = self
-                    .transaction_output_start(ra, self.registers[rb])
-                    .map(|_| ExecuteState::Proceed)
-            }
+            Opcode::XOS(ra, rb)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self.transaction_output_start(ra, self.registers[rb]).is_ok() => {}
 
-            Opcode::XWL(ra, rb) if self.gas_charge(&op).is_ok() && self.inc_pc() => {
-                result = self
-                    .transaction_witness_length(ra, self.registers[rb])
-                    .map(|_| ExecuteState::Proceed)
-            }
+            Opcode::XWL(ra, rb)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self.transaction_witness_length(ra, self.registers[rb]).is_ok() => {}
 
-            Opcode::XWS(ra, rb) if self.gas_charge(&op).is_ok() && self.inc_pc() => {
-                result = self
-                    .transaction_witness_start(ra, self.registers[rb])
-                    .map(|_| ExecuteState::Proceed)
-            }
+            Opcode::XWS(ra, rb)
+                if Self::is_register_writable(ra)
+                    && self.gas_charge(&op).is_ok()
+                    && self.transaction_witness_start(ra, self.registers[rb]).is_ok() => {}
 
-            Opcode::FLAG(ra) if self.gas_charge(&op).is_ok() && self.inc_pc() => self.set_flag(self.registers[ra]),
+            Opcode::FLAG(ra) if self.gas_charge(&op).is_ok() && self.set_flag(self.registers[ra]).is_ok() => {}
 
             Opcode::LDC(_ra, _rb, _rc) => result = Err(InterpreterError::OpcodeUnimplemented(op)),
             Opcode::SLDC(_ra, _rb, _rc) => result = Err(InterpreterError::OpcodeUnimplemented(op)),

--- a/src/interpreter/internal.rs
+++ b/src/interpreter/internal.rs
@@ -30,8 +30,10 @@ impl<S> Interpreter<S> {
         self.block_height
     }
 
-    pub(crate) fn set_flag(&mut self, a: Word) {
+    pub(crate) fn set_flag(&mut self, a: Word) -> Result<(), InterpreterError> {
         self.registers[REG_FLAG] = a;
+
+        self.inc_pc()
     }
 
     pub(crate) fn clear_err(&mut self) {
@@ -42,12 +44,11 @@ impl<S> Interpreter<S> {
         self.registers[REG_ERR] = 1;
     }
 
-    pub(crate) fn inc_pc(&mut self) -> bool {
-        let (result, overflow) = self.registers[REG_PC].overflowing_add(4);
-
-        self.registers[REG_PC] = result;
-
-        !overflow
+    pub(crate) fn inc_pc(&mut self) -> Result<(), InterpreterError> {
+        self.registers[REG_PC]
+            .checked_add(4)
+            .ok_or(InterpreterError::ProgramOverflow)
+            .map(|pc| self.registers[REG_PC] = pc)
     }
 
     pub(crate) const fn context(&self) -> Context {

--- a/src/interpreter/log.rs
+++ b/src/interpreter/log.rs
@@ -1,12 +1,13 @@
 use super::Interpreter;
 use crate::consts::*;
+use crate::error::InterpreterError;
 
 use fuel_tx::crypto::Hasher;
 use fuel_tx::Receipt;
 use fuel_types::Word;
 
 impl<S> Interpreter<S> {
-    pub(crate) fn log(&mut self, a: Word, b: Word, c: Word, d: Word) -> bool {
+    pub(crate) fn log(&mut self, a: Word, b: Word, c: Word, d: Word) -> Result<(), InterpreterError> {
         let receipt = Receipt::log(
             self.internal_contract_or_default(),
             a,
@@ -19,12 +20,12 @@ impl<S> Interpreter<S> {
 
         self.receipts.push(receipt);
 
-        true
+        self.inc_pc()
     }
 
-    pub(crate) fn log_data(&mut self, a: Word, b: Word, c: Word, d: Word) -> bool {
+    pub(crate) fn log_data(&mut self, a: Word, b: Word, c: Word, d: Word) -> Result<(), InterpreterError> {
         if d > MEM_MAX_ACCESS_SIZE || c >= VM_MAX_RAM - d {
-            return false;
+            return Err(InterpreterError::MemoryOverflow);
         }
 
         let cd = (c + d) as usize;
@@ -43,6 +44,6 @@ impl<S> Interpreter<S> {
 
         self.receipts.push(receipt);
 
-        true
+        self.inc_pc()
     }
 }

--- a/src/interpreter/transaction.rs
+++ b/src/interpreter/transaction.rs
@@ -14,7 +14,7 @@ impl<S> Interpreter<S> {
             .ok_or(InterpreterError::InputNotFound)
             .map(|input| input.serialized_size() as Word)?;
 
-        Ok(())
+        self.inc_pc()
     }
 
     pub(crate) fn transaction_input_start(&mut self, ra: RegisterId, b: Word) -> Result<(), InterpreterError> {
@@ -24,7 +24,7 @@ impl<S> Interpreter<S> {
                 .input_offset(b as usize)
                 .ok_or(InterpreterError::InputNotFound)?) as Word;
 
-        Ok(())
+        self.inc_pc()
     }
 
     pub(crate) fn transaction_output_length(&mut self, ra: RegisterId, b: Word) -> Result<(), InterpreterError> {
@@ -35,7 +35,7 @@ impl<S> Interpreter<S> {
             .ok_or(InterpreterError::OutputNotFound)
             .map(|output| output.serialized_size() as Word)?;
 
-        Ok(())
+        self.inc_pc()
     }
 
     pub(crate) fn transaction_output_start(&mut self, ra: RegisterId, b: Word) -> Result<(), InterpreterError> {
@@ -45,7 +45,7 @@ impl<S> Interpreter<S> {
                 .output_offset(b as usize)
                 .ok_or(InterpreterError::OutputNotFound)?) as Word;
 
-        Ok(())
+        self.inc_pc()
     }
 
     pub(crate) fn transaction_witness_length(&mut self, ra: RegisterId, b: Word) -> Result<(), InterpreterError> {
@@ -56,7 +56,7 @@ impl<S> Interpreter<S> {
             .ok_or(InterpreterError::OutputNotFound)
             .map(|witness| witness.serialized_size() as Word)?;
 
-        Ok(())
+        self.inc_pc()
     }
 
     pub(crate) fn transaction_witness_start(&mut self, ra: RegisterId, b: Word) -> Result<(), InterpreterError> {
@@ -66,6 +66,6 @@ impl<S> Interpreter<S> {
                 .witness_offset(b as usize)
                 .ok_or(InterpreterError::WitnessNotFound)?) as Word;
 
-        Ok(())
+        self.inc_pc()
     }
 }


### PR DESCRIPTION
Interpreter instructions should have uniform execution. Since `inc_pc`
is fallible - it can overflow the vm memory - then every instruction is
fallible with the exception of `RET` under specific circumstances.

A single exception is not a good reason to have divergent
implementations for all the opcodes.

As TODO optimization, the half-word should parsed only once and
gas/execution match statement should be simplified and executed only
once as well. Having an uniform implementation for all opcodes will
facilitate that optimization.