### PR TITLE
Duplicate revert receipt fix

### DIFF
--- a/tests/flow.rs
+++ b/tests/flow.rs
@@ -5,6 +5,9 @@ use fuel_vm::prelude::*;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 
+use fuel_vm::script_with_data_offset;
+use fuel_vm::util::test_helpers::TestBuilder;
+use itertools::Itertools;
 use std::mem;
 
 const WORD_SIZE: usize = mem::size_of::<Word>();
@@ -304,6 +307,54 @@ fn call_frame_code_offset() {
     assert_eq!(ssp, sp + stack);
     assert_eq!(ssp, fp + stack);
     assert_eq!(ssp, sp_p);
+}
+
+#[test]
+fn revert_from_call_immediately_ends_execution() {
+    // call a contract that reverts
+    // and then verify the revert is only logged once
+
+    let gas_limit = 1_000_000;
+
+    let mut test_context = TestBuilder::new(2322u64);
+    let contract_id = test_context
+        .setup_contract(vec![Opcode::RVRT(REG_ONE)], None, None)
+        .contract_id;
+
+    let (script_ops, offset) = script_with_data_offset!(
+        data_offset,
+        vec![
+            // load call data to 0x10
+            Opcode::MOVI(0x10, data_offset),
+            Opcode::CALL(0x10, REG_ZERO, REG_ZERO, REG_CGAS),
+            Opcode::RET(REG_ONE),
+        ]
+    );
+    let script_data: Vec<u8> = [Call::new(contract_id, 0, 0).to_bytes().as_slice()]
+        .into_iter()
+        .flatten()
+        .copied()
+        .collect();
+
+    // initiate the transfer between contracts
+    let result = test_context
+        .gas_limit(gas_limit)
+        .gas_price(0)
+        .byte_price(0)
+        .contract_input(contract_id)
+        .contract_output(&contract_id)
+        .script(script_ops)
+        .script_data(script_data)
+        .execute();
+
+    // verify there is only 1 revert receipt
+    let revert_receipts = result
+        .receipts()
+        .iter()
+        .filter(|r| matches!(r, Receipt::Revert { .. }))
+        .collect_vec();
+
+    assert_eq!(revert_receipts.len(), 1);
 }
 
 #[test]

--- a/tests/flow.rs
+++ b/tests/flow.rs
@@ -1,13 +1,8 @@
 use fuel_crypto::Hasher;
 use fuel_types::bytes;
-use fuel_vm::consts::*;
-use fuel_vm::prelude::*;
-use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
-
-use fuel_vm::script_with_data_offset;
-use fuel_vm::util::test_helpers::TestBuilder;
+use fuel_vm::{consts::*, prelude::*, script_with_data_offset, util::test_helpers::TestBuilder};
 use itertools::Itertools;
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::mem;
 
 const WORD_SIZE: usize = mem::size_of::<Word>();

--- a/tests/flow.rs
+++ b/tests/flow.rs
@@ -306,16 +306,16 @@ fn call_frame_code_offset() {
 
 #[test]
 fn revert_from_call_immediately_ends_execution() {
-    // call a contract that reverts
-    // and then verify the revert is only logged once
-
+    // call a contract that reverts and then verify the revert is only logged once
     let gas_limit = 1_000_000;
 
     let mut test_context = TestBuilder::new(2322u64);
+    // setup a contract which immediately reverts
     let contract_id = test_context
         .setup_contract(vec![Opcode::RVRT(REG_ONE)], None, None)
         .contract_id;
 
+    // setup a script to call the contract
     let (script_ops, _) = script_with_data_offset!(
         data_offset,
         vec![
@@ -331,11 +331,9 @@ fn revert_from_call_immediately_ends_execution() {
         .copied()
         .collect();
 
-    // initiate the transfer between contracts
+    // initiate the call to the contract which reverts
     let result = test_context
         .gas_limit(gas_limit)
-        .gas_price(0)
-        .byte_price(0)
         .contract_input(contract_id)
         .contract_output(&contract_id)
         .script(script_ops)

--- a/tests/flow.rs
+++ b/tests/flow.rs
@@ -316,7 +316,7 @@ fn revert_from_call_immediately_ends_execution() {
         .setup_contract(vec![Opcode::RVRT(REG_ONE)], None, None)
         .contract_id;
 
-    let (script_ops, offset) = script_with_data_offset!(
+    let (script_ops, _) = script_with_data_offset!(
         data_offset,
         vec![
             // load call data to 0x10


### PR DESCRIPTION
fixes: #126 

Expected Behavior:
The expected behavior for a revert is to immediately cease execution of opcodes, and only include one revert receipt.

Actual Behavior:
When a contract call reverted, the VM appended two revert receipts.

Summary:
The root cause is that while `run_call` correctly returned a revert state, this result was then discarded by the parent stack and not propagated. Since revert doesn't increase $pc, the same opcodes would run again on the parent stack (callee) causing the receipt to be appended twice.

The fix simply checks the result of `call` and returns with the Revert state if needed.