### PR TITLE
Disable faulty predicate checks during create tx execution

### DIFF
--- a/src/interpreter/executors/main.rs
+++ b/src/interpreter/executors/main.rs
@@ -127,13 +127,6 @@ where
                         .map_err(InterpreterError::from_io)?;
                 }
 
-                // Verify predicates
-                // https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/tx_validity.md#predicate-verification
-                // TODO implement debug support
-                if !Interpreter::<PredicateStorage>::check_predicates(self.tx.clone(), self.params) {
-                    return Err(InterpreterError::PredicateFailure);
-                }
-
                 ProgramState::Return(1)
             }
 


### PR DESCRIPTION
disable duplicative predicate verification checks when submitting create txs. Predicate verification should be executed by the client / txpool, not when a tx is run by the vm.

partially adresses: https://github.com/FuelLabs/fuel-core/issues/449