### PR TITLE
update vm to use newer ScriptExecutionResult

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ description = "FuelVM interpreter."
 [dependencies]
 dyn-clone = { version = "1.0", optional = true }
 fuel-asm = "0.3"
-fuel-crypto = "0.3"
+fuel-crypto = "0.4"
 fuel-merkle = "0.1"
 fuel-storage = "0.1"
-fuel-tx = "0.7"
+fuel-tx = "0.8"
 fuel-types = "0.3"
 itertools = "0.10"
 secp256k1 = { version = "0.20", features = ["recovery"] }
@@ -27,7 +27,7 @@ tracing = "0.1"
 rand = { version = "0.8", optional = true }
 
 [dev-dependencies]
-fuel-tx = { version = "0.7", features = ["random"] }
+fuel-tx = { version = "0.8", features = ["random"] }
 fuel-vm = { path = ".", default-features = false, features = ["test-helpers"]}
 
 [features]

--- a/src/backtrace.rs
+++ b/src/backtrace.rs
@@ -6,8 +6,7 @@ use crate::call::CallFrame;
 use crate::consts::*;
 use crate::interpreter::Interpreter;
 
-use fuel_asm::InstructionResult;
-use fuel_tx::Transaction;
+use fuel_tx::{ScriptExecutionResult, Transaction};
 use fuel_types::{ContractId, Word};
 
 #[derive(Debug)]
@@ -17,7 +16,7 @@ pub struct Backtrace {
     contract: ContractId,
     registers: [Word; VM_REGISTER_COUNT],
     memory: Vec<u8>,
-    result: InstructionResult,
+    result: ScriptExecutionResult,
     tx: Transaction,
 }
 
@@ -25,7 +24,7 @@ impl Backtrace {
     /// Create a backtrace from a vm instance and instruction result.
     ///
     /// This isn't copy-free and shouldn't be provided by default.
-    pub fn from_vm_error<S>(vm: &Interpreter<S>, result: InstructionResult) -> Self {
+    pub fn from_vm_error<S>(vm: &Interpreter<S>, result: ScriptExecutionResult) -> Self {
         let call_stack = vm.call_stack().to_owned();
         let contract = vm.internal_contract_or_default();
         let memory = vm.memory().to_owned();
@@ -65,7 +64,7 @@ impl Backtrace {
     }
 
     /// [`InstructionResult`] of the error that caused this backtrace.
-    pub const fn result(&self) -> &InstructionResult {
+    pub const fn result(&self) -> &ScriptExecutionResult {
         &self.result
     }
 
@@ -82,7 +81,7 @@ impl Backtrace {
         ContractId,
         [Word; VM_REGISTER_COUNT],
         Vec<u8>,
-        InstructionResult,
+        ScriptExecutionResult,
         Transaction,
     ) {
         let Self {

--- a/src/interpreter/flow.rs
+++ b/src/interpreter/flow.rs
@@ -208,7 +208,7 @@ where
         let pc = self.registers[REG_PC];
         let is = self.registers[REG_IS];
 
-        let receipt = Receipt::panic(self.internal_contract_or_default(), Word::from(result), pc, is);
+        let receipt = Receipt::panic(self.internal_contract_or_default(), result, pc, is);
 
         self.receipts.push(receipt);
     }

--- a/tests/alu.rs
+++ b/tests/alu.rs
@@ -71,9 +71,9 @@ fn alu_err(registers_init: &[(RegisterId, Immediate18)], op: Opcode) {
 
     let result = receipts
         .iter()
-        .find_map(Receipt::result)
+        .find_map(Receipt::reason)
         .map(|r| *r.reason())
-        .expect("Expected script result");
+        .expect("Expected panic reason");
 
     assert_eq!(PanicReason::ReservedRegisterNotWritable, result);
 }

--- a/tests/code_coverage.rs
+++ b/tests/code_coverage.rs
@@ -1,3 +1,4 @@
+use fuel_tx::ScriptExecutionResult;
 use std::sync::{Arc, Mutex};
 
 use fuel_vm::consts::*;
@@ -59,7 +60,7 @@ fn code_coverage() {
     let receipts = client.transact(tx_script);
 
     if let Some(Receipt::ScriptResult { result, .. }) = receipts.last() {
-        assert!(result.is_success());
+        assert!(matches!(result, ScriptExecutionResult::Success));
     } else {
         panic!("Missing result receipt");
     }


### PR DESCRIPTION
- Update to fuel-tx 0.8
- Use ScriptExecutionResult instead of InstructionResult in backtraces