### PR TITLE
Implement MOVI opcode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,3 +83,6 @@ required-features = ["random"]
 name = "test-predicate"
 path = "tests/predicate.rs"
 required-features = ["random"]
+
+[patch.crates-io]
+fuel-asm = { git = "https://github.com/FuelLabs/fuel-asm", branch = "movi" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ description = "FuelVM interpreter."
 
 [dependencies]
 dyn-clone = { version = "1.0", optional = true }
-fuel-asm = "0.2"
+fuel-asm = "0.3"
 fuel-crypto = "0.3"
 fuel-merkle = "0.1"
 fuel-storage = "0.1"
-fuel-tx = "0.6"
+fuel-tx = "0.7"
 fuel-types = "0.3"
 itertools = "0.10"
 secp256k1 = { version = "0.20", features = ["recovery"] }
@@ -27,7 +27,7 @@ tracing = "0.1"
 rand = { version = "0.8", optional = true }
 
 [dev-dependencies]
-fuel-tx = { version = "0.6", features = ["random"] }
+fuel-tx = { version = "0.7", features = ["random"] }
 fuel-vm = { path = ".", default-features = false, features = ["test-helpers"]}
 
 [features]
@@ -83,6 +83,3 @@ required-features = ["random"]
 name = "test-predicate"
 path = "tests/predicate.rs"
 required-features = ["random"]
-
-[patch.crates-io]
-fuel-asm = { git = "https://github.com/FuelLabs/fuel-asm", branch = "movi" }

--- a/src/interpreter/executors/instruction.rs
+++ b/src/interpreter/executors/instruction.rs
@@ -148,6 +148,11 @@ where
                 self.alu_set(ra, b)?;
             }
 
