### PR TITLE
Variable output bugfix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ itertools = "0.10"
 secp256k1 = { version = "0.20", features = ["recovery"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 sha3 = "0.9"
+thiserror = "1.0"
 tracing = "0.1"
 rand = { version = "0.8", optional = true }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,33 +1,42 @@
 //! Runtime interpreter error implementation
 
 use fuel_asm::{Instruction, InstructionResult, PanicReason};
-use fuel_tx::ValidationError;
+use fuel_tx::ValidationError as TxValidationError;
 
+use fuel_types::{AssetId, Word};
 use std::convert::Infallible as StdInfallible;
 use std::error::Error as StdError;
 use std::{fmt, io};
+use thiserror::Error;
 
 /// Interpreter runtime error variants.
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum InterpreterError {
     /// The instructions execution resulted in a well-formed panic, caused by an
     /// explicit instruction.
+    #[error("Execution error: {0:?}")]
     PanicInstruction(InstructionResult),
     /// The VM execution resulted in a well-formed panic. This panic wasn't
     /// caused by an instruction contained in the transaction or a called
     /// contract.
+    #[error("Execution error: {0:?}")]
     Panic(PanicReason),
     /// The provided transaction isn't valid.
-    ValidationError(ValidationError),
+    #[error("Failed to validate the transaction: {0}")]
+    ValidationError(#[from] VmValidationError),
     /// The predicate verification failed.
+    #[error("Execution error")]
     PredicateFailure,
     /// No transaction was initialized in the interpreter. It cannot provide
     /// state transitions.
+    #[error("Execution error")]
     NoTransactionInitialized,
     /// I/O and OS related errors.
-    Io(io::Error),
+    #[error("Unrecoverable error: {0}")]
+    Io(#[from] io::Error),
 
     #[cfg(feature = "debug")]
+    #[error("Execution error")]
     /// The debug state is not initialized; debug routines can't be called.
     DebugStateNotInitialized,
 }
@@ -76,41 +85,9 @@ impl InterpreterError {
     }
 }
 
-impl From<io::Error> for InterpreterError {
-    fn from(e: io::Error) -> Self {
-        InterpreterError::Io(e)
-    }
-}
-
-impl fmt::Display for InterpreterError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::ValidationError(e) => {
-                write!(f, "Failed to validate the transaction: {}", e)
-            }
-
-            Self::Io(e) => {
-                write!(f, "Unrecoverable error: {}", e)
-            }
-
-            _ => write!(f, "Execution error: {:?}", self),
-        }
-    }
-}
-
-impl StdError for InterpreterError {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        match self {
-            Self::ValidationError(e) => Some(e),
-            Self::Io(e) => Some(e),
-            _ => None,
-        }
-    }
-}
-
-impl From<ValidationError> for InterpreterError {
-    fn from(e: ValidationError) -> Self {
-        Self::ValidationError(e)
+impl From<TxValidationError> for InterpreterError {
+    fn from(e: TxValidationError) -> Self {
+        Self::ValidationError(VmValidationError::TransactionValidation(e))
     }
 }
 
@@ -127,6 +104,44 @@ impl From<RuntimeError> for InterpreterError {
             RuntimeError::Halt(e) => Self::Io(e),
         }
     }
+}
+
+/// Transaction validation errors the VM checks for. Also wraps errors from the fuel-tx library.
+#[derive(Debug, Error)]
+#[cfg_attr(feature = "serde-types-minimal", derive(serde::Serialize, serde::Deserialize))]
+pub enum VmValidationError {
+    /// Wrapped errors from fuel-tx
+    #[error(transparent)]
+    TransactionValidation(#[from] TxValidationError),
+    /// The transaction doesn't provide enough input amount of the native chain asset to cover
+    /// all potential execution fees
+    #[error("Insufficient fee amount provided: [Expected={expected}, Provided={provided}]")]
+    InsufficientFeeAmount {
+        /// The expected amount of fees required to cover the transaction
+        expected: Word,
+        /// The fee amount actually provided for spending
+        provided: Word,
+    },
+    /// The transaction doesn't provide enough input amount of the given asset to cover the
+    /// amounts used in the outputs.
+    #[error("Insufficient input amount [Asset={asset:x}, Expected={expected}, Provided={provided}")]
+    InsufficientInputAmount {
+        /// The asset id being spent
+        asset: AssetId,
+        /// The amount expected by a coin output
+        expected: Word,
+        /// The total amount provided by coin inputs
+        provided: Word,
+    },
+    /// The user provided transaction amounts for coins or gas prices caused an arithmetic
+    /// overflow.
+    #[error("Input causes an invalid arithmetic overflow")]
+    ArithmeticOverflow,
+    /// This error happens when a transaction attempts to create a coin output for an asset type
+    /// that doesn't exist in the coin inputs.
+    // TODO: promote this error variant to fuel-tx
+    #[error("Transaction output coin uses asset id not contained in inputs: {0:x}")]
+    TransactionOutputCoinAssetIdNotFound(AssetId),
 }
 
 #[derive(Debug)]

--- a/src/interpreter/executors/main.rs
+++ b/src/interpreter/executors/main.rs
@@ -9,8 +9,7 @@ use crate::storage::InterpreterStorage;
 
 use fuel_asm::{InstructionResult, PanicReason};
 use fuel_tx::{Input, Output, Receipt, Transaction};
-use fuel_types::bytes::SerializableVec;
-use fuel_types::Word;
+use fuel_types::{bytes::SerializableVec, Word};
 
 impl<S> Interpreter<S>
 where
@@ -163,7 +162,7 @@ where
         // refund remaining global gas
         let gas_refund = self.registers[REG_GGAS] * self.tx.gas_price();
         let revert = matches!(state, ProgramState::Revert(_));
-        self.update_change_amounts(gas_refund, revert)?;
+        self.finalize_outputs(gas_refund, revert)?;
 
         Ok(state)
     }

