### PR TITLE
Add `Opcode::BAL` implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,11 @@ path = "tests/blockchain.rs"
 required-features = ["random"]
 
 [[test]]
+name = "test-contract"
+path = "tests/contract.rs"
+required-features = ["random"]
+
+[[test]]
 name = "test-debug"
 path = "tests/debug.rs"
 required-features = ["debug"]

--- a/src/interpreter/contract.rs
+++ b/src/interpreter/contract.rs
@@ -1,9 +1,11 @@
 use super::Interpreter;
+use crate::consts::*;
 use crate::contract::Contract;
 use crate::error::InterpreterError;
 use crate::storage::InterpreterStorage;
 
-use fuel_types::{Color, ContractId, Word};
+use fuel_asm::{RegisterId, Word};
+use fuel_types::{Color, ContractId};
 
 use std::borrow::Cow;
 
@@ -18,6 +20,30 @@ where
             .ok_or(InterpreterError::ContractNotFound)?
     }
 
+    pub(crate) fn contract_balance(&mut self, ra: RegisterId, b: Word, c: Word) -> Result<(), InterpreterError> {
+        if b > VM_MAX_RAM - Color::LEN as Word || c > VM_MAX_RAM - ContractId::LEN as Word {
+            return Err(InterpreterError::MemoryOverflow);
+        }
+
+        Self::is_register_writable(ra)?;
+
+        let (b, c) = (b as usize, c as usize);
+
+        // Safety: memory bounds checked
+        let color = unsafe { Color::as_ref_unchecked(&self.memory[b..b + Color::LEN]) };
+        let contract = unsafe { ContractId::as_ref_unchecked(&self.memory[c..c + ContractId::LEN]) };
+
+        if !self.tx.input_contracts().any(|input| contract == input) {
+            return Err(InterpreterError::ContractNotInTxInputs);
+        }
+
+        let balance = self.balance(contract, color)?;
+
+        self.registers[ra] = balance;
+
+        self.inc_pc()
+    }
+
     pub(crate) fn check_contract_exists(&self, contract: &ContractId) -> Result<bool, InterpreterError> {
         self.storage.storage_contract_exists(contract)
     }
@@ -27,161 +53,5 @@ where
             .storage
             .merkle_contract_color_balance(contract, color)?
             .unwrap_or_default())
