### PR TITLE
Externalized Validity Checks

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -25,6 +25,7 @@ mod memory;
 mod metadata;
 mod post_execution;
 mod transaction;
+mod validation;
 
 #[cfg(feature = "debug")]
 mod debug;

--- a/src/interpreter/initialization.rs
+++ b/src/interpreter/initialization.rs
@@ -2,24 +2,21 @@ use super::Interpreter;
 use crate::consts::*;
 use crate::context::Context;
 use crate::error::InterpreterError;
+use crate::interpreter::validation::CheckedTransaction;
 use crate::storage::InterpreterStorage;
 
-use fuel_asm::PanicReason;
 use fuel_tx::consts::MAX_INPUTS;
-use fuel_tx::{Input, Output, Transaction};
 use fuel_types::bytes::{SerializableVec, SizedBytes};
 use fuel_types::{AssetId, Word};
 use itertools::Itertools;
-use std::collections::HashMap;
 use std::io;
 
 impl<S> Interpreter<S>
 where
     S: InterpreterStorage,
 {
-    pub(crate) fn init(&mut self, mut tx: Transaction) -> Result<(), InterpreterError> {
-        tx.validate_without_signature(self.block_height() as Word)?;
-        tx.precompute_metadata();
+    pub(crate) fn init(&mut self, checked_tx: CheckedTransaction) -> Result<(), InterpreterError> {
+        let mut tx = checked_tx.tx;
 
         self.block_height = self.storage.block_height().map_err(InterpreterError::from_io)?;
         self.context = Context::from(&tx);
@@ -40,7 +37,10 @@ where
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
 
         // Set initial unused balances
-        let free_balances = Self::initial_free_balances(&tx)?;
+        let free_balances = checked_tx.balances;
+        // Clear balance indexes in case vm is being re-initialized
+        self.unused_balance_index.clear();
+        // Put free balances into vm memory
         for (asset_id, amount) in free_balances.iter().sorted_by_key(|i| i.0) {
             // push asset ID
             self.push_stack(asset_id.as_ref())
@@ -73,46 +73,5 @@ where
         self.tx = tx;
 
         Ok(())
-    }
-
-    // compute the initial free balances for each asset type
-    pub(crate) fn initial_free_balances(tx: &Transaction) -> Result<HashMap<AssetId, Word>, InterpreterError> {
-        let mut balances = HashMap::<AssetId, Word>::new();
-
-        // Add up all the inputs for each asset ID
-        for (asset_id, amount) in tx.inputs().iter().filter_map(|input| match input {
-            Input::Coin { asset_id, amount, .. } => Some((asset_id, amount)),
-            _ => None,
-        }) {
-            *balances.entry(*asset_id).or_default() += amount;
-        }
-
-        // Reduce by unavailable balances
-        let base_asset = AssetId::default();
-        if let Some(base_asset_balance) = balances.get_mut(&base_asset) {
-            // remove byte costs from base asset spendable balance
-            let byte_balance = (tx.metered_bytes_size() as Word) * tx.byte_price();
-            *base_asset_balance = base_asset_balance
-                .checked_sub(byte_balance)
-                .ok_or(InterpreterError::Panic(PanicReason::NotEnoughBalance))?;
-            // remove gas costs from base asset spendable balance
-            *base_asset_balance = base_asset_balance
-                .checked_sub(tx.gas_limit() * tx.gas_price())
-                .ok_or(InterpreterError::Panic(PanicReason::NotEnoughBalance))?;
-        }
-
-        // reduce free balances by coin and withdrawal outputs
-        for (asset_id, amount) in tx.outputs().iter().filter_map(|output| match output {
-            Output::Coin { asset_id, amount, .. } => Some((asset_id, amount)),
-            Output::Withdrawal { asset_id, amount, .. } => Some((asset_id, amount)),
-            _ => None,
-        }) {
-            let balance = balances.get_mut(asset_id).unwrap();
-            *balance = balance
-                .checked_sub(*amount)
-                .ok_or(InterpreterError::Panic(PanicReason::NotEnoughBalance))?;
-        }
-
-        Ok(balances)
     }
 }

--- a/src/interpreter/internal.rs
+++ b/src/interpreter/internal.rs
@@ -224,6 +224,8 @@ mod tests {
             vec![vec![].into()],
         );
 
+        let tx = Interpreter::<()>::check_transaction(tx, 0).unwrap();
+
         vm.init(tx).expect("Failed to init VM!");
 
         for (asset_id, amount) in balances {
@@ -266,6 +268,8 @@ mod tests {
             vec![variable_output],
             vec![Witness::default()],
         );
+
+        let tx = Interpreter::<()>::check_transaction(tx, 0).unwrap();
 
         vm.init(tx).expect("Failed to init VM!");
 

--- a/src/interpreter/memory.rs
+++ b/src/interpreter/memory.rs
@@ -422,7 +422,8 @@ mod tests {
     #[test]
     fn memcopy() {
         let mut vm = Interpreter::with_memory_storage();
-        vm.init(Transaction::default()).expect("Failed to init VM");
+        let tx = Interpreter::<()>::check_transaction(Transaction::default(), 0).unwrap();
+        vm.init(tx).expect("Failed to init VM");
 
         let alloc = 1024;
 
@@ -473,7 +474,8 @@ mod tests {
         assert_eq!(m, m_p);
 
         let mut vm = Interpreter::with_memory_storage();
-        vm.init(Transaction::default()).expect("Failed to init VM");
+        let tx = Interpreter::<()>::check_transaction(Transaction::default(), 0).unwrap();
+        vm.init(tx).expect("Failed to init VM");
 
         let bytes = 1024;
         vm.instruction(Opcode::ADDI(0x10, REG_ZERO, bytes as Immediate12).into())
@@ -499,7 +501,8 @@ mod tests {
     #[test]
     fn stack_alloc_ownership() {
         let mut vm = Interpreter::with_memory_storage();
-        vm.init(Transaction::default()).expect("Failed to init VM");
+        let tx = Interpreter::<()>::check_transaction(Transaction::default(), 0).unwrap();
+        vm.init(tx).expect("Failed to init VM");
 
         vm.instruction(Opcode::MOVE(0x10, REG_SP).into()).unwrap();
         vm.instruction(Opcode::CFEI(2).into()).unwrap();

--- a/src/interpreter/validation.rs
+++ b/src/interpreter/validation.rs
@@ -1,0 +1,85 @@
+use crate::error::InterpreterError;
+use crate::interpreter::Interpreter;
+use fuel_asm::PanicReason;
+use fuel_tx::{Input, Output, Transaction};
+use fuel_types::{AssetId, Word};
+use std::collections::HashMap;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct CheckedTransaction {
+    /// the validated transaction
+    pub(crate) tx: Transaction,
+    /// the initial free balances of the transaction
+    pub(crate) balances: HashMap<AssetId, Word>,
+}
+
+impl AsRef<Transaction> for CheckedTransaction {
+    fn as_ref(&self) -> &Transaction {
+        &self.tx
+    }
+}
+
+impl<T> Interpreter<T> {
+    /// Validate a transaction for later VM execution. The checked transaction wrapper will
+    /// allow the VM to trust the transaction as valid and execute it at some point later on in
+    /// the future. Note - this doesn't mean the transaction has been completely validated,
+    /// predicates must be externally checked as well.
+    pub fn check_transaction(
+        mut transaction: Transaction,
+        height: Word,
+    ) -> Result<CheckedTransaction, InterpreterError> {
+        // verify transaction - transactions don't expire, once a tx passes the maturity
+        // requirements the height doesn't need to be validated again in the future.
+        transaction.validate_without_signature(height)?;
+        transaction.precompute_metadata();
+
+        // verify & cache initial balances
+        let balances = Self::initial_free_balances(&transaction)?;
+
+        Ok(CheckedTransaction {
+            tx: transaction,
+            balances,
+        })
+    }
+
+    // compute the initial free balances for each asset type
+    pub(crate) fn initial_free_balances(tx: &Transaction) -> Result<HashMap<AssetId, Word>, InterpreterError> {
+        let mut balances = HashMap::<AssetId, Word>::new();
+
+        // Add up all the inputs for each asset ID
+        for (asset_id, amount) in tx.inputs().iter().filter_map(|input| match input {
+            Input::Coin { asset_id, amount, .. } => Some((asset_id, amount)),
+            _ => None,
+        }) {
+            *balances.entry(*asset_id).or_default() += amount;
+        }
+
+        // Reduce by unavailable balances
+        let base_asset = AssetId::default();
+        if let Some(base_asset_balance) = balances.get_mut(&base_asset) {
+            // remove byte costs from base asset spendable balance
+            let byte_balance = (tx.metered_bytes_size() as Word) * tx.byte_price();
+            *base_asset_balance = base_asset_balance
+                .checked_sub(byte_balance)
+                .ok_or(InterpreterError::Panic(PanicReason::NotEnoughBalance))?;
+            // remove gas costs from base asset spendable balance
+            *base_asset_balance = base_asset_balance
+                .checked_sub(tx.gas_limit() * tx.gas_price())
+                .ok_or(InterpreterError::Panic(PanicReason::NotEnoughBalance))?;
+        }
+
+        // reduce free balances by coin and withdrawal outputs
+        for (asset_id, amount) in tx.outputs().iter().filter_map(|output| match output {
+            Output::Coin { asset_id, amount, .. } => Some((asset_id, amount)),
+            Output::Withdrawal { asset_id, amount, .. } => Some((asset_id, amount)),
+            _ => None,
+        }) {
+            let balance = balances.get_mut(asset_id).unwrap();
+            *balance = balance
+                .checked_sub(*amount)
+                .ok_or(InterpreterError::Panic(PanicReason::NotEnoughBalance))?;
+        }
+
+        Ok(balances)
+    }
+}


### PR DESCRIPTION
Previously, we didn't have a way to check if a tx was valid for block inclusion without also executing its' script. This introduces a new structure for `CheckedTransaction`'s, which allows a transaction to be validated with VM rules to ensure it's safe to include in a block, without requiring the actual script to be executed. The VM can accept these checked transactions when executing the script to avoid redundant validation as well. This will be useful for validating transactions inside the mempool.

closes #82