+            OpcodeRepr::MOVI => {
+                self.gas_charge(GAS_MOVI)?;
+                self.alu_set(ra, imm)?;
+            }
+
             OpcodeRepr::MROO => {
                 self.gas_charge(GAS_MROO)?;
                 self.alu_error(

--- a/src/interpreter/gas.rs
+++ b/src/interpreter/gas.rs
@@ -19,7 +19,7 @@ impl<S> Interpreter<S> {
 
             MLOG | MROO => GasUnit::ArithmeticExpensive(1).join(GasUnit::RegisterWrite(3)),
 
-            AND | EQ | GT | LT | OR | XOR | NOT | ANDI | MOVE | ORI | XORI => GasUnit::RegisterWrite(3),
+            AND | EQ | GT | LT | OR | XOR | NOT | ANDI | MOVE | MOVI | ORI | XORI => GasUnit::RegisterWrite(3),
 
             DIV | MOD | DIVI | MODI => GasUnit::Arithmetic(1).join(GasUnit::Branching(1)),
 

--- a/src/interpreter/gas/consts.rs
+++ b/src/interpreter/gas/consts.rs
@@ -19,6 +19,7 @@ pub const GAS_MLOG: Word = Interpreter::<()>::gas_cost_const(OpcodeRepr::MLOG);
 pub const GAS_MOD: Word = Interpreter::<()>::gas_cost_const(OpcodeRepr::MOD);
 pub const GAS_MODI: Word = Interpreter::<()>::gas_cost_const(OpcodeRepr::MODI);
 pub const GAS_MOVE: Word = Interpreter::<()>::gas_cost_const(OpcodeRepr::MOVE);
+pub const GAS_MOVI: Word = Interpreter::<()>::gas_cost_const(OpcodeRepr::MOVI);
 pub const GAS_MROO: Word = Interpreter::<()>::gas_cost_const(OpcodeRepr::MROO);
 pub const GAS_MUL: Word = Interpreter::<()>::gas_cost_const(OpcodeRepr::MUL);
 pub const GAS_MULI: Word = Interpreter::<()>::gas_cost_const(OpcodeRepr::MULI);

--- a/tests/alu.rs
+++ b/tests/alu.rs
@@ -1,7 +1,7 @@
 use fuel_vm::consts::*;
 use fuel_vm::prelude::*;
 
-fn alu(registers_init: &[(RegisterId, Immediate12)], op: Opcode, reg: RegisterId, expected: Word) {
+fn alu(registers_init: &[(RegisterId, Immediate18)], op: Opcode, reg: RegisterId, expected: Word) {
     let storage = MemoryStorage::default();
 
     let gas_price = 0;
@@ -11,7 +11,7 @@ fn alu(registers_init: &[(RegisterId, Immediate12)], op: Opcode, reg: RegisterId
 
     let script = registers_init
         .iter()
-        .map(|(r, v)| Opcode::ADDI(*r, REG_ZERO, *v))
+        .map(|(r, v)| Opcode::MOVI(*r, *v))
         .chain([op, Opcode::LOG(reg, 0, 0, 0), Opcode::RET(REG_ONE)].iter().copied())
         .collect();
 
@@ -38,7 +38,7 @@ fn alu(registers_init: &[(RegisterId, Immediate12)], op: Opcode, reg: RegisterId
     );
 }
 
-fn alu_err(registers_init: &[(RegisterId, Immediate12)], op: Opcode) {
+fn alu_err(registers_init: &[(RegisterId, Immediate18)], op: Opcode) {
     let storage = MemoryStorage::default();
 
     let gas_price = 0;
@@ -48,7 +48,7 @@ fn alu_err(registers_init: &[(RegisterId, Immediate12)], op: Opcode) {
 
     let script = registers_init
         .iter()
-        .map(|(r, v)| Opcode::ADDI(*r, REG_ZERO, *v))
+        .map(|(r, v)| Opcode::MOVI(*r, *v))
         .chain([op, Opcode::RET(REG_ONE)].iter().copied())
         .collect();
 

--- a/tests/backtrace.rs
+++ b/tests/backtrace.rs
@@ -52,18 +52,17 @@ fn backtrace() {
 
     #[rustfmt::skip]
     let mut function_call: Vec<Opcode> = vec![
-        Opcode::ADDI(0x10, REG_ZERO, (contract_undefined.as_ref().len() + WORD_SIZE * 2) as Immediate12),
+        Opcode::MOVI(0x10,  (contract_undefined.as_ref().len() + WORD_SIZE * 2) as Immediate18),
         Opcode::ALOC(0x10),
     ];
 
     contract_undefined.as_ref().iter().enumerate().for_each(|(i, b)| {
-        function_call.push(Opcode::ADDI(0x10, REG_ZERO, *b as Immediate12));
+        function_call.push(Opcode::MOVI(0x10, *b as Immediate18));
         function_call.push(Opcode::SB(REG_HP, 0x10, 1 + i as Immediate12));
     });
 
     function_call.push(Opcode::ADDI(0x10, REG_HP, 1));
-    function_call.push(Opcode::ADDI(0x11, REG_ZERO, gas_limit as Immediate12));
-    function_call.push(Opcode::CALL(0x10, REG_ZERO, 0x10, 0x11));
+    function_call.push(Opcode::CALL(0x10, REG_ZERO, 0x10, REG_CGAS));
     function_call.push(Opcode::RET(REG_ONE));
 
     let salt: Salt = rng.gen();
@@ -95,18 +94,17 @@ fn backtrace() {
 
     #[rustfmt::skip]
     let mut script: Vec<Opcode> = vec![
-        Opcode::ADDI(0x10, REG_ZERO, (contract_call.as_ref().len() + WORD_SIZE * 2) as Immediate12),
+        Opcode::MOVI(0x10, (contract_call.as_ref().len() + WORD_SIZE * 2) as Immediate18),
         Opcode::ALOC(0x10),
     ];
 
     contract_call.as_ref().iter().enumerate().for_each(|(i, b)| {
-        script.push(Opcode::ADDI(0x10, REG_ZERO, *b as Immediate12));
+        script.push(Opcode::MOVI(0x10, *b as Immediate18));
         script.push(Opcode::SB(REG_HP, 0x10, 1 + i as Immediate12));
     });
 
     script.push(Opcode::ADDI(0x10, REG_HP, 1));
-    script.push(Opcode::ADDI(0x11, REG_ZERO, gas_limit as Immediate12));
-    script.push(Opcode::CALL(0x10, REG_ZERO, 0x10, 0x11));
+    script.push(Opcode::CALL(0x10, REG_ZERO, REG_ZERO, REG_CGAS));
     script.push(Opcode::RET(REG_ONE));
 
     let input_undefined = Input::contract(rng.gen(), rng.gen(), rng.gen(), contract_undefined);

--- a/tests/contract.rs
+++ b/tests/contract.rs
@@ -64,9 +64,8 @@ fn mint_burn() {
     let output = Output::contract(0, rng.gen(), rng.gen());
 
     let mut script_ops = vec![
-        Opcode::ADDI(0x10, REG_ZERO, 0),
-        Opcode::ADDI(0x11, REG_ZERO, gas_limit as Immediate12),
-        Opcode::CALL(0x10, REG_ZERO, 0x10, 0x11),
+        Opcode::MOVI(0x10, 0),
+        Opcode::CALL(0x10, REG_ZERO, 0x10, REG_CGAS),
         Opcode::RET(REG_ONE),
     ];
 
@@ -84,7 +83,7 @@ fn mint_burn() {
     );
 
     let script_data_offset = VM_TX_MEMORY + tx.script_data_offset().unwrap();
-    script_ops[0] = Opcode::ADDI(0x10, REG_ZERO, script_data_offset as Immediate12);
+    script_ops[0] = Opcode::MOVI(0x10, script_data_offset as Immediate18);
 
     let script: Vec<u8> = script_ops.iter().copied().collect();
     let script_data = Call::new(contract, 0, balance).to_bytes();
@@ -128,7 +127,7 @@ fn mint_burn() {
     );
 
     let script_data_offset = VM_TX_MEMORY + tx_check_balance.script_data_offset().unwrap();
-    script_check_balance[0] = Opcode::ADDI(0x10, REG_ZERO, script_data_offset as Immediate12);
+    script_check_balance[0] = Opcode::MOVI(0x10, script_data_offset as Immediate18);
 
     let tx_check_balance = Transaction::script(
         gas_price,
@@ -247,15 +246,13 @@ fn call_increases_contract_asset_balance_and_balance_register() {
         data_offset,
         vec![
             // load call data to 0x10
-            Opcode::ADDI(0x10, REG_ZERO, data_offset + 32),
-            // load gas forward to 0x11
-            Opcode::ADDI(0x11, REG_ZERO, gas_limit as Immediate12),
+            Opcode::MOVI(0x10, data_offset + 32),
             // load balance to forward to 0x12
-            Opcode::ADDI(0x12, REG_ZERO, call_amount as Immediate12),
+            Opcode::MOVI(0x11, call_amount as Immediate18),
             // load the asset id to use to 0x13
-            Opcode::ADDI(0x13, REG_ZERO, data_offset),
+            Opcode::MOVI(0x12, data_offset),
             // call the transfer contract
-            Opcode::CALL(0x10, 0x12, 0x13, 0x11),
+            Opcode::CALL(0x10, 0x11, 0x12, REG_CGAS),
             Opcode::RET(REG_ONE),
         ]
     );
@@ -337,11 +334,9 @@ fn call_decreases_internal_balance_and_increases_destination_contract_balance() 
         data_offset,
         vec![
             // load call data to 0x10
-            Opcode::ADDI(0x10, REG_ZERO, data_offset + 64),
-            // load gas forward to 0x11
-            Opcode::ADDI(0x11, REG_ZERO, gas_limit as Immediate12),
+            Opcode::MOVI(0x10, data_offset + 64),
             // call the transfer contract
-            Opcode::CALL(0x10, REG_ZERO, REG_ZERO, 0x11),
+            Opcode::CALL(0x10, REG_ZERO, REG_ZERO, REG_CGAS),
             Opcode::RET(REG_ONE),
         ]
     );
@@ -425,11 +420,9 @@ fn internal_transfer_reduces_source_contract_balance_and_increases_destination_c
         data_offset,
         vec![
             // load call data to 0x10
-            Opcode::ADDI(0x10, REG_ZERO, data_offset + 64),
-            // load gas forward to 0x11
-            Opcode::ADDI(0x11, REG_ZERO, gas_limit as Immediate12),
+            Opcode::MOVI(0x10, data_offset + 64),
             // call the transfer contract
-            Opcode::CALL(0x10, REG_ZERO, REG_ZERO, 0x11),
+            Opcode::CALL(0x10, REG_ZERO, REG_ZERO, REG_CGAS),
             Opcode::RET(REG_ONE),
         ]
     );
@@ -508,11 +501,9 @@ fn internal_transfer_cant_exceed_more_than_source_contract_balance() {
         data_offset,
         vec![
             // load call data to 0x10
-            Opcode::ADDI(0x10, REG_ZERO, data_offset + 64),
-            // load gas forward to 0x11
-            Opcode::ADDI(0x11, REG_ZERO, gas_limit as Immediate12),
+            Opcode::MOVI(0x10, data_offset + 64),
             // call the transfer contract
-            Opcode::CALL(0x10, REG_ZERO, REG_ZERO, 0x11),
+            Opcode::CALL(0x10, REG_ZERO, REG_ZERO, REG_CGAS),
             Opcode::RET(REG_ONE),
         ]
     );

--- a/tests/crypto.rs
+++ b/tests/crypto.rs
@@ -28,14 +28,14 @@ fn ecrecover() {
 
     let alloc = e.len() + sig.len() + public.len() + public.len(); // Computed public key
 
-    let mut script = vec![Opcode::ADDI(0x20, REG_ZERO, alloc as Immediate12), Opcode::ALOC(0x20)];
+    let mut script = vec![Opcode::MOVI(0x20, alloc as Immediate18), Opcode::ALOC(0x20)];
 
     e.iter()
         .chain(sig.iter())
         .chain(public.iter())
         .enumerate()
         .for_each(|(i, b)| {
-            script.push(Opcode::ADDI(0x21, REG_ZERO, *b as Immediate12));
+            script.push(Opcode::MOVI(0x21, *b as Immediate18));
             script.push(Opcode::SB(REG_HP, 0x21, (i + 1) as Immediate12));
         });
 
@@ -52,7 +52,7 @@ fn ecrecover() {
     script.push(Opcode::ADDI(0x33, 0x32, public.len() as Immediate12));
 
     // Set public key length to 0x34
-    script.push(Opcode::ADDI(0x34, REG_ZERO, public.len() as Immediate12));
+    script.push(Opcode::MOVI(0x34, public.len() as Immediate18));
 
     // Compute the ECRECOVER
     // m[computed public key] := ecrecover(sig, e)
@@ -115,10 +115,10 @@ fn sha256() {
         + 32 // reference hash
         + 32; // computed hash
 
-    let mut script = vec![Opcode::ADDI(0x20, REG_ZERO, alloc), Opcode::ALOC(0x20)];
+    let mut script = vec![Opcode::MOVI(0x20, alloc as Immediate18), Opcode::ALOC(0x20)];
 
     message.iter().chain(hash.iter()).enumerate().for_each(|(i, b)| {
-        script.push(Opcode::ADDI(0x21, REG_ZERO, *b as Immediate12));
+        script.push(Opcode::MOVI(0x21, *b as Immediate18));
         script.push(Opcode::SB(REG_HP, 0x21, (i + 1) as Immediate12));
     });
 
@@ -132,10 +132,10 @@ fn sha256() {
     script.push(Opcode::ADDI(0x32, 0x31, 32));
 
     // Set message length to 0x33
-    script.push(Opcode::ADDI(0x33, REG_ZERO, length));
+    script.push(Opcode::MOVI(0x33, length as Immediate18));
 
     // Set hash length to 0x34
-    script.push(Opcode::ADDI(0x34, REG_ZERO, 32));
+    script.push(Opcode::MOVI(0x34, 32));
 
     // Compute the Keccak256
     // m[computed hash] := keccack256(m[message, length])
@@ -203,10 +203,10 @@ fn keccak256() {
         + 32 // reference hash
         + 32; // computed hash
 
-    let mut script = vec![Opcode::ADDI(0x20, REG_ZERO, alloc), Opcode::ALOC(0x20)];
+    let mut script = vec![Opcode::MOVI(0x20, alloc as Immediate18), Opcode::ALOC(0x20)];
 
     message.iter().chain(hash.iter()).enumerate().for_each(|(i, b)| {
-        script.push(Opcode::ADDI(0x21, REG_ZERO, *b as Immediate12));
+        script.push(Opcode::MOVI(0x21, *b as Immediate18));
         script.push(Opcode::SB(REG_HP, 0x21, (i + 1) as Immediate12));
     });
 
@@ -220,10 +220,10 @@ fn keccak256() {
     script.push(Opcode::ADDI(0x32, 0x31, 32));
 
     // Set message length to 0x33
-    script.push(Opcode::ADDI(0x33, REG_ZERO, length));
+    script.push(Opcode::MOVI(0x33, length as Immediate18));
 
     // Set hash length to 0x34
-    script.push(Opcode::ADDI(0x34, REG_ZERO, 32));
+    script.push(Opcode::MOVI(0x34, 32));
 
     // Compute the Keccak256
     // m[computed hash] := keccack256(m[message, length])

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -20,7 +20,7 @@ fn metadata() {
         Opcode::GM(0x10, InterpreterMetadata::IsCallerExternal.into()),
         Opcode::GM(0x11, InterpreterMetadata::GetCaller.into()),
         Opcode::LOG(0x10, 0x00, 0x00, 0x00),
-        Opcode::ADDI(0x20, REG_ZERO, ContractId::LEN as Immediate12),
+        Opcode::MOVI(0x20,  ContractId::LEN as Immediate18),
         Opcode::LOGD(0x00, 0x00, 0x11, 0x20),
         Opcode::RET(REG_ONE),
     ];
@@ -59,18 +59,17 @@ fn metadata() {
     let mut routine_call_metadata_contract: Vec<Opcode> = vec![
         Opcode::GM(0x10, InterpreterMetadata::IsCallerExternal.into()),
         Opcode::LOG(0x10, 0x00, 0x00, 0x00),
-        Opcode::ADDI(0x10, REG_ZERO, (Bytes32::LEN + 2 * Bytes8::LEN) as Immediate12),
+        Opcode::MOVI(0x10, (Bytes32::LEN + 2 * Bytes8::LEN) as Immediate18),
         Opcode::ALOC(0x10),
         Opcode::ADDI(0x10, REG_HP, 1),
     ];
 
     contract_metadata.as_ref().iter().enumerate().for_each(|(i, b)| {
-        routine_call_metadata_contract.push(Opcode::ADDI(0x11, REG_ZERO, *b as Immediate12));
+        routine_call_metadata_contract.push(Opcode::MOVI(0x11, *b as Immediate18));
         routine_call_metadata_contract.push(Opcode::SB(0x10, 0x11, i as Immediate12));
     });
 
-    routine_call_metadata_contract.push(Opcode::ADDI(0x11, REG_ZERO, gas_limit as Immediate12));
-    routine_call_metadata_contract.push(Opcode::CALL(0x10, REG_ZERO, 0x10, 0x11));
+    routine_call_metadata_contract.push(Opcode::CALL(0x10, REG_ZERO, 0x10, REG_CGAS));
     routine_call_metadata_contract.push(Opcode::RET(REG_ONE));
 
     let salt: Salt = rng.gen();
@@ -111,18 +110,17 @@ fn metadata() {
     outputs.push(Output::contract(1, rng.gen(), rng.gen()));
 
     let mut script = vec![
-        Opcode::ADDI(0x10, REG_ZERO, (Bytes32::LEN + 2 * Bytes8::LEN) as Immediate12),
+        Opcode::MOVI(0x10, (Bytes32::LEN + 2 * Bytes8::LEN) as Immediate18),
         Opcode::ALOC(0x10),
         Opcode::ADDI(0x10, REG_HP, 1),
     ];
 
     contract_call.as_ref().iter().enumerate().for_each(|(i, b)| {
-        script.push(Opcode::ADDI(0x11, REG_ZERO, *b as Immediate12));
+        script.push(Opcode::MOVI(0x11, *b as Immediate18));
         script.push(Opcode::SB(0x10, 0x11, i as Immediate12));
     });
 
-    script.push(Opcode::ADDI(0x11, REG_ZERO, gas_limit as Immediate12));
-    script.push(Opcode::CALL(0x10, REG_ZERO, 0x10, 0x11));
+    script.push(Opcode::CALL(0x10, REG_ZERO, 0x10, REG_CGAS));
     script.push(Opcode::RET(REG_ONE));
 
     let script = script.iter().copied().collect::<Vec<u8>>();

--- a/tests/predicate.rs
+++ b/tests/predicate.rs
@@ -16,13 +16,13 @@ fn predicate() {
 
     let mut predicate = vec![];
 
-    predicate.push(Opcode::ADDI(0x10, REG_ZERO, 0x11));
+    predicate.push(Opcode::MOVI(0x10, 0x11));
     predicate.push(Opcode::ADDI(0x11, 0x10, 0x12));
-    predicate.push(Opcode::ADDI(0x12, REG_ZERO, 0x08));
+    predicate.push(Opcode::MOVI(0x12, 0x08));
     predicate.push(Opcode::ALOC(0x12));
     predicate.push(Opcode::ADDI(0x12, REG_HP, 0x01));
     predicate.push(Opcode::SW(0x12, 0x11, 0));
-    predicate.push(Opcode::ADDI(0x10, REG_ZERO, 0x08));
+    predicate.push(Opcode::MOVI(0x10, 0x08));
     predicate.push(Opcode::XIL(0x20, 0));
     predicate.push(Opcode::XIS(0x11, 0));
     predicate.push(Opcode::ADD(0x11, 0x11, 0x20));
@@ -96,13 +96,13 @@ fn predicate_false() {
 
     let mut predicate = vec![];
 
-    predicate.push(Opcode::ADDI(0x10, REG_ZERO, 0x11));
+    predicate.push(Opcode::MOVI(0x10, 0x11));
     predicate.push(Opcode::ADDI(0x11, 0x10, 0x12));
-    predicate.push(Opcode::ADDI(0x12, REG_ZERO, 0x08));
+    predicate.push(Opcode::MOVI(0x12, 0x08));
     predicate.push(Opcode::ALOC(0x12));
     predicate.push(Opcode::ADDI(0x12, REG_HP, 0x01));
     predicate.push(Opcode::SW(0x12, 0x11, 0));
-    predicate.push(Opcode::ADDI(0x10, REG_ZERO, 0x08));
+    predicate.push(Opcode::MOVI(0x10, 0x08));
     predicate.push(Opcode::XIL(0x20, 0));
     predicate.push(Opcode::XIS(0x11, 0));
     predicate.push(Opcode::ADD(0x11, 0x11, 0x20));

--- a/tests/validation.rs
+++ b/tests/validation.rs
@@ -60,6 +60,7 @@ fn transaction_validation_fails_when_change_asset_id_not_in_inputs() {
     // make gas price too high for the input amount
     let gas_price = 0;
     let byte_price = 0;
+    let missing_asset = AssetId::from([1; 32]);
 
     let transaction = TestBuilder::new(2322u64)
         .gas_price(gas_price)
@@ -67,7 +68,7 @@ fn transaction_validation_fails_when_change_asset_id_not_in_inputs() {
         .coin_input(AssetId::default(), input_amount)
         .change_output(AssetId::default())
         // make change output with no corresponding input asset
-        .change_output(AssetId::from([1; 32]))
+        .change_output(missing_asset)
         .build();
 
     let mut interpreter = Interpreter::with_memory_storage();
@@ -75,8 +76,10 @@ fn transaction_validation_fails_when_change_asset_id_not_in_inputs() {
     assert!(matches!(
         result,
         Err(InterpreterError::ValidationError(
-            VmValidationError::TransactionValidation(ValidationError::TransactionOutputChangeAssetIdNotFound)
-        ))
+            VmValidationError::TransactionValidation(ValidationError::TransactionOutputChangeAssetIdNotFound(
+                asset
+            ))
+        )) if asset == missing_asset
     ));
 }
 
@@ -86,6 +89,7 @@ fn transaction_validation_fails_when_coin_output_asset_id_not_in_inputs() {
     // make gas price too high for the input amount
     let gas_price = 0;
     let byte_price = 0;
+    let missing_asset = AssetId::from([1; 32]);
 
     let transaction = TestBuilder::new(2322u64)
         .gas_price(gas_price)
@@ -93,7 +97,7 @@ fn transaction_validation_fails_when_coin_output_asset_id_not_in_inputs() {
         .coin_input(AssetId::default(), input_amount)
         .change_output(AssetId::default())
         // make coin output with no corresponding input asset
-        .coin_output(AssetId::from([1; 32]), 0)
+        .coin_output(missing_asset, 0)
         .build();
 
     let mut interpreter = Interpreter::with_memory_storage();
@@ -101,8 +105,8 @@ fn transaction_validation_fails_when_coin_output_asset_id_not_in_inputs() {
     assert!(matches!(
         result,
         Err(InterpreterError::ValidationError(
-            VmValidationError::TransactionOutputCoinAssetIdNotFound(_)
-        ))
+            VmValidationError::TransactionValidation(ValidationError::TransactionOutputCoinAssetIdNotFound(asset))
+        )) if asset == missing_asset
     ));
 }
 


### PR DESCRIPTION
Implement MOVI opcode and replace non-idiomatic usages of `ADDI r 0 imm`.

This unblocks support for transactions with 255 inputs, since their script data offsets are now too large to fit in an ADDI imm12.

blocked by: https://github.com/FuelLabs/fuel-asm/pull/53