-    }
-}
-
-#[cfg(all(test, feature = "random"))]
-mod tests {
-    use crate::consts::*;
-    use crate::prelude::*;
-    use rand::rngs::StdRng;
-    use rand::{Rng, SeedableRng};
-
-    #[test]
-    fn mint_burn() {
-        let rng = &mut StdRng::seed_from_u64(2322u64);
-
-        let mut balance = 1000;
-
-        let mut vm = Interpreter::in_memory();
-
-        let gas_price = 0;
-        let gas_limit = 1_000_000;
-        let maturity = 0;
-
-        let salt: Salt = rng.gen();
-        let program: Witness = [
-            Opcode::ADDI(0x10, REG_FP, CallFrame::a_offset() as Immediate12),
-            Opcode::LW(0x10, 0x10, 0),
-            Opcode::ADDI(0x11, REG_FP, CallFrame::b_offset() as Immediate12),
-            Opcode::LW(0x11, 0x11, 0),
-            Opcode::JNEI(0x10, REG_ZERO, 7),
-            Opcode::MINT(0x11),
-            Opcode::JI(8),
-            Opcode::BURN(0x11),
-            Opcode::RET(REG_ONE),
-        ]
-        .iter()
-        .copied()
-        .collect::<Vec<u8>>()
-        .into();
-
-        let contract = Contract::from(program.as_ref());
-        let contract_root = contract.root();
-        let contract = contract.id(&salt, &contract_root);
-
-        let color = Color::from(*contract);
-        let output = Output::contract_created(contract);
-
-        let bytecode_witness = 0;
-        let tx = Transaction::create(
-            gas_price,
-            gas_limit,
-            maturity,
-            bytecode_witness,
-            salt,
-            vec![],
-            vec![],
-            vec![output],
-            vec![program],
-        );
-
-        vm.transact(tx).expect("Failed to transact");
-
-        let input = Input::contract(rng.gen(), rng.gen(), rng.gen(), contract);
-        let output = Output::contract(0, rng.gen(), rng.gen());
-
-        let mut script_ops = vec![
-            Opcode::ADDI(0x10, REG_ZERO, 0),
-            Opcode::ADDI(0x11, REG_ZERO, gas_limit as Immediate12),
-            Opcode::CALL(0x10, REG_ZERO, 0x10, 0x11),
-            Opcode::RET(REG_ONE),
-        ];
-
-        let script: Vec<u8> = script_ops.iter().copied().collect();
-        let tx = Transaction::script(
-            gas_price,
-            gas_limit,
-            maturity,
-            script,
-            vec![],
-            vec![input.clone()],
-            vec![output],
-            vec![],
-        );
-
-        let script_data_offset = VM_TX_MEMORY + tx.script_data_offset().unwrap();
-        script_ops[0] = Opcode::ADDI(0x10, REG_ZERO, script_data_offset as Immediate12);
-
-        let script: Vec<u8> = script_ops.iter().copied().collect();
-        let script_data = Call::new(contract, 0, balance).to_bytes();
-        let tx = Transaction::script(
-            gas_price,
-            gas_limit,
-            maturity,
-            script,
-            script_data,
-            vec![input.clone()],
-            vec![output],
-            vec![],
-        );
-
-        assert_eq!(0, vm.balance(&contract, &color).unwrap());
-        vm.transact(tx).expect("Failed to transact");
-        assert_eq!(balance as Word, vm.balance(&contract, &color).unwrap());
-
-        // Try to burn more than the available balance
-        let script: Vec<u8> = script_ops.iter().copied().collect();
-        let script_data = Call::new(contract, 1, balance + 1).to_bytes();
-        let tx = Transaction::script(
-            gas_price,
-            gas_limit,
-            maturity,
-            script,
-            script_data,
-            vec![input.clone()],
-            vec![output],
-            vec![],
-        );
-
-        assert!(vm.transact(tx).is_err());
-        assert_eq!(balance as Word, vm.balance(&contract, &color).unwrap());
-
-        // Burn some of the balance
-        let burn = 100;
-
-        let script: Vec<u8> = script_ops.iter().copied().collect();
-        let script_data = Call::new(contract, 1, burn).to_bytes();
-        let tx = Transaction::script(
-            gas_price,
-            gas_limit,
-            maturity,
-            script,
-            script_data,
-            vec![input.clone()],
-            vec![output],
-            vec![],
-        );
-
-        vm.transact(tx).expect("Failed to transact");
-        balance -= burn;
-        assert_eq!(balance as Word, vm.balance(&contract, &color).unwrap());
-
-        // Burn the remainder balance
-        let script: Vec<u8> = script_ops.iter().copied().collect();
-        let script_data = Call::new(contract, 1, balance).to_bytes();
-        let tx = Transaction::script(
-            gas_price,
-            gas_limit,
-            maturity,
-            script,
-            script_data,
-            vec![input.clone()],
-            vec![output],
-            vec![],
-        );
-
-        vm.transact(tx).expect("Failed to transact");
-        assert_eq!(0, vm.balance(&contract, &color).unwrap());
     }
 }

--- a/src/interpreter/executors/instruction.rs
+++ b/src/interpreter/executors/instruction.rs
@@ -322,6 +322,11 @@ where
                 self.store_word(a, b, imm)?;
             }
 
