### PR TITLE
Fix `Recipt::Call`s having the wrong `id`

### DIFF
--- a/src/interpreter/flow.rs
+++ b/src/interpreter/flow.rs
@@ -176,6 +176,8 @@ where
             return Err(PanicReason::MemoryOverflow.into());
         }
 
+        let id = self.internal_contract_or_default();
+
         self.registers[REG_FP] = self.registers[REG_SP];
         self.registers[REG_SP] += len;
         self.registers[REG_SSP] = self.registers[REG_SP];
@@ -188,7 +190,7 @@ where
         self.registers[REG_CGAS] = forward_gas_amount;
 
         let receipt = Receipt::call(
-            self.internal_contract_or_default(),
+            id,
             *frame.to(),
             b,
             *frame.asset_id(),

--- a/tests/flow.rs
+++ b/tests/flow.rs
@@ -193,6 +193,11 @@ fn call() {
         .expect("Failed to execute script")
         .to_owned();
 
+    assert_eq!(
+        receipts[0].id().expect("Receipt value failed").to_owned(),
+        ContractId::default()
+    );
+    assert_eq!(receipts[0].to().expect("Receipt value failed").to_owned(), contract);
     assert_eq!(receipts[1].ra().expect("Receipt value failed"), 0x11);
     assert_eq!(receipts[1].rb().expect("Receipt value failed"), 0x2a);
     assert_eq!(receipts[1].rc().expect("Receipt value failed"), 0x3b);


### PR DESCRIPTION
When a script calls a contract, a Call receipt is appended. If I'm reading [the spec](https://github.com/FuelLabs/fuel-specs/blob/master/specs/vm/instruction_set.md#call-call-contract) correctly, in such a case, the call receipt's `to` field should be the called contract's ID, and the `from` field should be `0x0000...`, indicating that it was called from the script.

We were putting the contract's ID on both `to` and `from` fields and this PR aims to fix that.

The issue was:
- To initiate the call, we modify `REG_FP`.
- When creating the receipt, we check `self.registers[REG_FP] == 0` to see if the call is external.
- This gives an unexpected result because `REG_FP` was modified.

The fix is basically reading the value for the `from` field before `REG_FP` gets modified.