### PR TITLE
Add `MemoryClient`

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,0 +1,86 @@
+use crate::error::InterpreterError;
+use crate::interpreter::Interpreter;
+
+use fuel_tx::{Receipt, Transaction};
+
+mod storage;
+
+pub use storage::MemoryStorage;
+
+#[derive(Debug, Default, Clone)]
+pub struct MemoryClient {
+    storage: MemoryStorage,
+}
+
+impl From<MemoryStorage> for MemoryClient {
+    fn from(s: MemoryStorage) -> Self {
+        Self::new(s)
+    }
+}
+
+impl AsRef<MemoryStorage> for MemoryClient {
+    fn as_ref(&self) -> &MemoryStorage {
+        &self.storage
+    }
+}
+
+impl AsMut<MemoryStorage> for MemoryClient {
+    fn as_mut(&mut self) -> &mut MemoryStorage {
+        &mut self.storage
+    }
+}
+
+impl MemoryClient {
+    pub const fn new(storage: MemoryStorage) -> Self {
+        Self { storage }
+    }
+
+    pub fn transition<I: IntoIterator<Item = Transaction>>(
+        &mut self,
+        txs: I,
+    ) -> Result<Vec<Receipt>, InterpreterError> {
+        let mut interpreter = Interpreter::with_storage(&mut self.storage);
+
+        // A transaction that is considered valid will be reverted if the runtime
+        // returns an error.
+        //
+        // The exception is `InterpreterError::ValidationError` since this means the
+        // whole set of transactions must also fail.
+        //
+        // All the other variants of `InterpreterError` are supressed in this function
+        // and they will produce isolated `RVRT` operations.
+        let receipts = txs.into_iter().try_fold(vec![], |mut receipts, tx| {
+            match interpreter.transact(tx) {
+                Ok(state) => {
+                    receipts.extend(state.receipts());
+
+                    if !state.receipts().iter().any(|r| matches!(r, Receipt::Revert { .. })) {
+                        interpreter.as_mut().commit();
+                    } else {
+                        interpreter.as_mut().revert();
+                    }
+
+                    Ok(receipts)
+                }
+
+                Err(InterpreterError::ValidationError(e)) => {
+                    interpreter.as_mut().rollback();
+
+                    Err(InterpreterError::ValidationError(e))
+                }
+
+                // TODO VM is to return a `RVRT` receipt on runtime error. This way, the return of
+                // `transact` should be `Err` only if `InterpreterError::ValidationError` happens
+                Err(_) => {
+                    interpreter.as_mut().revert();
+
+                    Ok(receipts)
+                }
+            }
+        })?;
+
+        self.storage.persist();
+
+        Ok(receipts)
+    }
+}

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -85,7 +85,7 @@ impl TryFrom<&Transaction> for Contract {
             } => witnesses
                 .get(*bytecode_witness_index as usize)
                 .map(|c| c.as_ref().into())
-                .ok_or(ValidationError::TransactionCreateBytecodeWitnessIndex.into()),
+                .ok_or_else(|| ValidationError::TransactionCreateBytecodeWitnessIndex.into()),
 
             _ => Err(ValidationError::TransactionScriptOutputContractCreated { index: 0 }.into()),
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -78,8 +78,8 @@ impl From<io::Error> for InterpreterError {
     }
 }
 
