### PR TITLE
Capture overflow value instead of overflow state into `$of`

### DIFF
--- a/src/interpreter/alu.rs
+++ b/src/interpreter/alu.rs
@@ -24,7 +24,7 @@ impl<S> Interpreter<S> {
         self.registers[REG_ERR] = 0;
 
         // set the return value to the low bits of the u128 result
-        self.registers[ra] = result as u64;
+        self.registers[ra] = (result & Word::MAX as u128) as u64;
 
         self.inc_pc()
     }

--- a/src/interpreter/executors/instruction.rs
+++ b/src/interpreter/executors/instruction.rs
@@ -9,7 +9,7 @@ use fuel_asm::{Instruction, OpcodeRepr, PanicReason};
 use fuel_types::{bytes, Immediate18, Word};
 
 use std::mem;
-use std::ops::{Div, Shl};
+use std::ops::Div;
 
 const WORD_SIZE: usize = mem::size_of::<Word>();
 
@@ -196,22 +196,22 @@ where
 
             OpcodeRepr::SLL => {
                 self.gas_charge(GAS_SLL)?;
-                self.alu_set(ra, b << c)?;
+                self.alu_set(ra, b.checked_shl(c as u32).unwrap_or_default())?;
             }
 
             OpcodeRepr::SLLI => {
                 self.gas_charge(GAS_SLLI)?;
-                self.alu_set(ra, b << imm)?;
+                self.alu_set(ra, b.checked_shl(imm as u32).unwrap_or_default())?;
             }
 
             OpcodeRepr::SRL => {
                 self.gas_charge(GAS_SRL)?;
-                self.alu_set(ra, b >> c)?;
+                self.alu_set(ra, b.checked_shr(c as u32).unwrap_or_default())?;
             }
 
             OpcodeRepr::SRLI => {
                 self.gas_charge(GAS_SRLI)?;
-                self.alu_set(ra, b >> imm)?;
+                self.alu_set(ra, b.checked_shr(imm as u32).unwrap_or_default())?;
             }
 
             OpcodeRepr::SUB => {

--- a/src/interpreter/executors/instruction.rs
+++ b/src/interpreter/executors/instruction.rs
@@ -69,12 +69,12 @@ where
         match op {
             OpcodeRepr::ADD => {
                 self.gas_charge(GAS_ADD)?;
-                self.alu_overflow(ra, Word::overflowing_add, b, c)?;
+                self.alu_capture_overflow(ra, Word::overflowing_add, b, c)?;
             }
 
             OpcodeRepr::ADDI => {
                 self.gas_charge(GAS_ADDI)?;
-                self.alu_overflow(ra, Word::overflowing_add, b, imm)?;
+                self.alu_capture_overflow(ra, Word::overflowing_add, b, imm)?;
             }
 
             OpcodeRepr::AND => {
@@ -104,12 +104,12 @@ where
 
             OpcodeRepr::EXP => {
                 self.gas_charge(GAS_EXP)?;
-                self.alu_overflow(ra, Word::overflowing_pow, b, c as u32)?;
+                self.alu_boolean_overflow(ra, Word::overflowing_pow, b, c as u32)?;
             }
 
             OpcodeRepr::EXPI => {
                 self.gas_charge(GAS_EXPI)?;
-                self.alu_overflow(ra, Word::overflowing_pow, b, imm as u32)?;
+                self.alu_boolean_overflow(ra, Word::overflowing_pow, b, imm as u32)?;
             }
 
             OpcodeRepr::GT => {
@@ -166,12 +166,12 @@ where
 
             OpcodeRepr::MUL => {
                 self.gas_charge(GAS_MUL)?;
-                self.alu_overflow(ra, Word::overflowing_mul, b, c)?;
+                self.alu_capture_overflow(ra, Word::overflowing_mul, b, c)?;
             }
 
             OpcodeRepr::MULI => {
                 self.gas_charge(GAS_MULI)?;
-                self.alu_overflow(ra, Word::overflowing_mul, b, imm)?;
+                self.alu_capture_overflow(ra, Word::overflowing_mul, b, imm)?;
             }
 
             OpcodeRepr::NOOP => {
@@ -196,32 +196,32 @@ where
 
             OpcodeRepr::SLL => {
                 self.gas_charge(GAS_SLL)?;
-                self.alu_overflow(ra, Word::overflowing_shl, b, c as u32)?;
+                self.alu_capture_overflow(ra, Word::overflowing_shl, b, c as u32)?;
             }
 
             OpcodeRepr::SLLI => {
                 self.gas_charge(GAS_SLLI)?;
-                self.alu_overflow(ra, Word::overflowing_shl, b, imm as u32)?;
+                self.alu_capture_overflow(ra, Word::overflowing_shl, b, imm as u32)?;
             }
 
             OpcodeRepr::SRL => {
                 self.gas_charge(GAS_SRL)?;
-                self.alu_overflow(ra, Word::overflowing_shr, b, c as u32)?;
+                self.alu_capture_overflow(ra, Word::overflowing_shr, b, c as u32)?;
             }
 
             OpcodeRepr::SRLI => {
                 self.gas_charge(GAS_SRLI)?;
-                self.alu_overflow(ra, Word::overflowing_shr, b, imm as u32)?;
+                self.alu_capture_overflow(ra, Word::overflowing_shr, b, imm as u32)?;
             }
 
             OpcodeRepr::SUB => {
                 self.gas_charge(GAS_SUB)?;
-                self.alu_overflow(ra, Word::overflowing_sub, b, c)?;
+                self.alu_capture_overflow(ra, Word::overflowing_sub, b, c)?;
             }
 
             OpcodeRepr::SUBI => {
                 self.gas_charge(GAS_SUBI)?;
-                self.alu_overflow(ra, Word::overflowing_sub, b, imm)?;
+                self.alu_capture_overflow(ra, Word::overflowing_sub, b, imm)?;
             }
 
             OpcodeRepr::XOR => {

--- a/src/interpreter/executors/instruction.rs
+++ b/src/interpreter/executors/instruction.rs
@@ -9,7 +9,7 @@ use fuel_asm::{Instruction, OpcodeRepr, PanicReason};
 use fuel_types::{bytes, Immediate18, Word};
 
 use std::mem;
-use std::ops::Div;
+use std::ops::{Div, Shl};
 
 const WORD_SIZE: usize = mem::size_of::<Word>();
 
@@ -196,22 +196,22 @@ where
 
             OpcodeRepr::SLL => {
                 self.gas_charge(GAS_SLL)?;
-                self.alu_capture_overflow(ra, u128::overflowing_shl, b.into(), c as u32)?;
+                self.alu_set(ra, b << c)?;
             }
 
             OpcodeRepr::SLLI => {
                 self.gas_charge(GAS_SLLI)?;
-                self.alu_capture_overflow(ra, u128::overflowing_shl, b.into(), imm as u32)?;
+                self.alu_set(ra, b << imm)?;
             }
 
             OpcodeRepr::SRL => {
                 self.gas_charge(GAS_SRL)?;
-                self.alu_capture_overflow(ra, u128::overflowing_shr, b.into(), c as u32)?;
+                self.alu_set(ra, b >> c)?;
             }
 
             OpcodeRepr::SRLI => {
                 self.gas_charge(GAS_SRLI)?;
-                self.alu_capture_overflow(ra, u128::overflowing_shr, b.into(), imm as u32)?;
+                self.alu_set(ra, b >> imm)?;
             }
 
             OpcodeRepr::SUB => {

--- a/src/interpreter/executors/instruction.rs
+++ b/src/interpreter/executors/instruction.rs
@@ -69,12 +69,12 @@ where
         match op {
             OpcodeRepr::ADD => {
                 self.gas_charge(GAS_ADD)?;
-                self.alu_capture_overflow(ra, Word::overflowing_add, b, c)?;
+                self.alu_capture_overflow(ra, u128::overflowing_add, b.into(), c.into())?;
             }
 
             OpcodeRepr::ADDI => {
                 self.gas_charge(GAS_ADDI)?;
-                self.alu_capture_overflow(ra, Word::overflowing_add, b, imm)?;
+                self.alu_capture_overflow(ra, u128::overflowing_add, b.into(), imm.into())?;
             }
 
             OpcodeRepr::AND => {
@@ -166,12 +166,12 @@ where
 
             OpcodeRepr::MUL => {
                 self.gas_charge(GAS_MUL)?;
-                self.alu_capture_overflow(ra, Word::overflowing_mul, b, c)?;
+                self.alu_capture_overflow(ra, u128::overflowing_mul, b.into(), c.into())?;
             }
 
             OpcodeRepr::MULI => {
                 self.gas_charge(GAS_MULI)?;
-                self.alu_capture_overflow(ra, Word::overflowing_mul, b, imm)?;
+                self.alu_capture_overflow(ra, u128::overflowing_mul, b.into(), imm.into())?;
             }
 
             OpcodeRepr::NOOP => {
@@ -196,32 +196,32 @@ where
 
             OpcodeRepr::SLL => {
                 self.gas_charge(GAS_SLL)?;
-                self.alu_capture_overflow(ra, Word::overflowing_shl, b, c as u32)?;
+                self.alu_capture_overflow(ra, u128::overflowing_shl, b.into(), c as u32)?;
             }
 
             OpcodeRepr::SLLI => {
                 self.gas_charge(GAS_SLLI)?;
-                self.alu_capture_overflow(ra, Word::overflowing_shl, b, imm as u32)?;
+                self.alu_capture_overflow(ra, u128::overflowing_shl, b.into(), imm as u32)?;
             }
 
             OpcodeRepr::SRL => {
                 self.gas_charge(GAS_SRL)?;
-                self.alu_capture_overflow(ra, Word::overflowing_shr, b, c as u32)?;
+                self.alu_capture_overflow(ra, u128::overflowing_shr, b.into(), c as u32)?;
             }
 
             OpcodeRepr::SRLI => {
                 self.gas_charge(GAS_SRLI)?;
-                self.alu_capture_overflow(ra, Word::overflowing_shr, b, imm as u32)?;
+                self.alu_capture_overflow(ra, u128::overflowing_shr, b.into(), imm as u32)?;
             }
 
             OpcodeRepr::SUB => {
                 self.gas_charge(GAS_SUB)?;
-                self.alu_capture_overflow(ra, Word::overflowing_sub, b, c)?;
+                self.alu_capture_overflow(ra, u128::overflowing_sub, b.into(), c.into())?;
             }
 
             OpcodeRepr::SUBI => {
                 self.gas_charge(GAS_SUBI)?;
-                self.alu_capture_overflow(ra, Word::overflowing_sub, b, imm)?;
+                self.alu_capture_overflow(ra, u128::overflowing_sub, b.into(), imm.into())?;
             }
 
             OpcodeRepr::XOR => {

--- a/tests/alu.rs
+++ b/tests/alu.rs
@@ -279,6 +279,7 @@ fn addi() {
 
 #[test]
 fn mul() {
+    todo!();
     alu(&[(0x10, 128), (0x11, 25)], Opcode::ADD(0x12, 0x10, 0x11), 0x12, 153);
     alu_overflow(
         &[
@@ -292,25 +293,39 @@ fn mul() {
 }
 
 #[test]
-fn muli() {}
+fn muli() {
+    todo!()
+}
 
 #[test]
-fn sll() {}
+fn sll() {
+    todo!()
+}
 
 #[test]
-fn slli() {}
+fn slli() {
+    todo!()
+}
 
 #[test]
-fn srl() {}
+fn srl() {
+    todo!()
+}
 
 #[test]
-fn srli() {}
+fn srli() {
+    todo!()
+}
 
 #[test]
-fn sub() {}
+fn sub() {
+    todo!()
+}
 
 #[test]
-fn subi() {}
+fn subi() {
+    todo!()
+}
 
 #[test]
 fn and() {

--- a/tests/alu.rs
+++ b/tests/alu.rs
@@ -110,7 +110,7 @@ fn alu_overflow(program: &[Opcode], reg: RegisterId, expected: u128) {
     let lo_value = receipts.first().expect("Receipt not found").ra().expect("$ra expected");
     let hi_value = receipts.first().expect("Receipt not found").rb().expect("$rb expected");
 
-    let overflow_value = lo_value as u128 + (hi_value as u128) << 64;
+    let overflow_value = lo_value as u128 + ((hi_value as u128) << 64);
 
     assert_eq!(overflow_value, expected);
 }
@@ -255,11 +255,12 @@ fn add() {
     alu_overflow(
         &[
             Opcode::MOVE(0x10, REG_ZERO),
+            Opcode::MOVI(0x11, 10),
             Opcode::NOT(0x10, 0x10),
-            Opcode::ADD(0x10, 0x10, REG_ONE),
+            Opcode::ADD(0x10, 0x10, 0x11),
         ],
         0x10,
-        Word::MAX as u128 + 1,
+        Word::MAX as u128 + 10,
     );
 }
 
@@ -270,31 +271,40 @@ fn addi() {
         &[
             Opcode::MOVE(0x10, REG_ZERO),
             Opcode::NOT(0x10, 0x10),
-            Opcode::ADDI(0x10, 0x10, 1),
+            Opcode::ADDI(0x10, 0x10, 10),
         ],
         0x10,
-        Word::MAX as u128 + 1,
+        Word::MAX as u128 + 10,
     );
 }
 
 #[test]
 fn mul() {
-    todo!();
-    alu(&[(0x10, 128), (0x11, 25)], Opcode::ADD(0x12, 0x10, 0x11), 0x12, 153);
+    alu(&[(0x10, 128), (0x11, 25)], Opcode::MUL(0x12, 0x10, 0x11), 0x12, 3200);
     alu_overflow(
         &[
             Opcode::MOVE(0x10, REG_ZERO),
+            Opcode::MOVI(0x11, 2),
             Opcode::NOT(0x10, 0x10),
-            Opcode::ADD(0x10, 0x10, REG_ONE),
+            Opcode::MUL(0x10, 0x10, 0x11),
         ],
         0x10,
-        Word::MAX as u128 + 1,
+        Word::MAX as u128 * 2,
     );
 }
 
 #[test]
 fn muli() {
-    todo!()
+    alu(&[(0x10, 128)], Opcode::MULI(0x11, 0x10, 25), 0x11, 3200);
+    alu_overflow(
+        &[
+            Opcode::MOVE(0x10, REG_ZERO),
+            Opcode::NOT(0x10, 0x10),
+            Opcode::MULI(0x10, 0x10, 2),
+        ],
+        0x10,
+        Word::MAX as u128 * 2,
+    );
 }
 
 #[test]

--- a/tests/alu.rs
+++ b/tests/alu.rs
@@ -309,32 +309,78 @@ fn muli() {
 
 #[test]
 fn sll() {
-    todo!()
+    alu(&[(0x10, 128), (0x11, 2)], Opcode::SLL(0x12, 0x10, 0x11), 0x12, 512);
+    alu_overflow(
+        &[
+            Opcode::MOVE(0x10, REG_ZERO),
+            Opcode::MOVI(0x11, 2),
+            Opcode::NOT(0x10, 0x10),
+            Opcode::SLL(0x10, 0x10, 0x11),
+        ],
+        0x10,
+        (Word::MAX as u128) << 2,
+    );
 }
 
 #[test]
 fn slli() {
-    todo!()
+    alu(&[(0x10, 128)], Opcode::SLLI(0x11, 0x10, 2), 0x11, 512);
+    alu_overflow(
+        &[
+            Opcode::MOVE(0x10, REG_ZERO),
+            Opcode::NOT(0x10, 0x10),
+            Opcode::SLLI(0x10, 0x10, 2),
+        ],
+        0x10,
+        (Word::MAX as u128) << 2,
+    );
 }
 
 #[test]
 fn srl() {
-    todo!()
+    alu(&[(0x10, 128), (0x11, 2)], Opcode::SRL(0x12, 0x10, 0x11), 0x12, 32);
+    // TODO: unsure what the expected overflow behavior is for shift right, seems like it shouldn't
+    //       interact with REG_OF at all really
+    // alu_overflow(
+    //     &[
+    //         Opcode::MOVE(0x10, REG_ZERO),
+    //         Opcode::MOVI(0x11, 2),
+    //         Opcode::SRL(0x10, 0x10, 0x11),
+    //     ],
+    //     0x10,
+    //     (0 as u128).overflowing_shr(2).0,
+    // );
 }
 
 #[test]
 fn srli() {
-    todo!()
+    alu(&[(0x10, 128)], Opcode::SRLI(0x11, 0x10, 2), 0x11, 32);
+    // TODO: unsure what the expected overflow behavior is for shift right, seems like it shouldn't
+    //       interact with REG_OF at all really
 }
 
 #[test]
 fn sub() {
-    todo!()
+    alu(&[(0x10, 128), (0x11, 25)], Opcode::SUB(0x12, 0x10, 0x11), 0x12, 103);
+    alu_overflow(
+        &[
+            Opcode::MOVE(0x10, REG_ZERO),
+            Opcode::MOVI(0x11, 10),
+            Opcode::SUB(0x10, 0x10, 0x11),
+        ],
+        0x10,
+        (0 as u128).wrapping_sub(10),
+    );
 }
 
 #[test]
 fn subi() {
-    todo!()
+    alu(&[(0x10, 128)], Opcode::SUBI(0x11, 0x10, 25), 0x11, 103);
+    alu_overflow(
+        &[Opcode::MOVE(0x10, REG_ZERO), Opcode::SUBI(0x10, 0x10, 10)],
+        0x10,
+        (0 as u128).wrapping_sub(10),
+    );
 }
 
 #[test]


### PR DESCRIPTION
fixes: https://github.com/FuelLabs/fuel-vm/issues/121

Uses u128 math for all the instructions that need to treat the overflow register as the high bits of a u128. This will unblock the stdlib impl of u128 types.

This includes:

- add
- addi
- mul
- muli
- sll
- slli
- srl
- srli
- sub
- subi

The wording of the specs was somewhat confusing for srl & srli, since a logical shift right can't underflow. However, the specs describe the same `$of` behavior as other opcodes which do have under/overflow.