### PR TITLE
Remove unimplemented SLDC opcode

### DIFF
--- a/src/interpreter/executors/instruction.rs
+++ b/src/interpreter/executors/instruction.rs
@@ -500,7 +500,7 @@ where
             }
 
             // list of currently unimplemented opcodes
-            OpcodeRepr::SLDC | _ => {
+            _ => {
                 return Err(PanicReason::ErrorFlag.into());
             }
         }


### PR DESCRIPTION
This is a non-breaking change, but prepares for the next release of fuel-asm which doesn't have SLDC anymore.

Closes #143 