### PR TITLE
Profiler fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --verbose --features random,profile-gas,profile-coverage
+        args: --verbose --features random,profile-gas,profile-coverage,serde
 
     - name: Run debug tests
       uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ required-features = ["random", "profile-coverage"]
 [[test]]
 name = "test-serde-profile"
 path = "tests/serde_profile.rs"
-required-features = ["random", "profile-coverage", "profile-gas", "serde-types"]
+required-features = ["random", "profile-coverage", "profile-gas", "serde"]
 
 [[test]]
 name = "test-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ rand = { version = "0.8", optional = true }
 [dev-dependencies]
 fuel-tx = { version = "0.10", features = ["random"] }
 fuel-vm = { path = ".", default-features = false, features = ["test-helpers"] }
+serde_json = "1.0"
 
 [features]
 debug = []
@@ -67,7 +68,7 @@ required-features = ["random", "profile-coverage"]
 [[test]]
 name = "test-serde-profile"
 path = "tests/serde_profile.rs"
-required-features = ["random", "profile-coverage", "profile-gas"]
+required-features = ["random", "profile-coverage", "profile-gas", "serde-types"]
 
 [[test]]
 name = "test-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,11 @@ path = "tests/code_coverage.rs"
 required-features = ["random", "profile-coverage"]
 
 [[test]]
+name = "test-serde-profile"
+path = "tests/serde_profile.rs"
+required-features = ["random", "profile-coverage", "profile-gas"]
+
+[[test]]
 name = "test-encoding"
 path = "tests/encoding.rs"
 required-features = ["random"]

--- a/src/interpreter/constructors.rs
+++ b/src/interpreter/constructors.rs
@@ -36,7 +36,7 @@ impl<S> Interpreter<S> {
 
     /// Sets a profiler for the VM
     #[cfg(feature = "profile-any")]
-    pub fn with_profiling(mut self, receiver: Box<dyn ProfileReceiver>) -> Self {
+    pub fn with_profiling(mut self, receiver: Box<dyn ProfileReceiver + Send + Sync>) -> Self {
         self.profiler.set_receiver(receiver);
         self
     }

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -11,12 +11,66 @@ use crate::prelude::*;
 
 /// Location of an instructing collected during runtime
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InstructionLocation {
     /// Context, i.e. current contract. None if running a script.
     context: Option<ContractId>,
     /// Offset from the IS register
     offset: u64,
+}
+
+#[cfg(feature = "serde-types")]
+impl serde::Serialize for InstructionLocation {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if let Some(ctx) = self.context {
+            serializer.serialize_str(&format!("{}:{}", ctx, self.offset))
+        } else {
+            serializer.serialize_str(&format!("{}", self.offset))
+        }
+    }
+}
+
+#[cfg(feature = "serde-types")]
+struct InstructionLocationVisitor;
+
+#[cfg(feature = "serde-types")]
+impl<'de> serde::de::Visitor<'de> for InstructionLocationVisitor {
+    type Value = InstructionLocation;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("A valid instruction location")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        use std::str::FromStr;
+
+        Ok(if let Some((l, r)) = value.split_once(':') {
+            let context = Some(
+                ContractId::from_str(l)
+                    .map_err(|_| serde::de::Error::custom("Invalid ContractId in InstructionLocation"))?,
+            );
+            let offset = r.parse().unwrap();
+            InstructionLocation { context, offset }
+        } else {
+            let offset = value.parse().unwrap();
+            InstructionLocation { context: None, offset }
+        })
+    }
+}
+
+#[cfg(feature = "serde-types")]
+impl<'de> serde::Deserialize<'de> for InstructionLocation {
+    fn deserialize<D>(deserializer: D) -> Result<InstructionLocation, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_str(InstructionLocationVisitor)
+    }
 }
 
 impl InstructionLocation {

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -63,7 +63,7 @@ impl<'de> serde::de::Visitor<'de> for InstructionLocationVisitor {
     }
 }
 
-#[cfg(feature = "serde-types")]
+#[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for InstructionLocation {
     fn deserialize<D>(deserializer: D) -> Result<InstructionLocation, D::Error>
     where

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -32,7 +32,7 @@ impl serde::Serialize for InstructionLocation {
     }
 }
 
-#[cfg(feature = "serde-types")]
+#[cfg(feature = "serde")]
 struct InstructionLocationVisitor;
 
 #[cfg(feature = "serde-types")]

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -35,7 +35,7 @@ impl serde::Serialize for InstructionLocation {
 #[cfg(feature = "serde")]
 struct InstructionLocationVisitor;
 
-#[cfg(feature = "serde-types")]
+#[cfg(feature = "serde")]
 impl<'de> serde::de::Visitor<'de> for InstructionLocationVisitor {
     type Value = InstructionLocation;
 

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -160,7 +160,7 @@ impl ProfileReceiver for StderrReceiver {
 #[derive(Default, Clone)]
 pub struct Profiler {
     /// Settings
-    receiver: Option<Box<dyn ProfileReceiver>>,
+    receiver: Option<Box<dyn ProfileReceiver + Send + Sync>>,
     /// Collected profiling data
     data: ProfilingData,
 }
@@ -174,7 +174,7 @@ impl Profiler {
     }
 
     /// Sets profiling data receiver
-    pub fn set_receiver(&mut self, receiver: Box<dyn ProfileReceiver>) {
+    pub fn set_receiver(&mut self, receiver: Box<dyn ProfileReceiver + Send + Sync>) {
         self.receiver = Some(receiver);
     }
 

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -18,7 +18,7 @@ pub struct InstructionLocation {
     offset: u64,
 }
 
-#[cfg(feature = "serde-types")]
+#[cfg(feature = "serde")]
 impl serde::Serialize for InstructionLocation {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/tests/serde_profile.rs
+++ b/tests/serde_profile.rs
@@ -1,0 +1,23 @@
+use fuel_vm::profiler::{InstructionLocation, ProfilingData};
+
+#[test]
+fn test_profile_serde() {
+    let mut data = ProfilingData::default();
+
+    {
+        let coverage = data.coverage_mut();
+        coverage.set(InstructionLocation::new(None, 1));
+        coverage.set(InstructionLocation::new(None, 1));
+        coverage.set(InstructionLocation::new(None, 2));
+    }
+
+    {
+        let gas = data.gas_mut();
+        gas.add(InstructionLocation::new(None, 1), 4);
+        gas.add(InstructionLocation::new(None, 1), 4);
+        gas.add(InstructionLocation::new(None, 2), 2);
+    }
+
+    let json = serde_json::to_vec(&data).expect("Serialization failed");
+    let _: ProfilingData = serde_json::from_slice(&json).expect("Deserialization failed");
+}


### PR DESCRIPTION
Currently the data produced by the profiler cannot be serialized to JSON using Serde, as the data model requires object keys to be strings. Rust doesn't detect this at compile time, and the data was already usable in most binary formats like bincode. This PR makes it possible to serialize the data as JSON, but unfortunately Serde doesn't allow different formats for binary files, so this also increases size of bincode-encoded profile files.

This PR also adds `Send + Sync` trait bounds to the profile receiver, so that it can be used in multithreaded contexts, like in `async` functions. 