### PR TITLE
fix block height when performing tx validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/FuelLabs/fuel-vm"
 description = "FuelVM interpreter."
 
 [dependencies]
+anyhow = "1.0"
 dyn-clone = { version = "1.0", optional = true }
 fuel-asm = "0.5"
 fuel-crypto = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,8 @@ tracing = "0.1"
 rand = { version = "0.8", optional = true }
 
 [dev-dependencies]
-fuel-tx = { version = "0.13", features = ["random"] }
+fuel-crypto = { version = "0.5", features = ["random"] }
+fuel-tx = { version = "0.13", features = ["random", "internals", "builder"] }
 fuel-vm = { path = ".", default-features = false, features = ["test-helpers"] }
 serde_json = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/FuelLabs/fuel-vm"
 description = "FuelVM interpreter."
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { version = "1.0", optional = true }
 dyn-clone = { version = "1.0", optional = true }
 fuel-asm = "0.5"
 fuel-crypto = "0.5"
@@ -40,7 +40,7 @@ profile-coverage = ["profile-any"]
 profile-any = ["dyn-clone"] # All profiling features should depend on this
 random = ["fuel-types/random", "fuel-tx/random", "rand"]
 serde = ["dep:serde", "fuel-asm/serde", "fuel-types/serde", "fuel-tx/serde"]
-test-helpers = ["random"]
+test-helpers = ["random", "dep:anyhow"]
 
 [[test]]
 name = "test-backtrace"

--- a/src/interpreter/initialization.rs
+++ b/src/interpreter/initialization.rs
@@ -17,8 +17,7 @@ impl<S> Interpreter<S> {
     pub fn init(&mut self, predicate: bool, block_height: u32, tx: Transaction) -> Result<(), InterpreterError> {
         self.tx = tx;
 
-        self.tx
-            .validate_without_signature(self.block_height() as Word, &self.params)?;
+        self.tx.validate_without_signature(block_height as Word, &self.params)?;
         self.tx.precompute_metadata();
 
         self.block_height = block_height;

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -78,6 +78,7 @@ impl MemoryStorage {
         self.persisted = self.transacted.clone();
     }
 
+    #[cfg(feature = "test-helpers")]
     /// Set the block height of the chain
     pub fn set_block_height(&mut self, block_height: u32) {
         self.block_height = block_height;

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -77,6 +77,11 @@ impl MemoryStorage {
         self.memory = self.transacted.clone();
         self.persisted = self.transacted.clone();
     }
+
+    /// Set the block height of the chain
+    pub fn set_block_height(&mut self, block_height: u32) {
+        self.block_height = block_height;
+    }
 }
 
 impl Default for MemoryStorage {

--- a/src/util.rs
+++ b/src/util.rs
@@ -101,6 +101,7 @@ pub mod test_helpers {
         witness: Vec<Witness>,
         storage: MemoryStorage,
         params: ConsensusParameters,
+        block_height: u32,
     }
 
     impl TestBuilder {
@@ -117,6 +118,7 @@ pub mod test_helpers {
                 witness: vec![Witness::default()],
                 storage: MemoryStorage::default(),
                 params: ConsensusParameters::default(),
+                block_height: 0,
             }
         }
 
@@ -210,6 +212,11 @@ pub mod test_helpers {
 
         pub fn params(&mut self, params: ConsensusParameters) -> &mut TestBuilder {
             self.params = params;
+            self
+        }
+
+        pub fn block_height(&mut self, block_height: u32) -> &mut TestBuilder {
+            self.block_height = block_height;
             self
         }
 
@@ -315,7 +322,8 @@ pub mod test_helpers {
             }
         }
 
-        fn execute_tx(&mut self, tx: Transaction) -> StateTransition {
+        pub fn execute_tx(&mut self, tx: Transaction) -> StateTransition {
+            self.storage.set_block_height(self.block_height);
             let mut client = MemoryClient::new(self.storage.clone(), self.params);
 
             client.transact(tx);

--- a/tests/validation.rs
+++ b/tests/validation.rs
@@ -263,5 +263,5 @@ fn transaction_can_be_executed_after_maturity() {
         .finalize();
 
     let result = TestBuilder::new(2322u64).block_height(BLOCK_HEIGHT).execute_tx(tx);
-    assert!(!result.is_ok());
+    assert!(result.is_ok());
 }


### PR DESCRIPTION
The VM was passing the default block height to tx validation before it was set. 

This PR updates the init logic to use the height passed in to the init function instead of relying on when the block height is set on the interpreter.

fixes: https://github.com/FuelLabs/fuel-core/issues/432