### PR TITLE
make registers and memory public

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -52,10 +52,12 @@ pub struct Interpreter<S> {
 }
 
 impl<S> Interpreter<S> {
+    /// Returns the current state of the VM memory
     pub fn memory(&self) -> &[u8] {
         self.memory.as_slice()
     }
 
+    /// Returns the current state of the registers
     pub const fn registers(&self) -> &[Word] {
         &self.registers
     }


### PR DESCRIPTION
Access to these are needed for remote debugging