### PR TITLE
Update VM memory for receipts root after append

### DIFF
--- a/src/interpreter/contract.rs
+++ b/src/interpreter/contract.rs
@@ -86,14 +86,16 @@ where
         // credit destination contract
         self.balance_increase(&destination, &asset_id, amount)?;
 
-        self.receipts.push(Receipt::transfer(
+        let receipt = Receipt::transfer(
             internal_context.unwrap_or_default(),
             destination,
             amount,
             asset_id,
             self.registers[REG_PC],
             self.registers[REG_IS],
-        ));
+        );
+
+        self.append_receipt(receipt);
 
         self.inc_pc()
     }

--- a/src/interpreter/executors/main.rs
+++ b/src/interpreter/executors/main.rs
@@ -8,7 +8,8 @@ use crate::storage::{InterpreterStorage, PredicateStorage};
 
 use fuel_asm::PanicReason;
 use fuel_tx::{ConsensusParameters, Contract, Input, Output, Receipt, ScriptExecutionResult, Transaction};
-use fuel_types::{bytes::SerializableVec, Word};
+use fuel_types::bytes::SerializableVec;
+use fuel_types::Word;
 
 impl Interpreter<PredicateStorage> {
     /// Initialize the VM with the provided transaction and check all predicates defined in the
@@ -186,7 +187,7 @@ where
 
                 let receipt = Receipt::script_result(status, gas_used);
 
-                self.receipts.push(receipt);
+                self.append_receipt(receipt);
 
                 program
             }

--- a/src/interpreter/flow.rs
+++ b/src/interpreter/flow.rs
@@ -90,7 +90,7 @@ impl<S> Interpreter<S> {
                 });
         }
 
-        self.receipts.push(receipt);
+        self.append_receipt(receipt);
 
         self.inc_pc()
     }
@@ -144,7 +144,7 @@ impl<S> Interpreter<S> {
             self.registers[REG_IS],
         );
 
-        self.receipts.push(receipt);
+        self.append_receipt(receipt);
     }
 
     pub(crate) fn append_panic_receipt(&mut self, result: InstructionResult) {
@@ -153,7 +153,7 @@ impl<S> Interpreter<S> {
 
         let receipt = Receipt::panic(self.internal_contract_or_default(), result, pc, is);
 
-        self.receipts.push(receipt);
+        self.append_receipt(receipt);
     }
 }
 
@@ -220,7 +220,8 @@ where
             self.registers[REG_IS],
         );
 
-        self.receipts.push(receipt);
+        self.append_receipt(receipt);
+
         self.frames.push(frame);
 
         self.run_call()

--- a/src/interpreter/log.rs
+++ b/src/interpreter/log.rs
@@ -19,7 +19,7 @@ impl<S> Interpreter<S> {
             self.registers[REG_IS],
         );
 
-        self.receipts.push(receipt);
+        self.append_receipt(receipt);
 
         self.inc_pc()
     }
@@ -44,7 +44,7 @@ impl<S> Interpreter<S> {
             self.registers[REG_IS],
         );
 
-        self.receipts.push(receipt);
+        self.append_receipt(receipt);
 
         self.inc_pc()
     }


### PR DESCRIPTION
The VM memory section for the receipts root was updated only after the
script execution.

It is desirable to have it updated on the fly so the scripts can consume
the generated receipts root.

Closes #125