### PR TITLE
Fix feature style and improve readme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --verbose --features random,profile-gas
+        args: --verbose --features random,profiler-gas
 
     - name: Run debug tests
       uses: actions-rs/cargo@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# CHANGELOG
+
+## Pending
+
+### Breaking changes
+
+### Features
+
+### Improvements
+
+- [#65] Fix feature style and improve readme.
+
+### Bugfixes
+
+## v0.1.1
+
+### Improvements
+
+- [#64] Fix license SPDX identifier.
+
+## v0.1.0 (Initial release of FuelLabs/fuel-vm)
+
+[#65]: https://github.com/FuelLabs/fuel-vm/pull/65
+[#64]: https://github.com/FuelLabs/fuel-vm/pull/64

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,73 +2,73 @@
 name = "fuel-vm"
 version = "0.1.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
-categories = ["concurrency", "cryptography::cryptocurrencies", "emulators"]
+categories = [ "concurrency", "cryptography::cryptocurrencies", "emulators" ]
 edition = "2021"
 homepage = "https://fuel.network/"
-keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
+keywords = [ "blockchain", "cryptocurrencies", "fuel-vm", "vm" ]
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
 description = "FuelVM interpreter."
 
 [dependencies]
+dyn-clone = { version = "1.0", optional = true }
 fuel-asm = "0.1"
 fuel-merkle = "0.1"
 fuel-storage = "0.1"
 fuel-tx = "0.1"
 fuel-types = "0.1"
 itertools = "0.10"
-secp256k1 = { version = "0.20", features = ["recovery"] }
-serde = { version = "1.0", features = ["derive"], optional = true }
+secp256k1 = { version = "0.20", features = [ "recovery" ] }
+serde = { version = "1.0", features = [ "derive" ], optional = true }
 sha3 = "0.9"
 tracing = "0.1"
-dyn-clone = { version = "1.0", optional = true }
 
 [dev-dependencies]
 rand = "0.8"
 
 [features]
 debug = []
-profile-gas = [ "profile-any" ]
-profile-any = [ "dyn-clone" ] # All profiling features should depend on this
+profiler-any = [ "dyn-clone" ] # All profiling features should depend on this
+profiler-gas = [ "profiler-any" ]
 random = [ "fuel-types/random", "fuel-tx/random" ]
 serde-types = [ "fuel-asm/serde-types", "fuel-types/serde-types", "fuel-tx/serde-types", "serde" ]
 
 [[test]]
 name = "test-backtrace"
 path = "tests/backtrace.rs"
-required-features = ["random"]
+required-features = [ "random" ]
 
 [[test]]
 name = "test-blockchain"
 path = "tests/blockchain.rs"
-required-features = ["random"]
+required-features = [ "random" ]
 
 [[test]]
 name = "test-contract"
 path = "tests/contract.rs"
-required-features = ["random"]
+required-features = [ "random" ]
 
 [[test]]
-name = "test-profile-gas"
-path = "tests/profile_gas.rs"
-required-features = [ "random", "profile-gas" ]
+name = "test-profiler-gas"
+path = "tests/profiler_gas.rs"
+required-features = [ "random", "profiler-gas" ]
 
 [[test]]
 name = "test-encoding"
 path = "tests/encoding.rs"
-required-features = ["random"]
+required-features = [ "random" ]
 
 [[test]]
 name = "test-flow"
 path = "tests/flow.rs"
-required-features = ["random"]
+required-features = [ "random" ]
 
 [[test]]
 name = "test-metadata"
 path = "tests/metadata.rs"
-required-features = ["random"]
+required-features = [ "random" ]
 
 [[test]]
 name = "test-predicate"
 path = "tests/predicate.rs"
-required-features = ["random"]
+required-features = [ "random" ]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
-# fuel-vm
+# Fuel VM interpreter
 
 [![build](https://github.com/FuelLabs/fuel-vm/actions/workflows/ci.yml/badge.svg)](https://github.com/FuelLabs/fuel-vm/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/fuel-vm?label=latest)](https://crates.io/crates/fuel-vm)
 [![docs](https://docs.rs/fuel-vm/badge.svg)](https://docs.rs/fuel-vm/)
 [![discord](https://img.shields.io/badge/chat%20on-discord-orange?&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/xfpK4Pe)
 
-Rust interpreter for the Fuel Virtual Machine
+Rust interpreter for the [FuelVM](https://github.com/FuelLabs/fuel-specs).
+
+## Compile features
+
+- `debug`[1]: Expose the `Debugger` structure, allowing the interpreter to interact with `Breakpoints`s.
+- `profile-any`[1]: Expose the `Profiler` primitives, allowing the interpreter to trace profiler implementations.
+- `profile-gas`[1]: Profiler implementation to trace gas consumption per instruction.
+- `random`: Implement [rand](https://crates.io/crates/rand) features for the provided types.
+- `serde-types`: Add support for [serde](https://crates.io/crates/serde) for the types exposed by this crate.
+
+[1] This will cause runtime overhead and isn't recommended for production.

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,5 +1,11 @@
+//! Debugger implementation for the VM
+
 use fuel_asm::Opcode;
 use fuel_types::{ContractId, Word};
+
+mod debugger;
+
+pub use debugger::Debugger;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde-types", derive(serde::Serialize, serde::Deserialize))]

--- a/src/debug/debugger.rs
+++ b/src/debug/debugger.rs
@@ -1,4 +1,5 @@
-use crate::state::{Breakpoint, DebugEval, ProgramState};
+use super::{Breakpoint, DebugEval};
+use crate::state::ProgramState;
 
 use fuel_types::{ContractId, Word};
 

--- a/src/interpreter/constructors.rs
+++ b/src/interpreter/constructors.rs
@@ -1,15 +1,17 @@
 //! Exposed constructors API for the [`Interpreter`]
 
-use fuel_tx::Transaction;
-
 use super::Interpreter;
 use crate::consts::*;
 use crate::context::Context;
-use crate::prelude::*;
-use crate::state::Debugger;
+use crate::memory_client::MemoryStorage;
 
-#[cfg(feature = "profile-any")]
+#[cfg(feature = "debug")]
+use crate::debug::Debugger;
+
+#[cfg(feature = "profiler-any")]
 use crate::profiler::{ProfileReceiver, Profiler};
+
+use fuel_tx::Transaction;
 
 impl<S> Interpreter<S> {
     /// Create a new interpreter instance out of a storage implementation.
@@ -25,16 +27,19 @@ impl<S> Interpreter<S> {
             receipts: vec![],
             tx: Transaction::default(),
             storage,
-            debugger: Debugger::default(),
             context: Context::default(),
             block_height: 0,
-            #[cfg(feature = "profile-any")]
+
+            #[cfg(feature = "debug")]
+            debugger: Debugger::default(),
+
+            #[cfg(feature = "profiler-any")]
             profiler: Profiler::default(),
         }
     }
 
     /// Sets a profiler for the VM
-    #[cfg(feature = "profile-any")]
+    #[cfg(feature = "profiler-any")]
     pub fn with_profiling(mut self, receiver: Box<dyn ProfileReceiver>) -> Self {
         self.profiler.set_receiver(receiver);
         self

--- a/src/interpreter/debug.rs
+++ b/src/interpreter/debug.rs
@@ -1,7 +1,8 @@
 use super::Interpreter;
 use crate::call::CallFrame;
 use crate::consts::*;
-use crate::state::{Breakpoint, DebugEval, ProgramState};
+use crate::debug::{Breakpoint, DebugEval};
+use crate::state::ProgramState;
 
 impl<S> Interpreter<S> {
     /// Set a new breakpoint for the provided location.

--- a/src/interpreter/executors/main.rs
+++ b/src/interpreter/executors/main.rs
@@ -1,10 +1,9 @@
 use crate::consts::*;
 use crate::contract::Contract;
 use crate::crypto;
-use crate::error::InterpreterError;
+use crate::error::{InterpreterError, RuntimeError};
 use crate::interpreter::{Interpreter, MemoryRange};
-use crate::prelude::*;
-use crate::state::{ExecuteState, ProgramState, StateTransitionRef};
+use crate::state::{ExecuteState, ProgramState, StateTransition, StateTransitionRef};
 use crate::storage::InterpreterStorage;
 
 use fuel_asm::{InstructionResult, PanicReason};
@@ -222,7 +221,7 @@ where
     pub fn transact(&mut self, tx: Transaction) -> Result<StateTransitionRef<'_>, InterpreterError> {
         let state_result = self.init(tx).and_then(|_| self.run());
 
-        #[cfg(feature = "profile-any")]
+        #[cfg(feature = "profiler-any")]
         self.profiler.on_transaction(&state_result);
 
         let state = state_result?;

--- a/src/interpreter/gas.rs
+++ b/src/interpreter/gas.rs
@@ -65,10 +65,13 @@ impl<S> Interpreter<S> {
     pub(crate) fn gas_charge(&mut self, gas: Word) -> Result<(), RuntimeError> {
         let gas = !self.is_predicate() as Word * gas;
 
-        #[cfg(feature = "profile-gas")]
+        #[cfg(feature = "profiler-gas")]
         {
+            use crate::profiler::InstructionLocation;
+
             let gas_use = gas.min(self.registers[REG_CGAS]);
-            let location = self.current_location();
+            let location = InstructionLocation::from_vm_context(self);
+
             self.profiler.data_mut().gas_mut().add(location, gas_use);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,10 @@ pub mod state;
 pub mod storage;
 pub mod transactor;
 
-#[cfg(feature = "profile-any")]
+#[cfg(feature = "debug")]
+pub mod debug;
+
+#[cfg(feature = "profiler-any")]
 pub mod profiler;
 
 pub mod prelude {
@@ -38,10 +41,19 @@ pub mod prelude {
     pub use crate::error::{Infallible, InterpreterError, RuntimeError};
     pub use crate::interpreter::{Interpreter, InterpreterMetadata, MemoryRange};
     pub use crate::memory_client::{MemoryClient, MemoryStorage};
-    pub use crate::state::{Debugger, ProgramState, StateTransition, StateTransitionRef};
+    pub use crate::state::{ProgramState, StateTransition, StateTransitionRef};
     pub use crate::storage::InterpreterStorage;
     pub use crate::transactor::Transactor;
 
     #[cfg(feature = "debug")]
-    pub use crate::state::{Breakpoint, DebugEval};
+    pub use crate::debug::{Breakpoint, DebugEval, Debugger};
+
+    #[cfg(feature = "profiler-any")]
+    pub use crate::profiler::{
+        InstructionLocation, PerLocation, PerLocationIter, PerLocationKeys, PerLocationValues, ProfileReceiver,
+        Profiler, ProfilerStderrReceiver, ProfilingData,
+    };
+
+    #[cfg(feature = "profiler-gas")]
+    pub use crate::profiler::GasProfilingData;
 }

--- a/src/profiler/gas.rs
+++ b/src/profiler/gas.rs
@@ -1,0 +1,61 @@
+use super::{InstructionLocation, PerLocation, PerLocationIter, PerLocationKeys, PerLocationValues, ProfilingData};
+
+use std::fmt;
+
+impl ProfilingData {
+    /// Gas profiling info, immutable
+    pub fn gas(&self) -> &GasProfilingData {
+        &self.gas
+    }
+
+    /// Gas profiling info, mutable
+    pub fn gas_mut(&mut self) -> &mut GasProfilingData {
+        &mut self.gas
+    }
+}
+
+/// Used gas per memory address
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GasProfilingData {
+    gas_use: PerLocation<u64>,
+}
+
+impl<'a> GasProfilingData {
+    /// Get total gas used at location
+    pub fn get(&self, location: &InstructionLocation) -> u64 {
+        self.gas_use.get(location).copied().unwrap_or(0)
+    }
+
+    /// Increase gas used at location
+    pub fn add(&mut self, location: InstructionLocation, amount: u64) {
+        *self.gas_use.entry(location).or_insert(0) += amount;
+    }
+
+    /// Iterate through locations and gas values
+    pub fn iter(&'a self) -> PerLocationIter<'a, u64> {
+        PerLocationIter(self.gas_use.iter())
+    }
+
+    /// Iterate through locations
+    pub fn keys(&'a self) -> PerLocationKeys<'a, u64> {
+        PerLocationKeys(self.gas_use.keys())
+    }
+
+    /// Iterate through gas values
+    /// Can be used to get whole gas usage with `.sum()`
+    pub fn values(&'a self) -> PerLocationValues<'a, u64> {
+        PerLocationValues(self.gas_use.values())
+    }
+}
+
+impl fmt::Display for GasProfilingData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut items: Vec<(_, _)> = self.iter().collect();
+        items.sort();
+        for (addr, count) in items {
+            writeln!(f, "{}: {}", addr, count)?;
+        }
+        Ok(())
+    }
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,20 +4,7 @@ use fuel_tx::{Receipt, Transaction};
 use fuel_types::{Bytes32, Word};
 
 #[cfg(feature = "debug")]
-mod debug;
-
-#[cfg(feature = "debug")]
-mod debugger;
-
-#[cfg(feature = "debug")]
-pub use debug::{Breakpoint, DebugEval};
-
-#[cfg(feature = "debug")]
-pub use debugger::Debugger;
-
-#[cfg(not(feature = "debug"))]
-/// Fallback functionless implementation if `debug` feature isn't enabled.
-pub type Debugger = ();
+use crate::debug::{Breakpoint, DebugEval};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 /// Resulting state of an instruction set execution.

--- a/tests/profiler_gas.rs
+++ b/tests/profiler_gas.rs
@@ -1,11 +1,10 @@
-use std::sync::{Arc, Mutex};
-
 use fuel_vm::consts::*;
-use fuel_vm::prelude::*;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 
-use fuel_vm::profiler::{ProfileReceiver, ProfilingData};
+use std::sync::{Arc, Mutex};
+
+use fuel_vm::prelude::*;
 
 #[test]
 fn profile_gas() {


### PR DESCRIPTION
* Make the debugger attribute of the interpreter compatible with the
  format proposed by the profiler that avoids using a mock
  implementation.

* Modularize the profiler and split the feature requirements defined by
  `profiler-any` and `profiler-gas` with their respective modules.

* Avoid importing internal preludes related to the library to improve
  source readability.

* Include a changelog.