+            OpcodeRepr::BAL => {
+                self.gas_charge(GAS_BAL)?;
+                self.contract_balance(ra, b, c)?;
+            }
+
             OpcodeRepr::BHEI => {
                 self.gas_charge(GAS_BHEI)?;
                 self.alu_set(ra, self.block_height() as Word)?;

--- a/src/interpreter/gas/consts.rs
+++ b/src/interpreter/gas/consts.rs
@@ -51,6 +51,7 @@ pub const GAS_LW: Word = Interpreter::<()>::gas_cost_const(OpcodeRepr::ADD);
 pub const GAS_MEQ: Word = Interpreter::<()>::gas_cost_const(OpcodeRepr::ADD);
 pub const GAS_SB: Word = Interpreter::<()>::gas_cost_const(OpcodeRepr::ADD);
 pub const GAS_SW: Word = Interpreter::<()>::gas_cost_const(OpcodeRepr::ADD);
+pub const GAS_BAL: Word = Interpreter::<()>::gas_cost_const(OpcodeRepr::ADD);
 pub const GAS_BHEI: Word = Interpreter::<()>::gas_cost_const(OpcodeRepr::ADD);
 pub const GAS_BHSH: Word = Interpreter::<()>::gas_cost_const(OpcodeRepr::ADD);
 pub const GAS_BURN: Word = Interpreter::<()>::gas_cost_const(OpcodeRepr::ADD);

--- a/tests/contract.rs
+++ b/tests/contract.rs
@@ -1,0 +1,222 @@
+use fuel_vm::consts::*;
+use fuel_vm::prelude::*;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+#[test]
+fn mint_burn() {
+    let rng = &mut StdRng::seed_from_u64(2322u64);
+
+    let mut balance = 1000;
+
+    let mut vm = Interpreter::in_memory();
+
+    let gas_price = 0;
+    let gas_limit = 1_000_000;
+    let maturity = 0;
+
+    let salt: Salt = rng.gen();
+    let program: Witness = [
+        Opcode::ADDI(0x10, REG_FP, CallFrame::a_offset() as Immediate12),
+        Opcode::LW(0x10, 0x10, 0),
+        Opcode::ADDI(0x11, REG_FP, CallFrame::b_offset() as Immediate12),
+        Opcode::LW(0x11, 0x11, 0),
+        Opcode::JNEI(0x10, REG_ZERO, 7),
+        Opcode::MINT(0x11),
+        Opcode::JI(8),
+        Opcode::BURN(0x11),
+        Opcode::RET(REG_ONE),
+    ]
+    .iter()
+    .copied()
+    .collect::<Vec<u8>>()
+    .into();
+
+    let contract = Contract::from(program.as_ref());
+    let contract_root = contract.root();
+    let contract = contract.id(&salt, &contract_root);
+
+    let color = Color::from(*contract);
+    let output = Output::contract_created(contract);
+
+    let bytecode_witness = 0;
+    let tx = Transaction::create(
+        gas_price,
+        gas_limit,
+        maturity,
+        bytecode_witness,
+        salt,
+        vec![],
+        vec![],
+        vec![output],
+        vec![program],
+    );
+
+    vm.transact(tx).expect("Failed to transact");
+
+    let input = Input::contract(rng.gen(), rng.gen(), rng.gen(), contract);
+    let output = Output::contract(0, rng.gen(), rng.gen());
+
+    let mut script_ops = vec![
+        Opcode::ADDI(0x10, REG_ZERO, 0),
+        Opcode::ADDI(0x11, REG_ZERO, gas_limit as Immediate12),
+        Opcode::CALL(0x10, REG_ZERO, 0x10, 0x11),
+        Opcode::RET(REG_ONE),
+    ];
+
+    let script: Vec<u8> = script_ops.iter().copied().collect();
+    let tx = Transaction::script(
+        gas_price,
+        gas_limit,
+        maturity,
+        script,
+        vec![],
+        vec![input.clone()],
+        vec![output],
+        vec![],
+    );
+
+    let script_data_offset = VM_TX_MEMORY + tx.script_data_offset().unwrap();
+    script_ops[0] = Opcode::ADDI(0x10, REG_ZERO, script_data_offset as Immediate12);
+
+    let script: Vec<u8> = script_ops.iter().copied().collect();
+    let script_data = Call::new(contract, 0, balance).to_bytes();
+    let tx = Transaction::script(
+        gas_price,
+        gas_limit,
+        maturity,
+        script,
+        script_data,
+        vec![input.clone()],
+        vec![output],
+        vec![],
+    );
+
+    let script_data_check_balance: Vec<u8> = color.as_ref().iter().chain(contract.as_ref().iter()).copied().collect();
+    let mut script_check_balance = vec![
+        Opcode::NOOP,
+        Opcode::MOVE(0x11, 0x10),
+        Opcode::ADDI(0x12, 0x10, Color::LEN as Immediate12),
+        Opcode::BAL(0x10, 0x11, 0x12),
+        Opcode::LOG(0x10, REG_ZERO, REG_ZERO, REG_ZERO),
+        Opcode::RET(REG_ONE),
+    ];
+
+    let tx_check_balance = Transaction::script(
+        gas_price,
+        gas_limit,
+        maturity,
+        script_check_balance.iter().copied().collect(),
+        vec![],
+        vec![input.clone()],
+        vec![output.clone()],
+        vec![],
+    );
+
+    let script_data_offset = VM_TX_MEMORY + tx_check_balance.script_data_offset().unwrap();
+    script_check_balance[0] = Opcode::ADDI(0x10, REG_ZERO, script_data_offset as Immediate12);
+
+    let tx_check_balance = Transaction::script(
+        gas_price,
+        gas_limit,
+        maturity,
+        script_check_balance.into_iter().collect(),
+        script_data_check_balance,
+        vec![input.clone()],
+        vec![output.clone()],
+        vec![],
+    );
+
+    let storage_balance = vm
+        .transact(tx_check_balance.clone())
+        .expect("Failed to transact")
+        .receipts()[0]
+        .ra()
+        .expect("Balance expected");
+    assert_eq!(0, storage_balance);
+
+    vm.transact(tx).expect("Failed to transact");
+
+    let storage_balance = vm
+        .transact(tx_check_balance.clone())
+        .expect("Failed to transact")
+        .receipts()[0]
+        .ra()
+        .expect("Balance expected");
+    assert_eq!(balance as Word, storage_balance);
+
+    // Try to burn more than the available balance
+    let script: Vec<u8> = script_ops.iter().copied().collect();
+    let script_data = Call::new(contract, 1, balance + 1).to_bytes();
+    let tx = Transaction::script(
+        gas_price,
+        gas_limit,
+        maturity,
+        script,
+        script_data,
+        vec![input.clone()],
+        vec![output],
+        vec![],
+    );
+
+    assert!(vm.transact(tx).is_err());
+
+    let storage_balance = vm
+        .transact(tx_check_balance.clone())
+        .expect("Failed to transact")
+        .receipts()[0]
+        .ra()
+        .expect("Balance expected");
+    assert_eq!(balance as Word, storage_balance);
+
+    // Burn some of the balance
+    let burn = 100;
+
+    let script: Vec<u8> = script_ops.iter().copied().collect();
+    let script_data = Call::new(contract, 1, burn).to_bytes();
+    let tx = Transaction::script(
+        gas_price,
+        gas_limit,
+        maturity,
+        script,
+        script_data,
+        vec![input.clone()],
+        vec![output],
+        vec![],
+    );
+
+    vm.transact(tx).expect("Failed to transact");
+    balance -= burn;
+
+    let storage_balance = vm
+        .transact(tx_check_balance.clone())
+        .expect("Failed to transact")
+        .receipts()[0]
+        .ra()
+        .expect("Balance expected");
+    assert_eq!(balance as Word, storage_balance);
+
+    // Burn the remainder balance
+    let script: Vec<u8> = script_ops.iter().copied().collect();
+    let script_data = Call::new(contract, 1, balance).to_bytes();
+    let tx = Transaction::script(
+        gas_price,
+        gas_limit,
+        maturity,
+        script,
+        script_data,
+        vec![input.clone()],
+        vec![output],
+        vec![],
+    );
+
+    vm.transact(tx).expect("Failed to transact");
+
+    let storage_balance = vm
+        .transact(tx_check_balance.clone())
+        .expect("Failed to transact")
+        .receipts()[0]
+        .ra()
+        .expect("Balance expected");
+    assert_eq!(0, storage_balance);
+}


### PR DESCRIPTION
The opcode implementation brings the ability to inspect the balance of a
given color+contract tuple.

This allows the test case `mint_burn` to be moved to the integrated
scope since before this opcode, there was no way to fetch the balance of
the tuple without inspecting the internals of the interpreter.

Follows FuelLabs/fuel-specs#226