### PR TITLE
Implement GM::GetVerifyingPredicate metadata instr

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -2,6 +2,8 @@
 
 use crate::predicate::RuntimePredicate;
 
+use fuel_asm::Word;
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Runtime context description.
@@ -12,9 +14,15 @@ pub enum Context {
         program: RuntimePredicate,
     },
     /// Current context is a script execution.
-    Script,
+    Script {
+        /// Block height of the context
+        block_height: u32,
+    },
     /// Current context is under a `CALL` scop.e
-    Call,
+    Call {
+        /// Block height of the context
+        block_height: u32,
+    },
     /// No transaction initialized/invalid context.
     NotInitialized,
 }
@@ -28,7 +36,7 @@ impl Default for Context {
 impl Context {
     /// Return `true` if the context is external; `false` otherwise.
     pub const fn is_external(&self) -> bool {
-        matches!(self, Self::Predicate { .. } | Self::Script)
+        matches!(self, Self::Predicate { .. } | Self::Script { .. })
     }
 
     /// Return the program to be executed, if its a predicate
@@ -36,6 +44,32 @@ impl Context {
         match self {
             Context::Predicate { program } => Some(program),
             _ => None,
+        }
+    }
+
+    /// Return the block height from the context, if either script or call
+    pub const fn block_height(&self) -> Option<u32> {
+        match self {
+            Context::Script { block_height } | Context::Call { block_height } => Some(*block_height),
+            _ => None,
+        }
+    }
+
+    /// Update the context according to the provided frame pointer
+    pub fn update_from_frame_pointer(&mut self, fp: Word) {
+        match self {
+            Context::Script { block_height } if fp != 0 => {
+                *self = Self::Call {
+                    block_height: *block_height,
+                }
+            }
+
+            Context::Call { block_height } if fp == 0 => {
+                *self = Self::Script {
+                    block_height: *block_height,
+                }
+            }
+            _ => (),
         }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,11 +1,16 @@
 //! VM runtime context definitions
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+use crate::predicate::RuntimePredicate;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Runtime context description.
 pub enum Context {
     /// Current context is a predicate verification.
-    Predicate,
+    Predicate {
+        /// Predicate program to be executed
+        program: RuntimePredicate,
+    },
     /// Current context is a script execution.
     Script,
     /// Current context is under a `CALL` scop.e
@@ -23,6 +28,14 @@ impl Default for Context {
 impl Context {
     /// Return `true` if the context is external; `false` otherwise.
     pub const fn is_external(&self) -> bool {
-        matches!(self, Self::Predicate | Self::Script)
+        matches!(self, Self::Predicate { .. } | Self::Script)
+    }
+
+    /// Return the program to be executed, if its a predicate
+    pub const fn predicate(&self) -> Option<&RuntimePredicate> {
+        match self {
+            Context::Predicate { program } => Some(program),
+            _ => None,
+        }
     }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -56,7 +56,6 @@ pub struct Interpreter<S> {
     storage: S,
     debugger: Debugger,
     context: Context,
-    block_height: u32,
     balances: RuntimeBalances,
     #[cfg(feature = "profile-any")]
     profiler: Profiler,

--- a/src/interpreter/blockchain.rs
+++ b/src/interpreter/blockchain.rs
@@ -173,6 +173,18 @@ where
         self.inc_pc()
     }
 
+    pub(crate) fn set_block_height(&mut self, ra: RegisterId) -> Result<(), RuntimeError> {
+        Self::is_register_writable(ra)?;
+
+        self.context
+            .block_height()
+            .map(|h| h as Word)
+            .map(|h| self.registers[ra] = h)
+            .ok_or(PanicReason::TransactionValidity)?;
+
+        self.inc_pc()
+    }
+
     pub(crate) fn block_proposer(&mut self, a: Word) -> Result<(), RuntimeError> {
         self.coinbase()
             .and_then(|data| self.try_mem_write(a as usize, data.as_ref()))?;

--- a/src/interpreter/constructors.rs
+++ b/src/interpreter/constructors.rs
@@ -27,7 +27,6 @@ impl<S> Interpreter<S> {
             storage,
             debugger: Debugger::default(),
             context: Context::default(),
-            block_height: 0,
             balances: RuntimeBalances::default(),
             #[cfg(feature = "profile-any")]
             profiler: Profiler::default(),

--- a/src/interpreter/contract.rs
+++ b/src/interpreter/contract.rs
@@ -20,6 +20,14 @@ where
             .ok_or(PanicReason::ContractNotFound.into())
     }
 
+    pub(crate) fn set_block_height(&mut self, ra: RegisterId) -> Result<(), RuntimeError> {
+        Self::is_register_writable(ra)?;
+
+        self.registers[ra] = self.storage.block_height().map_err(|e| e.into())? as Word;
+
+        self.inc_pc()
+    }
+
     pub(crate) fn contract_balance(&mut self, ra: RegisterId, b: Word, c: Word) -> Result<(), RuntimeError> {
         if b > VM_MAX_RAM - AssetId::LEN as Word || c > VM_MAX_RAM - ContractId::LEN as Word {
             return Err(PanicReason::MemoryOverflow.into());

--- a/src/interpreter/contract.rs
+++ b/src/interpreter/contract.rs
@@ -20,14 +20,6 @@ where
             .ok_or(PanicReason::ContractNotFound.into())
     }
 
-    pub(crate) fn set_block_height(&mut self, ra: RegisterId) -> Result<(), RuntimeError> {
-        Self::is_register_writable(ra)?;
-
-        self.registers[ra] = self.storage.block_height().map_err(|e| e.into())? as Word;
-
-        self.inc_pc()
-    }
-
     pub(crate) fn contract_balance(&mut self, ra: RegisterId, b: Word, c: Word) -> Result<(), RuntimeError> {
         if b > VM_MAX_RAM - AssetId::LEN as Word || c > VM_MAX_RAM - ContractId::LEN as Word {
             return Err(PanicReason::MemoryOverflow.into());

--- a/src/interpreter/executors/instruction.rs
+++ b/src/interpreter/executors/instruction.rs
@@ -359,7 +359,7 @@ where
 
             OpcodeRepr::BHEI => {
                 self.gas_charge(GAS_BHEI)?;
-                self.alu_set(ra, self.block_height() as Word)?;
+                self.set_block_height(ra)?;
             }
 
             OpcodeRepr::BHSH => {

--- a/src/interpreter/executors/predicate.rs
+++ b/src/interpreter/executors/predicate.rs
@@ -1,16 +1,18 @@
 use crate::consts::*;
 use crate::error::InterpreterError;
-use crate::interpreter::{Interpreter, MemoryRange};
+use crate::interpreter::Interpreter;
 use crate::state::{ExecuteState, ProgramState};
 use crate::storage::PredicateStorage;
 
 use fuel_asm::PanicReason;
 
 impl Interpreter<PredicateStorage> {
-    pub(crate) fn verify_predicate(&mut self, predicate: &MemoryRange) -> Result<ProgramState, InterpreterError> {
-        debug_assert!(self.is_predicate());
-
-        let (start, end) = predicate.boundaries(self);
+    pub(crate) fn verify_predicate(&mut self) -> Result<ProgramState, InterpreterError> {
+        let (start, end) = self
+            .context
+            .predicate()
+            .map(|p| p.program().boundaries(self))
+            .ok_or(InterpreterError::PredicateFailure)?;
 
         self.registers[REG_PC] = start;
         self.registers[REG_IS] = start;

--- a/src/interpreter/initialization.rs
+++ b/src/interpreter/initialization.rs
@@ -13,10 +13,8 @@ use std::io;
 
 impl<S> Interpreter<S> {
     /// Initialize the VM with a given transaction
-    pub fn init(&mut self, block_height: u32, tx: CheckedTransaction) -> Result<(), InterpreterError> {
+    pub fn init(&mut self, tx: CheckedTransaction) -> Result<(), InterpreterError> {
         self.tx = tx;
-
-        self.block_height = block_height;
 
         self.frames.clear();
         self.receipts.clear();
@@ -55,13 +53,11 @@ impl<S> Interpreter<S> {
 
     /// Initialize the VM for a predicate context
     pub fn init_predicate(&mut self, tx: CheckedTransaction) -> bool {
-        let block_height = 0;
-
         self.context = Context::Predicate {
             program: Default::default(),
         };
 
-        self.init(block_height, tx).is_ok()
+        self.init(tx).is_ok()
     }
 }
 
@@ -74,10 +70,8 @@ where
     ///
     /// For predicate verification, check [`Self::init`]
     pub fn init_with_storage(&mut self, tx: CheckedTransaction) -> Result<(), InterpreterError> {
-        let block_height = self.storage.block_height().map_err(InterpreterError::from_io)?;
-
         self.context = Context::Script;
 
-        self.init(block_height, tx)
+        self.init(tx)
     }
 }

--- a/src/interpreter/initialization.rs
+++ b/src/interpreter/initialization.rs
@@ -70,7 +70,9 @@ where
     ///
     /// For predicate verification, check [`Self::init`]
     pub fn init_with_storage(&mut self, tx: CheckedTransaction) -> Result<(), InterpreterError> {
-        self.context = Context::Script;
+        let block_height = self.storage.block_height().map_err(InterpreterError::from_io)?;
+
+        self.context = Context::Script { block_height };
 
         self.init(tx)
     }

--- a/src/interpreter/initialization.rs
+++ b/src/interpreter/initialization.rs
@@ -13,11 +13,10 @@ use std::io;
 
 impl<S> Interpreter<S> {
     /// Initialize the VM with a given transaction
-    pub fn init(&mut self, predicate: bool, block_height: u32, tx: CheckedTransaction) -> Result<(), InterpreterError> {
+    pub fn init(&mut self, block_height: u32, tx: CheckedTransaction) -> Result<(), InterpreterError> {
         self.tx = tx;
 
         self.block_height = block_height;
-        self.context = if predicate { Context::Predicate } else { Context::Script };
 
         self.frames.clear();
         self.receipts.clear();
@@ -53,6 +52,17 @@ impl<S> Interpreter<S> {
 
         Ok(())
     }
+
+    /// Initialize the VM for a predicate context
+    pub fn init_predicate(&mut self, tx: CheckedTransaction) -> bool {
+        let block_height = 0;
+
+        self.context = Context::Predicate {
+            program: Default::default(),
+        };
+
+        self.init(block_height, tx).is_ok()
+    }
 }
 
 impl<S> Interpreter<S>
@@ -64,9 +74,10 @@ where
     ///
     /// For predicate verification, check [`Self::init`]
     pub fn init_with_storage(&mut self, tx: CheckedTransaction) -> Result<(), InterpreterError> {
-        let predicate = false;
         let block_height = self.storage.block_height().map_err(InterpreterError::from_io)?;
 
-        self.init(predicate, block_height, tx)
+        self.context = Context::Script;
+
+        self.init(block_height, tx)
     }
 }

--- a/src/interpreter/internal.rs
+++ b/src/interpreter/internal.rs
@@ -30,10 +30,6 @@ impl<S> Interpreter<S> {
         Ok(())
     }
 
-    pub(crate) const fn block_height(&self) -> u32 {
-        self.block_height
-    }
-
     pub(crate) fn set_flag(&mut self, a: Word) -> Result<(), RuntimeError> {
         self.registers[REG_FLAG] = a;
 

--- a/src/interpreter/internal.rs
+++ b/src/interpreter/internal.rs
@@ -55,11 +55,11 @@ impl<S> Interpreter<S> {
             .map(|pc| self.registers[REG_PC] = pc)
     }
 
-    pub(crate) const fn context(&self) -> Context {
+    pub(crate) const fn context(&self) -> &Context {
         if self.registers[REG_FP] == 0 {
-            self.context
+            &self.context
         } else {
-            Context::Call
+            &Context::Call
         }
     }
 
@@ -72,7 +72,7 @@ impl<S> Interpreter<S> {
     }
 
     pub(crate) const fn is_predicate(&self) -> bool {
-        matches!(self.context, Context::Predicate)
+        matches!(self.context, Context::Predicate { .. })
     }
 
     pub(crate) const fn is_register_writable(ra: RegisterId) -> Result<(), RuntimeError> {

--- a/src/interpreter/internal.rs
+++ b/src/interpreter/internal.rs
@@ -52,11 +52,7 @@ impl<S> Interpreter<S> {
     }
 
     pub(crate) const fn context(&self) -> &Context {
-        if self.registers[REG_FP] == 0 {
-            &self.context
-        } else {
-            &Context::Call
-        }
+        &self.context
     }
 
     pub(crate) const fn is_external_context(&self) -> bool {
@@ -189,6 +185,12 @@ impl<S> Interpreter<S> {
     pub(crate) fn tx_id(&self) -> &Bytes32 {
         // Safety: vm parameters guarantees enough space for txid
         unsafe { Bytes32::as_ref_unchecked(&self.memory[..Bytes32::LEN]) }
+    }
+
+    pub(crate) fn set_frame_pointer(&mut self, fp: Word) {
+        self.context.update_from_frame_pointer(fp);
+
+        self.registers[REG_FP] = fp;
     }
 }
 

--- a/src/interpreter/memory.rs
+++ b/src/interpreter/memory.rs
@@ -18,6 +18,16 @@ pub struct MemoryRange {
     len: Word,
 }
 
+impl Default for MemoryRange {
+    fn default() -> Self {
+        Self {
+            start: ops::Bound::Included(0),
+            end: ops::Bound::Excluded(0),
+            len: 0,
+        }
+    }
+}
+
 impl MemoryRange {
     /// Create a new memory range represented as `[address, address + size[`.
     pub const fn new(address: Word, size: Word) -> Self {

--- a/src/interpreter/metadata.rs
+++ b/src/interpreter/metadata.rs
@@ -9,31 +9,39 @@ impl<S> Interpreter<S> {
     pub(crate) fn metadata(&mut self, ra: RegisterId, imm: Immediate18) -> Result<(), RuntimeError> {
         Self::is_register_writable(ra)?;
 
-        // Both metadata implementations should panic if external context
-        if self.is_external_context() {
-            return Err(PanicReason::ExpectedInternalContext.into());
-        }
+        let external = self.is_external_context();
+        let args = GMArgs::try_from(imm)?;
 
-        let parent = self
-            .frames
-            .last()
-            .map(|f| f.registers()[REG_FP])
-            .expect("External context will always have a frame");
+        if external {
+            match args {
+                GMArgs::GetVerifyingPredicate => {
+                    self.registers[ra] = self
+                        .context
+                        .predicate()
+                        .map(|p| p.idx() as Word)
+                        .ok_or(PanicReason::TransactionValidity)?;
+                }
 
-        match GMArgs::try_from(imm)? {
-            GMArgs::IsCallerExternal => {
-                self.registers[ra] = (parent == 0) as Word;
+                _ => return Err(PanicReason::ExpectedInternalContext.into()),
             }
+        } else {
+            let parent = self
+                .frames
+                .last()
+                .map(|f| f.registers()[REG_FP])
+                .expect("External context will always have a frame");
 
-            GMArgs::GetCaller if parent == 0 => {
-                return Err(PanicReason::ExpectedInternalContext.into());
+            match args {
+                GMArgs::IsCallerExternal => {
+                    self.registers[ra] = (parent == 0) as Word;
+                }
+
+                GMArgs::GetCaller if parent != 0 => {
+                    self.registers[ra] = parent;
+                }
+
+                _ => return Err(PanicReason::ExpectedInternalContext.into()),
             }
-
-            GMArgs::GetCaller => {
-                self.registers[ra] = parent;
-            }
-
-            GMArgs::GetVerifyingPredicate => todo!(),
         }
 
         self.inc_pc()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod error;
 pub mod gas;
 pub mod interpreter;
 pub mod memory_client;
+pub mod predicate;
 pub mod state;
 pub mod storage;
 pub mod transactor;
@@ -59,6 +60,7 @@ pub mod prelude {
     pub use crate::error::{Infallible, InterpreterError, RuntimeError};
     pub use crate::interpreter::{Interpreter, MemoryRange};
     pub use crate::memory_client::MemoryClient;
+    pub use crate::predicate::RuntimePredicate;
     pub use crate::state::{Debugger, ProgramState, StateTransition, StateTransitionRef};
     pub use crate::storage::{InterpreterStorage, MemoryStorage, PredicateStorage};
     pub use crate::transactor::Transactor;

--- a/src/predicate.rs
+++ b/src/predicate.rs
@@ -1,0 +1,112 @@
+//! Predicate representations with required data to be executed during VM runtime
+
+use crate::interpreter::MemoryRange;
+
+use fuel_asm::Word;
+use fuel_tx::{ConsensusParameters, Transaction};
+
+use std::borrow::Borrow;
+
+/// Runtime representation of a predicate
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct RuntimePredicate {
+    program: MemoryRange,
+    idx: usize,
+}
+
+impl RuntimePredicate {
+    /// Memory slice with the program representation of the predicate
+    pub const fn program(&self) -> &MemoryRange {
+        &self.program
+    }
+
+    /// Index of the transaction input that maps to this predicate
+    pub const fn idx(&self) -> usize {
+        self.idx
+    }
+
+    /// Create a new runtime predicate from a transaction, given the input index
+    ///
+    /// Return `None` if the tx input doesn't map to an input coin with a predicate
+    pub fn from_tx<T>(params: &ConsensusParameters, tx: T, idx: usize) -> Option<Self>
+    where
+        T: Borrow<Transaction>,
+    {
+        tx.borrow()
+            .input_coin_predicate_offset(idx)
+            .map(|(ofs, len)| (ofs as Word + params.tx_offset() as Word, len as Word))
+            .map(|(ofs, len)| MemoryRange::new(ofs, len))
+            .map(|program| Self { program, idx })
+    }
+}
+
+#[test]
+fn from_tx_works() {
+    use fuel_tx::TransactionBuilder;
+    use fuel_types::bytes;
+    use fuel_vm::prelude::*;
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
+
+    use std::iter;
+
+    let rng = &mut StdRng::seed_from_u64(2322u64);
+
+    let params = ConsensusParameters::default();
+    let height = 1;
+
+    #[rustfmt::skip]
+    let predicate: Vec<u8> = vec![
+        Opcode::ADDI(0x10, 0x00, 0x01),
+        Opcode::ADDI(0x10, 0x10, 0x01),
+        Opcode::RET(0x01),
+    ].into_iter().collect();
+
+    let predicate_data = b"If people do not believe that mathematics is simple, it is only because they do not realize how complicated life is.".to_vec();
+
+    let owner = (*Contract::root_from_code(&predicate)).into();
+    let a = Input::coin_predicate(
+        rng.gen(),
+        owner,
+        rng.gen(),
+        rng.gen(),
+        rng.gen(),
+        predicate.clone(),
+        predicate_data,
+    );
+
+    let tx = TransactionBuilder::script(vec![], vec![])
+        .add_input(a)
+        .finalize_checked_without_signature(height, &params);
+
+    // assert invalid idx wont panic
+    let idx = 1;
+    let runtime = RuntimePredicate::from_tx(&params, tx.as_ref(), idx);
+
+    assert!(runtime.is_none());
+
+    // fetch the input predicate
+    let idx = 0;
+    let runtime =
+        RuntimePredicate::from_tx(&params, tx.as_ref(), idx).expect("failed to generate predicate from valid tx");
+
+    assert_eq!(idx, runtime.idx());
+
+    let mut interpreter = Interpreter::without_storage();
+
+    assert!(interpreter.init_predicate(tx));
+
+    let pad = bytes::padded_len(&predicate) - predicate.len();
+
+    // assert we are testing an edge case
+    assert_ne!(0, pad);
+
+    let padded_predicate: Vec<u8> = predicate.iter().copied().chain(iter::repeat(0u8).take(pad)).collect();
+
+    let program = runtime.program();
+    let program = &interpreter.memory()[program.start() as usize..program.end() as usize];
+
+    // assert the program in the vm memory is the same of the input
+    assert_eq!(program, &padded_predicate);
+}


### PR DESCRIPTION
The context of the execution should contain more info such as the index
of the current predicate so we decouple that from the vm initialization.

Also, its worthy to create a type that will encapsulate the behavior of
the runtime predicates since it needs to store not only the program to
be executed - so it can't be represented just as a memory slice - but
the original input index that created the predicate.

The input index is not required for the predicate execution since the
program memory offset is a constant function of the consensus
parameters, but it might be consumed by the user - as in the specs.