### PR TITLE
Fix gas subtraction overflow

### DIFF
--- a/src/interpreter/executors/main.rs
+++ b/src/interpreter/executors/main.rs
@@ -135,7 +135,11 @@ where
                 // TODO set tree balance
 
                 let program = self.run_program();
-                let gas_used = self.transaction().gas_limit() - self.registers[REG_GGAS];
+                let gas_used = self
+                    .transaction()
+                    .gas_limit()
+                    .checked_sub(self.registers[REG_GGAS])
+                    .ok_or(InterpreterError::Panic(PanicReason::ArithmeticOverflow))?;
 
                 // Catch VM panic and don't propagate, generating a receipt
                 let (status, program) = match program {

--- a/src/interpreter/executors/main.rs
+++ b/src/interpreter/executors/main.rs
@@ -139,7 +139,7 @@ where
                     .transaction()
                     .gas_limit()
                     .checked_sub(self.registers[REG_GGAS])
-                    .ok_or(InterpreterError::Panic(PanicReason::ArithmeticOverflow))?;
+                    .ok_or(InterpreterError::Panic(PanicReason::OutOfGas))?;
 
                 // Catch VM panic and don't propagate, generating a receipt
                 let (status, program) = match program {


### PR DESCRIPTION
As pointed by @mediremi , we might overflow on the post-execution gas
deduction.

That operation must be safe, so we have to use `checked_sub`