### PR TITLE
Improve hygiene of `script_with_data_offset!`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,10 +22,15 @@ pub mod profiler;
 pub mod prelude {
     //! Required implementations for full functionality
 
-    pub use fuel_asm::{Instruction, InstructionResult, Opcode, OpcodeRepr, PanicReason};
-    pub use fuel_storage::{MerkleRoot, MerkleStorage, Storage};
-    pub use fuel_tx::{Contract, Input, Output, Receipt, Transaction, UtxoId, ValidationError, Witness};
+    #[doc(no_inline)]
+    pub use fuel_asm::{self, Instruction, InstructionResult, Opcode, OpcodeRepr, PanicReason};
+    #[doc(no_inline)]
+    pub use fuel_storage::{self, MerkleRoot, MerkleStorage, Storage};
+    #[doc(no_inline)]
+    pub use fuel_tx::{self, Contract, Input, Output, Receipt, Transaction, UtxoId, ValidationError, Witness};
+    #[doc(no_inline)]
     pub use fuel_types::{
+        self,
         bytes::{Deserializable, SerializableVec, SizedBytes},
         Address, AssetId, Bytes32, Bytes4, Bytes64, Bytes8, ContractId, Immediate06, Immediate12, Immediate18,
         Immediate24, RegisterId, Salt, Word,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,18 +19,30 @@ pub mod util;
 #[cfg(feature = "profile-any")]
 pub mod profiler;
 
+// Fully re-export fuel dependencies
+#[doc(no_inline)]
+pub use fuel_asm;
+#[doc(no_inline)]
+pub use fuel_crypto;
+#[doc(no_inline)]
+pub use fuel_merkle;
+#[doc(no_inline)]
+pub use fuel_storage;
+#[doc(no_inline)]
+pub use fuel_tx;
+#[doc(no_inline)]
+pub use fuel_types;
+
 pub mod prelude {
     //! Required implementations for full functionality
-
     #[doc(no_inline)]
-    pub use fuel_asm::{self, Instruction, InstructionResult, Opcode, OpcodeRepr, PanicReason};
+    pub use fuel_asm::{Instruction, InstructionResult, Opcode, OpcodeRepr, PanicReason};
     #[doc(no_inline)]
-    pub use fuel_storage::{self, MerkleRoot, MerkleStorage, Storage};
+    pub use fuel_storage::{MerkleRoot, MerkleStorage, Storage};
     #[doc(no_inline)]
-    pub use fuel_tx::{self, Contract, Input, Output, Receipt, Transaction, UtxoId, ValidationError, Witness};
+    pub use fuel_tx::{Contract, Input, Output, Receipt, Transaction, UtxoId, ValidationError, Witness};
     #[doc(no_inline)]
     pub use fuel_types::{
-        self,
         bytes::{Deserializable, SerializableVec, SizedBytes},
         Address, AssetId, Bytes32, Bytes4, Bytes64, Bytes8, ContractId, Immediate06, Immediate12, Immediate18,
         Immediate24, RegisterId, Salt, Word,

--- a/src/util.rs
+++ b/src/util.rs
@@ -41,7 +41,7 @@
 #[macro_export]
 macro_rules! script_with_data_offset {
     ($offset:ident, $script:expr) => {{
-        let data_offset = {
+        let $offset = {
             let $offset = {
                 use $crate::prelude::Immediate18;
                 0 as Immediate18
@@ -54,8 +54,6 @@ macro_rules! script_with_data_offset {
                 (VM_TX_MEMORY + Transaction::script_offset() + padded_len(script_bytes.as_slice())) as Immediate18
             }
         };
-
-        let $offset = data_offset;
         ($script, $offset)
     }};
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -41,12 +41,21 @@
 #[macro_export]
 macro_rules! script_with_data_offset {
     ($offset:ident, $script:expr) => {{
-        use $crate::consts::VM_TX_MEMORY;
-        use $crate::prelude::{fuel_types::bytes::padded_len, Immediate18, Transaction};
-        let $offset = 0 as Immediate18;
-        let script_bytes: ::std::vec::Vec<u8> = ::std::iter::IntoIterator::into_iter({ $script }).collect();
-        let data_offset = VM_TX_MEMORY + Transaction::script_offset() + padded_len(script_bytes.as_slice());
-        let $offset = data_offset as Immediate18;
+        let data_offset = {
+            let $offset = {
+                use $crate::prelude::Immediate18;
+                0 as Immediate18
+            };
+            let script_bytes: ::std::vec::Vec<u8> = ::std::iter::IntoIterator::into_iter({ $script }).collect();
+            {
+                use $crate::consts::VM_TX_MEMORY;
+                use $crate::fuel_types::bytes::padded_len;
+                use $crate::prelude::{Immediate18, Transaction};
+                (VM_TX_MEMORY + Transaction::script_offset() + padded_len(script_bytes.as_slice())) as Immediate18
+            }
+        };
+
+        let $offset = data_offset;
         ($script, $offset)
     }};
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -41,12 +41,11 @@
 #[macro_export]
 macro_rules! script_with_data_offset {
     ($offset:ident, $script:expr) => {{
-        use fuel_types::{bytes, Immediate18};
         use $crate::consts::VM_TX_MEMORY;
-        use $crate::prelude::Transaction;
+        use $crate::prelude::{fuel_types::bytes::padded_len, Immediate18, Transaction};
         let $offset = 0 as Immediate18;
-        let script_bytes: Vec<u8> = { $script }.into_iter().collect();
-        let data_offset = VM_TX_MEMORY + Transaction::script_offset() + bytes::padded_len(script_bytes.as_slice());
+        let script_bytes: ::std::vec::Vec<u8> = ::std::iter::IntoIterator::into_iter({ $script }).collect();
+        let data_offset = VM_TX_MEMORY + Transaction::script_offset() + padded_len(script_bytes.as_slice());
         let $offset = data_offset as Immediate18;
         ($script, $offset)
     }};

--- a/src/util.rs
+++ b/src/util.rs
@@ -42,11 +42,14 @@
 macro_rules! script_with_data_offset {
     ($offset:ident, $script:expr) => {{
         let $offset = {
+            // first set offset to 0 before evaluating script expression
             let $offset = {
                 use $crate::prelude::Immediate18;
                 0 as Immediate18
             };
+            // evaluate script expression with zeroed data offset to get the script length
             let script_bytes: ::std::vec::Vec<u8> = ::std::iter::IntoIterator::into_iter({ $script }).collect();
+            // compute the script data offset within the VM memory given the script length
             {
                 use $crate::consts::VM_TX_MEMORY;
                 use $crate::fuel_types::bytes::padded_len;
@@ -54,6 +57,7 @@ macro_rules! script_with_data_offset {
                 (VM_TX_MEMORY + Transaction::script_offset() + padded_len(script_bytes.as_slice())) as Immediate18
             }
         };
+        // re-evaluate and return the finalized script with the correct data offset length set.
         ($script, $offset)
     }};
 }


### PR DESCRIPTION
- Fix hygiene of script_with_data_offset so that no other imports are externally required.
- Fullly re-export all fuel-* prelude deps to simplify downstream dep management.