--- a/src/interpreter/executors/main.rs
+++ b/src/interpreter/executors/main.rs
@@ -156,6 +156,7 @@ where
                 crypto::ephemeral_merkle_root(self.receipts().iter().map(|r| r.clone().to_bytes()))
             };
 
+            // TODO: also set this on the serialized tx in memory to keep serialized form consistent
             self.tx.set_receipts_root(receipts_root);
         }
 

--- a/src/interpreter/executors/main.rs
+++ b/src/interpreter/executors/main.rs
@@ -156,6 +156,7 @@ where
             };
 
             // TODO: also set this on the serialized tx in memory to keep serialized form consistent
+            // https://github.com/FuelLabs/fuel-vm/issues/97
             self.tx.set_receipts_root(receipts_root);
         }
 

--- a/src/interpreter/internal.rs
+++ b/src/interpreter/internal.rs
@@ -181,7 +181,7 @@ impl<S> Interpreter<S> {
             ErrorKind::Other,
             "Invalid output index",
         )))?;
-        if std::mem::discriminant(tx_out) != std::mem::discriminant(&output) {
+        if core::mem::discriminant(tx_out) != core::mem::discriminant(&output) {
             return Err(RuntimeError::Halt(io::Error::new(
                 ErrorKind::Other,
                 "Invalid output type",

--- a/src/interpreter/internal.rs
+++ b/src/interpreter/internal.rs
@@ -107,7 +107,10 @@ impl<S> Interpreter<S> {
         let offset = *self
             .unused_balance_index
             .get(asset_id)
-            .ok_or(PanicReason::AssetIdNotFound)?;
+            .ok_or(RuntimeError::Halt(io::Error::new(
+                ErrorKind::Other,
+                "AssetId doesn't exist in balances",
+            )))?;
         let balance_memory = &self.memory[offset..offset + WORD_SIZE];
 
         let balance = <[u8; WORD_SIZE]>::try_from(&*balance_memory).expect("Expected slice to be word length!");

--- a/src/interpreter/internal.rs
+++ b/src/interpreter/internal.rs
@@ -179,7 +179,6 @@ impl<S> Interpreter<S> {
             "Invalid output index",
         )))?;
         if std::mem::discriminant(tx_out) != std::mem::discriminant(&output) {
-            // TODO: need a panic reason for a generic UnexpectedOutputType
             return Err(RuntimeError::Halt(io::Error::new(
                 ErrorKind::Other,
                 "Invalid output type",

--- a/src/interpreter/post_execution.rs
+++ b/src/interpreter/post_execution.rs
@@ -7,40 +7,41 @@ impl<S> Interpreter<S>
 where
     S: InterpreterStorage,
 {
-    /// Set the appropriate change output values after execution has concluded.
-    pub(crate) fn update_change_amounts(
-        &mut self,
-        unused_gas_cost: Word,
-        revert: bool,
-    ) -> Result<(), InterpreterError> {
+    /// Finalize outputs post-execution.
+    /// Set the appropriate change output values.
+    /// Revert variable output amounts as needed
+    /// TODO: do we want to set contract outputs in memory?
+    pub(crate) fn finalize_outputs(&mut self, unused_gas_cost: Word, revert: bool) -> Result<(), InterpreterError> {
         let init_balances = Self::initial_free_balances(&self.tx)?;
 
-        let update_outputs = match &self.tx {
+        let mut update_outputs = match &self.tx {
             Transaction::Script { outputs, .. } => outputs.clone(),
             Transaction::Create { outputs, .. } => outputs.clone(),
         };
 
         // Update each output based on free balance
-        for (idx, output) in update_outputs.iter().enumerate() {
-            if let Output::Change { asset_id, .. } = output {
+        for (idx, output) in update_outputs.iter_mut().enumerate() {
+            if let Output::Change { asset_id, amount, .. } = output {
                 let refund = if *asset_id == AssetId::default() {
                     unused_gas_cost
                 } else {
                     0
                 };
 
-                let amount = if revert {
+                let final_amount = if revert {
                     init_balances[asset_id] + refund
                 } else {
                     let balance = self.external_asset_id_balance(asset_id)?;
                     balance + refund
                 };
-                self.set_change_output(idx, amount)?;
+                *amount = final_amount;
+                self.set_output(idx, *output)?;
             }
-            if let Output::Variable { .. } = output {
+            if let Output::Variable { amount, .. } = output {
                 if revert {
                     // reset amounts to zero on revert
-                    self.revert_variable_output(idx)?;
+                    *amount = 0;
+                    self.set_output(idx, *output)?;
                 }
             }
         }

--- a/src/interpreter/post_execution.rs
+++ b/src/interpreter/post_execution.rs
@@ -28,12 +28,16 @@ where
                     0
                 };
 
+                // Safety: initialization verifies that every output has a compatible input asset
+                // by returning a TransactionOutputChangeAssetIdNotFound or
+                // TransactionOutputCoinAssetIdNotFound error for missing inputs.
                 let final_amount = if revert {
                     init_balances[asset_id] + refund
                 } else {
                     let balance = self.external_asset_id_balance(asset_id)?;
                     balance + refund
                 };
+
                 *amount = final_amount;
                 self.set_output(idx, *output)?;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub mod prelude {
     pub use crate::call::{Call, CallFrame};
     pub use crate::context::Context;
     pub use crate::contract::Contract;
-    pub use crate::error::{Infallible, InterpreterError, RuntimeError};
+    pub use crate::error::{Infallible, InterpreterError, RuntimeError, VmValidationError};
     pub use crate::interpreter::{Interpreter, InterpreterMetadata, MemoryRange};
     pub use crate::memory_client::{MemoryClient, MemoryStorage};
     pub use crate::state::{Debugger, ProgramState, StateTransition, StateTransitionRef};

--- a/tests/outputs.rs
+++ b/tests/outputs.rs
@@ -118,33 +118,6 @@ fn correct_change_is_provided_for_withdrawal_outputs() {
 }
 
 #[test]
-#[should_panic(expected = "ValidationError(TransactionOutputChangeAssetIdDuplicated)")]
-fn change_is_not_duplicated_for_each_base_asset_change_output() {
-    // create multiple change outputs for the base asset and ensure the total change is correct
-    let input_amount = 1000;
-    let gas_price = 0;
-    let byte_price = 0;
-    let asset_id = AssetId::default();
-
-    let outputs = TestBuilder::new(2322u64)
-        .gas_price(gas_price)
-        .byte_price(byte_price)
-        .coin_input(asset_id, input_amount)
-        .change_output(asset_id)
-        .change_output(asset_id)
-        .execute_get_outputs();
-
-    let mut total_change = 0;
-    for output in outputs {
-        if let Output::Change { amount, .. } = output {
-            total_change += amount;
-        }
-    }
-    // verify total change matches the input amount
-    assert_eq!(total_change, input_amount);
-}
-
-#[test]
 fn change_is_reduced_by_external_transfer() {
     let input_amount = 1000;
     let transfer_amount: Word = 400;

--- a/tests/validation.rs
+++ b/tests/validation.rs
@@ -1,0 +1,205 @@
+use fuel_vm::{prelude::*, util::test_helpers::TestBuilder};
+
+#[test]
+fn transaction_validation_fails_when_provided_fees_dont_cover_byte_costs() {
+    let input_amount = 1000;
+    let gas_price = 0;
+    // make byte price too high for the input amount
+    let byte_price = 1000;
+
+    let transaction = TestBuilder::new(2322u64)
+        .gas_price(gas_price)
+        .byte_price(byte_price)
+        .coin_input(AssetId::default(), input_amount)
+        .change_output(AssetId::default())
+        .build();
+
+    let mut interpreter = Interpreter::with_memory_storage();
+    let result = interpreter.transact(transaction);
+    assert!(matches!(
+        result,
+        Err(InterpreterError::ValidationError(
+            VmValidationError::InsufficientFeeAmount {
+                provided: _,
+                expected: _
+            }
+        ))
+    ));
+}
+
+#[test]
+fn transaction_validation_fails_when_provided_fees_dont_cover_gas_costs() {
+    let input_amount = 1000;
+    // make gas price too high for the input amount
+    let gas_price = 1000;
+    let byte_price = 0;
+
+    let transaction = TestBuilder::new(2322u64)
+        .gas_price(gas_price)
+        .byte_price(byte_price)
+        .coin_input(AssetId::default(), input_amount)
+        .change_output(AssetId::default())
+        .build();
+
+    let mut interpreter = Interpreter::with_memory_storage();
+    let result = interpreter.transact(transaction);
+    assert!(matches!(
+        result,
+        Err(InterpreterError::ValidationError(
+            VmValidationError::InsufficientFeeAmount {
+                provided: _,
+                expected: _
+            }
+        ))
+    ));
+}
+
+#[test]
+fn transaction_validation_fails_when_change_asset_id_not_in_inputs() {
+    let input_amount = 1000;
+    // make gas price too high for the input amount
+    let gas_price = 0;
+    let byte_price = 0;
+
+    let transaction = TestBuilder::new(2322u64)
+        .gas_price(gas_price)
+        .byte_price(byte_price)
+        .coin_input(AssetId::default(), input_amount)
+        .change_output(AssetId::default())
+        // make change output with no corresponding input asset
+        .change_output(AssetId::from([1; 32]))
+        .build();
+
+    let mut interpreter = Interpreter::with_memory_storage();
+    let result = interpreter.transact(transaction);
+    assert!(matches!(
+        result,
+        Err(InterpreterError::ValidationError(
+            VmValidationError::TransactionValidation(ValidationError::TransactionOutputChangeAssetIdNotFound)
+        ))
+    ));
+}
+
+#[test]
+fn transaction_validation_fails_when_coin_output_asset_id_not_in_inputs() {
+    let input_amount = 1000;
+    // make gas price too high for the input amount
+    let gas_price = 0;
+    let byte_price = 0;
+
+    let transaction = TestBuilder::new(2322u64)
+        .gas_price(gas_price)
+        .byte_price(byte_price)
+        .coin_input(AssetId::default(), input_amount)
+        .change_output(AssetId::default())
+        // make change output with no corresponding input asset
+        .coin_output(AssetId::from([1; 32]), 0)
+        .build();
+
+    let mut interpreter = Interpreter::with_memory_storage();
+    let result = interpreter.transact(transaction);
+    assert!(matches!(
+        result,
+        Err(InterpreterError::ValidationError(
+            VmValidationError::TransactionOutputCoinAssetIdNotFound(_)
+        ))
+    ));
+}
+
+#[test]
+fn change_is_not_duplicated_for_each_base_asset_change_output() {
+    // create multiple change outputs for the base asset and ensure the total change is correct
+    let input_amount = 1000;
+    let gas_price = 0;
+    let byte_price = 0;
+    let asset_id = AssetId::default();
+
+    let transaction = TestBuilder::new(2322u64)
+        .gas_price(gas_price)
+        .byte_price(byte_price)
+        .coin_input(asset_id, input_amount)
+        .change_output(asset_id)
+        .change_output(asset_id)
+        .build();
+
+    let mut interpreter = Interpreter::with_memory_storage();
+    let result = interpreter.transact(transaction);
+    assert!(matches!(
+        result,
+        Err(InterpreterError::ValidationError(
+            VmValidationError::TransactionValidation(ValidationError::TransactionOutputChangeAssetIdDuplicated)
+        ))
+    ))
+}
+
+#[test]
+fn bytes_fee_cant_overflow() {
+    let input_amount = 1000;
+    let gas_price = 0;
+    // make byte price too high for the input amount
+    let byte_price = Word::MAX;
+
+    let transaction = TestBuilder::new(2322u64)
+        .gas_price(gas_price)
+        .byte_price(byte_price)
+        .coin_input(AssetId::default(), input_amount)
+        .change_output(AssetId::default())
+        .build();
+
+    let mut interpreter = Interpreter::with_memory_storage();
+    let result = interpreter.transact(transaction);
+    assert!(matches!(
+        result,
+        Err(InterpreterError::ValidationError(VmValidationError::ArithmeticOverflow))
+    ));
+}
+
+#[test]
+fn gas_fee_cant_overflow() {
+    let input_amount = 1000;
+    let gas_price = Word::MAX;
+    let gas_limit = 2;
+    // make byte price too high for the input amount
+    let byte_price = 0;
+
+    let transaction = TestBuilder::new(2322u64)
+        .gas_price(gas_price)
+        .gas_limit(gas_limit)
+        .byte_price(byte_price)
+        .coin_input(AssetId::default(), input_amount)
+        .change_output(AssetId::default())
+        .build();
+
+    let mut interpreter = Interpreter::with_memory_storage();
+    let result = interpreter.transact(transaction);
+    assert!(matches!(
+        result,
+        Err(InterpreterError::ValidationError(VmValidationError::ArithmeticOverflow))
+    ));
+}
+
+#[test]
+fn total_fee_cant_overflow() {
+    // ensure that total fee can't overflow as a result of adding the gas fee and byte fee
+
+    let input_amount = 1000;
+    let gas_price = Word::MAX;
+    let gas_limit = 1;
+    // make byte price too high for the input amount
+    let byte_price = 1;
+
+    let transaction = TestBuilder::new(2322u64)
+        .gas_price(gas_price)
+        .gas_limit(gas_limit)
+        .byte_price(byte_price)
+        .coin_input(AssetId::default(), input_amount)
+        .change_output(AssetId::default())
+        .build();
+
+    let mut interpreter = Interpreter::with_memory_storage();
+    let result = interpreter.transact(transaction);
+    assert!(matches!(
+        result,
+        Err(InterpreterError::ValidationError(VmValidationError::ArithmeticOverflow))
+    ));
+}

--- a/tests/validation.rs
+++ b/tests/validation.rs
@@ -92,7 +92,7 @@ fn transaction_validation_fails_when_coin_output_asset_id_not_in_inputs() {
         .byte_price(byte_price)
         .coin_input(AssetId::default(), input_amount)
         .change_output(AssetId::default())
-        // make change output with no corresponding input asset
+        // make coin output with no corresponding input asset
         .coin_output(AssetId::from([1; 32]), 0)
         .build();
 


### PR DESCRIPTION
Variable outputs need to be updated directly on the serialized transaction representation in VM memory for IVG purposes. However, there was a bug when writing the variable output changes such that the wrong offset was used, potentially overwriting freebalances.

This PR also makes change outputs consistent between the serialized tx and ref tx. Since if the serialized tx matches the VM referenced tx after post-execution, the tx won't need to be recloned and serialized later in the client for merkleizing.