-impl Into<InterpreterError> for Infallible {
-    fn into(self) -> InterpreterError {
+impl From<Infallible> for InterpreterError {
+    fn from(_i: Infallible) -> InterpreterError {
         unreachable!()
     }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,7 +1,7 @@
 use crate::call::CallFrame;
+use crate::client::MemoryStorage;
 use crate::consts::*;
 use crate::context::Context;
-use crate::data::MemoryStorage;
 use crate::state::Debugger;
 
 use fuel_tx::{Receipt, Transaction};
@@ -98,5 +98,11 @@ impl Interpreter<()> {
 impl<S> From<Interpreter<S>> for Transaction {
     fn from(vm: Interpreter<S>) -> Self {
         vm.tx
+    }
+}
+
+impl<S> AsMut<S> for Interpreter<S> {
+    fn as_mut(&mut self) -> &mut S {
+        &mut self.storage
     }
 }

--- a/src/interpreter/blockchain.rs
+++ b/src/interpreter/blockchain.rs
@@ -1,7 +1,7 @@
 use super::Interpreter;
 use crate::consts::*;
-use crate::data::InterpreterStorage;
 use crate::error::InterpreterError;
+use crate::storage::InterpreterStorage;
 
 use fuel_tx::Input;
 use fuel_types::{Address, Bytes32, Bytes8, Color, ContractId, RegisterId, Word};
@@ -153,7 +153,7 @@ where
 
         self.registers[ra] = self
             .storage
-            .merkle_contract_state(&contract, key)?
+            .merkle_contract_state(contract, key)?
             .map(|state| unsafe { Bytes8::from_slice_unchecked(state.as_ref().as_ref()).into() })
             .map(Word::from_be_bytes)
             .unwrap_or(0);
@@ -175,7 +175,7 @@ where
 
         let state = self
             .storage
-            .merkle_contract_state(&contract, key)?
+            .merkle_contract_state(contract, key)?
             .map(|s| s.into_owned())
             .unwrap_or_default();
 

--- a/src/interpreter/contract.rs
+++ b/src/interpreter/contract.rs
@@ -1,7 +1,7 @@
 use super::Interpreter;
 use crate::contract::Contract;
-use crate::data::InterpreterStorage;
 use crate::error::InterpreterError;
+use crate::storage::InterpreterStorage;
 
 use fuel_types::{Color, ContractId, Word};
 

--- a/src/interpreter/executors/debug.rs
+++ b/src/interpreter/executors/debug.rs
@@ -1,7 +1,7 @@
-use crate::data::InterpreterStorage;
 use crate::error::InterpreterError;
 use crate::interpreter::Interpreter;
 use crate::state::ProgramState;
+use crate::storage::InterpreterStorage;
 
 impl<S> Interpreter<S>
 where

--- a/src/interpreter/executors/instruction.rs
+++ b/src/interpreter/executors/instruction.rs
@@ -1,7 +1,7 @@
-use crate::data::InterpreterStorage;
 use crate::error::InterpreterError;
 use crate::interpreter::Interpreter;
 use crate::state::ExecuteState;
+use crate::storage::InterpreterStorage;
 
 use fuel_asm::Opcode;
 use fuel_types::Word;

--- a/src/interpreter/executors/main.rs
+++ b/src/interpreter/executors/main.rs
@@ -1,10 +1,10 @@
 use crate::consts::*;
 use crate::contract::Contract;
 use crate::crypto;
-use crate::data::InterpreterStorage;
 use crate::error::InterpreterError;
 use crate::interpreter::{Interpreter, MemoryRange};
 use crate::state::{ExecuteState, ProgramState, StateTransition, StateTransitionRef};
+use crate::storage::InterpreterStorage;
 
 use fuel_asm::Opcode;
 use fuel_tx::{Input, Output, Receipt, Transaction};

--- a/src/interpreter/executors/predicate.rs
+++ b/src/interpreter/executors/predicate.rs
@@ -1,8 +1,8 @@
 use crate::consts::*;
-use crate::data::InterpreterStorage;
 use crate::error::InterpreterError;
 use crate::interpreter::{Interpreter, MemoryRange};
 use crate::state::{ExecuteState, ProgramState};
+use crate::storage::InterpreterStorage;
 
 use fuel_asm::Opcode;
 

--- a/src/interpreter/flow.rs
+++ b/src/interpreter/flow.rs
@@ -1,9 +1,9 @@
 use super::Interpreter;
 use crate::call::{Call, CallFrame};
 use crate::consts::*;
-use crate::data::InterpreterStorage;
 use crate::error::InterpreterError;
 use crate::state::ProgramState;
+use crate::storage::InterpreterStorage;
 
 use fuel_tx::crypto::Hasher;
 use fuel_tx::{Input, Receipt};

--- a/src/interpreter/frame.rs
+++ b/src/interpreter/frame.rs
@@ -1,7 +1,7 @@
 use super::Interpreter;
 use crate::call::{Call, CallFrame};
-use crate::data::InterpreterStorage;
 use crate::error::InterpreterError;
+use crate::storage::InterpreterStorage;
 
 use fuel_types::Color;
 

--- a/src/interpreter/initialization.rs
+++ b/src/interpreter/initialization.rs
@@ -1,8 +1,8 @@
 use super::Interpreter;
 use crate::consts::*;
 use crate::context::Context;
-use crate::data::InterpreterStorage;
 use crate::error::InterpreterError;
+use crate::storage::InterpreterStorage;
 
 use fuel_tx::consts::*;
 use fuel_tx::{Input, Transaction};

--- a/src/interpreter/memory.rs
+++ b/src/interpreter/memory.rs
@@ -9,7 +9,6 @@ use std::{ops, ptr};
 
 // Memory bounds must be manually checked and cannot follow general PartialEq
 // rules
-#[allow(clippy::derive_hash_xor_eq)]
 #[derive(Debug, Clone, Eq, Hash)]
 #[cfg_attr(feature = "serde-types", derive(serde::Serialize, serde::Deserialize))]
 pub struct MemoryRange {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,14 @@
-#![allow(clippy::try_err)]
-// Wrong clippy convention; check
-// https://rust-lang.github.io/api-guidelines/naming.html
-#![allow(clippy::wrong_self_convention)]
-
 pub mod call;
+pub mod client;
 pub mod consts;
 pub mod context;
 pub mod contract;
 pub mod crypto;
-pub mod data;
 pub mod error;
 pub mod gas;
 pub mod interpreter;
 pub mod state;
+pub mod storage;
 
 pub mod prelude {
     pub use fuel_asm::Opcode;
@@ -25,12 +21,13 @@ pub mod prelude {
     };
 
     pub use crate::call::{Call, CallFrame};
+    pub use crate::client::{MemoryClient, MemoryStorage};
     pub use crate::context::Context;
     pub use crate::contract::Contract;
-    pub use crate::data::{InterpreterStorage, MemoryStorage};
     pub use crate::error::InterpreterError;
     pub use crate::interpreter::{Interpreter, InterpreterMetadata, MemoryRange};
     pub use crate::state::{Debugger, ProgramState, StateTransition, StateTransitionRef};
+    pub use crate::storage::InterpreterStorage;
 
     #[cfg(feature = "debug")]
     pub use crate::state::{Breakpoint, DebugEval};

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -8,10 +8,6 @@ use std::borrow::Cow;
 use std::error::Error as StdError;
 use std::ops::Deref;
 
-mod memory;
-
-pub use memory::MemoryStorage;
-
 /// When this trait is implemented, the underlying interpreter is guaranteed to
 /// have full functionality
 pub trait InterpreterStorage:
@@ -69,7 +65,7 @@ pub trait InterpreterStorage:
         key: &Bytes32,
         value: &Bytes32,
     ) -> Result<Option<Bytes32>, InterpreterError> {
-        <Self as MerkleStorage<ContractId, Bytes32, Bytes32>>::insert(self, contract, key, &value).map_err(|e| e.into())
+        <Self as MerkleStorage<ContractId, Bytes32, Bytes32>>::insert(self, contract, key, value).map_err(|e| e.into())
     }
 
     fn merkle_contract_color_balance(&self, id: &ContractId, color: &Color) -> Result<Option<Word>, InterpreterError> {


### PR DESCRIPTION
This struct should emulate a functional client and take iterators of
`Transaction`s to mutate a storage.

This implementation should define the commit/revert/persist/rollback
strategy depending on the receipts returned by the VM.