### PR TITLE
Add traceable bug id to unexpected behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,17 @@ jobs:
         command: build
         args: --verbose
 
-    - name: Run tests
+    - name: Run basic tests
       uses: actions-rs/cargo@v1
       with:
         command: test
         args: --verbose
+
+    - name: Run all tests
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --verbose --all-features
 
     - name: Run tests random
       uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ description = "FuelVM interpreter."
 
 [dependencies]
 anyhow = { version = "1.0", optional = true }
+backtrace = { version = "0.3", optional = true } # requires debug symbols to work
 dyn-clone = { version = "1.0", optional = true }
 fuel-asm = "0.7"
 fuel-crypto = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ itertools = "0.10"
 secp256k1 = { version = "0.20", features = ["recovery"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 sha3 = "0.9"
+strum = { version = "0.24", features = ["derive"], optional = true }
 thiserror = "1.0"
 tracing = "0.1"
 rand = { version = "0.8", optional = true }
@@ -30,6 +31,8 @@ rand = { version = "0.8", optional = true }
 [dev-dependencies]
 fuel-tx = { version = "0.17", features = ["builder", "internals"] }
 fuel-vm = { path = ".", default-features = false, features = ["test-helpers"] }
+glob = "0.3"
+regex = "1.6"
 serde_json = "1.0"
 
 [features]
@@ -50,6 +53,11 @@ required-features = ["random"]
 name = "test-blockchain"
 path = "tests/blockchain.rs"
 required-features = ["random"]
+
+[[test]]
+name = "test-bug-id"
+path = "tests/bug-id.rs"
+required-features = ["strum"]
 
 [[test]]
 name = "test-contract"

--- a/src/error.rs
+++ b/src/error.rs
@@ -225,6 +225,7 @@ pub enum BugId {
     ID003,
     ID004,
     ID005,
+    ID006,
 }
 
 /// Traceable bug variants
@@ -287,5 +288,11 @@ impl StdError for Bug {}
 impl From<Bug> for RuntimeError {
     fn from(bug: Bug) -> Self {
         Self::Halt(io::Error::new(io::ErrorKind::Other, bug))
+    }
+}
+
+impl From<Bug> for InterpreterError {
+    fn from(bug: Bug) -> Self {
+        RuntimeError::from(bug).into()
     }
 }

--- a/src/interpreter/executors/main.rs
+++ b/src/interpreter/executors/main.rs
@@ -139,7 +139,7 @@ where
                     .transaction()
                     .gas_limit()
                     .checked_sub(self.registers[REG_GGAS])
-                    .ok_or(InterpreterError::Panic(PanicReason::OutOfGas))?;
+                    .ok_or(Bug::GlobalGasUnderflow(BugId::ID006))?;
 
                 // Catch VM panic and don't propagate, generating a receipt
                 let (status, program) = match program {

--- a/src/interpreter/executors/main.rs
+++ b/src/interpreter/executors/main.rs
@@ -139,7 +139,7 @@ where
                     .transaction()
                     .gas_limit()
                     .checked_sub(self.registers[REG_GGAS])
-                    .ok_or(Bug::GlobalGasUnderflow(BugId::ID006))?;
+                    .ok_or_else(|| Bug::new(BugId::ID006, BugVariant::GlobalGasUnderflow))?;
 
                 // Catch VM panic and don't propagate, generating a receipt
                 let (status, program) = match program {

--- a/src/interpreter/flow.rs
+++ b/src/interpreter/flow.rs
@@ -1,7 +1,7 @@
 use super::Interpreter;
 use crate::call::{Call, CallFrame};
 use crate::consts::*;
-use crate::error::{Bug, BugId, RuntimeError};
+use crate::error::{Bug, BugId, BugVariant, RuntimeError};
 use crate::state::ProgramState;
 use crate::storage::InterpreterStorage;
 
@@ -48,7 +48,7 @@ impl<S> Interpreter<S> {
         if let Some(frame) = self.frames.pop() {
             self.registers[REG_CGAS] = self.registers[REG_CGAS]
                 .checked_add(frame.context_gas())
-                .ok_or(Bug::ContextGasOverflow(BugId::ID001))?;
+                .ok_or_else(|| Bug::new(BugId::ID001, BugVariant::ContextGasOverflow))?;
 
             let cgas = self.registers[REG_CGAS];
             let ggas = self.registers[REG_GGAS];
@@ -172,7 +172,7 @@ where
         // subtract gas
         self.registers[REG_CGAS] = self.registers[REG_CGAS]
             .checked_sub(forward_gas_amount)
-            .ok_or(Bug::ContextGasUnderflow(BugId::ID003))?;
+            .ok_or_else(|| Bug::new(BugId::ID003, BugVariant::ContextGasUnderflow))?;
 
         let mut frame = self.call_frame(call, asset_id)?;
 

--- a/src/interpreter/flow.rs
+++ b/src/interpreter/flow.rs
@@ -1,7 +1,7 @@
 use super::Interpreter;
 use crate::call::{Call, CallFrame};
 use crate::consts::*;
-use crate::error::RuntimeError;
+use crate::error::{Bug, BugId, RuntimeError};
 use crate::state::ProgramState;
 use crate::storage::InterpreterStorage;
 
@@ -48,7 +48,7 @@ impl<S> Interpreter<S> {
         if let Some(frame) = self.frames.pop() {
             self.registers[REG_CGAS] = self.registers[REG_CGAS]
                 .checked_add(frame.context_gas())
-                .ok_or(RuntimeError::halt_on_bug("CGAS would overflow"))?;
+                .ok_or(Bug::ContextGasOverflow(BugId::ID001))?;
 
             let cgas = self.registers[REG_CGAS];
             let ggas = self.registers[REG_GGAS];
@@ -172,7 +172,7 @@ where
         // subtract gas
         self.registers[REG_CGAS] = self.registers[REG_CGAS]
             .checked_sub(forward_gas_amount)
-            .ok_or(RuntimeError::halt_on_bug("gas invariant violation"))?;
+            .ok_or(Bug::ContextGasUnderflow(BugId::ID003))?;
 
         let mut frame = self.call_frame(call, asset_id)?;
 

--- a/src/interpreter/gas.rs
+++ b/src/interpreter/gas.rs
@@ -1,6 +1,6 @@
 use super::Interpreter;
 use crate::consts::*;
-use crate::error::{Bug, BugId, RuntimeError};
+use crate::error::{Bug, BugId, BugVariant, RuntimeError};
 use crate::gas::GasUnit;
 
 use fuel_asm::{OpcodeRepr, PanicReason};
@@ -77,17 +77,17 @@ impl<S> Interpreter<S> {
         if gas > self.registers[REG_CGAS] {
             self.registers[REG_GGAS] = self.registers[REG_GGAS]
                 .checked_sub(self.registers[REG_CGAS])
-                .ok_or(Bug::GlobalGasUnderflow(BugId::ID002))?;
+                .ok_or_else(|| Bug::new(BugId::ID002, BugVariant::GlobalGasUnderflow))?;
             self.registers[REG_CGAS] = 0;
 
             Err(PanicReason::OutOfGas.into())
         } else {
             self.registers[REG_CGAS] = self.registers[REG_CGAS]
                 .checked_sub(gas)
-                .ok_or(Bug::ContextGasUnderflow(BugId::ID004))?;
+                .ok_or_else(|| Bug::new(BugId::ID004, BugVariant::ContextGasUnderflow))?;
             self.registers[REG_GGAS] = self.registers[REG_GGAS]
                 .checked_sub(gas)
-                .ok_or(Bug::GlobalGasUnderflow(BugId::ID005))?;
+                .ok_or_else(|| Bug::new(BugId::ID005, BugVariant::GlobalGasUnderflow))?;
 
             Ok(())
         }

--- a/src/interpreter/gas.rs
+++ b/src/interpreter/gas.rs
@@ -1,6 +1,6 @@
 use super::Interpreter;
 use crate::consts::*;
-use crate::error::RuntimeError;
+use crate::error::{Bug, BugId, RuntimeError};
 use crate::gas::GasUnit;
 
 use fuel_asm::{OpcodeRepr, PanicReason};
@@ -77,17 +77,17 @@ impl<S> Interpreter<S> {
         if gas > self.registers[REG_CGAS] {
             self.registers[REG_GGAS] = self.registers[REG_GGAS]
                 .checked_sub(self.registers[REG_CGAS])
-                .ok_or(RuntimeError::halt_on_bug("gas invariant violation"))?;
+                .ok_or(Bug::GlobalGasUnderflow(BugId::ID002))?;
             self.registers[REG_CGAS] = 0;
 
             Err(PanicReason::OutOfGas.into())
         } else {
             self.registers[REG_CGAS] = self.registers[REG_CGAS]
                 .checked_sub(gas)
-                .ok_or(RuntimeError::halt_on_bug("gas invariant violation"))?;
+                .ok_or(Bug::ContextGasUnderflow(BugId::ID004))?;
             self.registers[REG_GGAS] = self.registers[REG_GGAS]
                 .checked_sub(gas)
-                .ok_or(RuntimeError::halt_on_bug("gas invariant violation"))?;
+                .ok_or(Bug::GlobalGasUnderflow(BugId::ID005))?;
 
             Ok(())
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ pub mod prelude {
     pub use crate::backtrace::Backtrace;
     pub use crate::call::{Call, CallFrame};
     pub use crate::context::Context;
-    pub use crate::error::{Bug, BugId, Infallible, InterpreterError, RuntimeError};
+    pub use crate::error::{Bug, BugId, BugVariant, Infallible, InterpreterError, RuntimeError};
     pub use crate::interpreter::{Interpreter, MemoryRange};
     pub use crate::memory_client::MemoryClient;
     pub use crate::predicate::RuntimePredicate;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ pub mod prelude {
     pub use crate::backtrace::Backtrace;
     pub use crate::call::{Call, CallFrame};
     pub use crate::context::Context;
-    pub use crate::error::{Infallible, InterpreterError, RuntimeError};
+    pub use crate::error::{Bug, BugId, Infallible, InterpreterError, RuntimeError};
     pub use crate::interpreter::{Interpreter, MemoryRange};
     pub use crate::memory_client::MemoryClient;
     pub use crate::predicate::RuntimePredicate;

--- a/tests/bug-id.rs
+++ b/tests/bug-id.rs
@@ -11,10 +11,15 @@ use fuel_vm::prelude::*;
 fn check_bug_id_unique() {
     let mut matches = HashSet::new();
     let re = Regex::new(r"BugId::ID\d{3}").expect("failed to create regex");
+    let re_use = Regex::new(r"BugId::\*").expect("failed to create regex");
 
     for source in glob("src/**/*.rs").expect("Failed to read glob pattern") {
         let source = source.expect("failed to fetch source from glob");
         let source = fs::read_to_string(source).expect("failed to read source");
+
+        if re_use.is_match(&source) {
+            panic!("BugId isn't supposed to be required as '*'")
+        }
 
         re.find_iter(&source).map(|m| m.as_str().to_string()).for_each(|s| {
             if !matches.insert(s.clone()) {
@@ -24,7 +29,13 @@ fn check_bug_id_unique() {
     }
 
     BugId::VARIANTS.iter().for_each(|v| {
-        if !matches.contains(&format!("BugId::{}", v)) {
+        let v = format!("BugId::{}", v);
+
+        if !re.is_match(&v) {
+            panic!("the bug id format is inconsistent: {}", v);
+        }
+
+        if !matches.contains(&v) {
             panic!("the bug id variant is never constructed: {}", v);
         }
     });

--- a/tests/bug-id.rs
+++ b/tests/bug-id.rs
@@ -1,0 +1,31 @@
+use std::collections::HashSet;
+use std::fs;
+
+use glob::glob;
+use regex::Regex;
+use strum::VariantNames;
+
+use fuel_vm::prelude::*;
+
+#[test]
+fn check_bug_id_unique() {
+    let mut matches = HashSet::new();
+    let re = Regex::new(r"BugId::ID\d{3}").expect("failed to create regex");
+
+    for source in glob("src/**/*.rs").expect("Failed to read glob pattern") {
+        let source = source.expect("failed to fetch source from glob");
+        let source = fs::read_to_string(source).expect("failed to read source");
+
+        re.find_iter(&source).map(|m| m.as_str().to_string()).for_each(|s| {
+            if !matches.insert(s.clone()) {
+                panic!("duplicated bug id detected: {}", s);
+            }
+        });
+    }
+
+    BugId::VARIANTS.iter().for_each(|v| {
+        if !matches.contains(&format!("BugId::{}", v)) {
+            panic!("the bug id variant is never constructed: {}", v);
+        }
+    });
+}

--- a/tests/bug-id.rs
+++ b/tests/bug-id.rs
@@ -11,10 +11,7 @@ use fuel_vm::prelude::*;
 #[test]
 fn check_bug_id_unique() {
     let mut matches = HashSet::new();
-
     let re = Regex::new(r"BugId::ID\d{3}").expect("failed to create regex");
-    let re_use = Regex::new(r"BugId::\*").expect("failed to create regex");
-
     let error_source = PathBuf::new().join("src").join("error.rs");
 
     for source in glob("src/**/*.rs").expect("Failed to read glob pattern") {
@@ -23,7 +20,7 @@ fn check_bug_id_unique() {
         if source != error_source {
             let source = fs::read_to_string(source).expect("failed to read source");
 
-            if re_use.is_match(&source) {
+            if source.contains("BugId::*") {
                 panic!("BugId isn't supposed to be required as '*'")
             }
 

--- a/tests/bug-id.rs
+++ b/tests/bug-id.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::fs;
+use std::path::PathBuf;
 
 use glob::glob;
 use regex::Regex;
@@ -10,22 +11,28 @@ use fuel_vm::prelude::*;
 #[test]
 fn check_bug_id_unique() {
     let mut matches = HashSet::new();
+
     let re = Regex::new(r"BugId::ID\d{3}").expect("failed to create regex");
     let re_use = Regex::new(r"BugId::\*").expect("failed to create regex");
 
+    let error_source = PathBuf::new().join("src").join("error.rs");
+
     for source in glob("src/**/*.rs").expect("Failed to read glob pattern") {
         let source = source.expect("failed to fetch source from glob");
-        let source = fs::read_to_string(source).expect("failed to read source");
 
-        if re_use.is_match(&source) {
-            panic!("BugId isn't supposed to be required as '*'")
-        }
+        if source != error_source {
+            let source = fs::read_to_string(source).expect("failed to read source");
 
-        re.find_iter(&source).map(|m| m.as_str().to_string()).for_each(|s| {
-            if !matches.insert(s.clone()) {
-                panic!("duplicated bug id detected: {}", s);
+            if re_use.is_match(&source) {
+                panic!("BugId isn't supposed to be required as '*'")
             }
-        });
+
+            re.find_iter(&source).map(|m| m.as_str().to_string()).for_each(|s| {
+                if !matches.insert(s.clone()) {
+                    panic!("duplicated bug id detected: {}", s);
+                }
+            });
+        }
     }
 
     BugId::VARIANTS.iter().for_each(|v| {


### PR DESCRIPTION
Some states of the VM are ultimately invalid and contradict the
specifications constraints. These maps to implementation errors that
must be fixed.

In order to make it easier for the user to spot these errors, we must
have a reliable reporting system.

As a first step, its important to map the origin of the error. This
commit introduces `Bug`, that will provide meaningful descriptions to
circumstances that violates the specifications constraints, and `BugId`,
that is guaranteed by tests to map to a specic - and unique - location
of the code.