### PR TITLE
Fix GM opcode for returning the opposite result

### DIFF
--- a/src/interpreter/metadata.rs
+++ b/src/interpreter/metadata.rs
@@ -57,7 +57,7 @@ impl<S> Interpreter<S> {
 
         match imm {
             IS_CALLER_EXTERNAL => {
-                self.registers[ra] = (parent != 0) as Word;
+                self.registers[ra] = (parent == 0) as Word;
             }
 
             GET_CALLER => {

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -148,12 +148,12 @@ fn metadata() {
     let ra = receipts[1]
         .ra()
         .expect("IsCallerExternal should set $rA as boolean flag");
-    assert_eq!(0, ra);
+    assert_eq!(1, ra);
 
     let ra = receipts[3]
         .ra()
         .expect("IsCallerExternal should set $rA as boolean flag");
-    assert_eq!(1, ra);
+    assert_eq!(0, ra);
 
     let contract_call = Hasher::hash(contract_call.as_ref());
     let digest = receipts[4].digest().expect("GetCaller should return contract Id");


### PR DESCRIPTION
GM was returning the opposite of what it should've when checking if the caller was external. Instead of setting rA = true when the caller was external, we set rA = true when the caller was internal.

fixes: https://github.com/FuelLabs/fuel-vm/issues/83