### PR TITLE
Remove transmute

### DIFF
--- a/src/interpreter/executors/main.rs
+++ b/src/interpreter/executors/main.rs
@@ -5,7 +5,7 @@ use crate::error::{Bug, BugId, BugVariant, InterpreterError, RuntimeError};
 use crate::interpreter::Interpreter;
 use crate::predicate::RuntimePredicate;
 use crate::state::StateTransition;
-use crate::state::{ExecuteState, ProgramState, StateTransitionRef};
+use crate::state::{ExecuteState, ProgramState};
 use crate::storage::{InterpreterStorage, PredicateStorage};
 
 use fuel_asm::PanicReason;
@@ -264,25 +264,22 @@ where
         tx: CheckedTransaction,
         params: ConsensusParameters,
     ) -> Result<StateTransition, InterpreterError> {
-        Interpreter::with_storage(storage, params)
+        let mut interpreter = Interpreter::with_storage(storage, params);
+        interpreter
             .transact(tx)
-            .map(|st| st.into_owned())
+            .map(|state| StateTransition::new(state, interpreter.tx.into(), interpreter.receipts))
     }
 
     /// Initialize a pre-allocated instance of [`Interpreter`] with the provided
     /// transaction and execute it. The result will be bound to the lifetime
     /// of the interpreter and will avoid unnecessary copy with the data
     /// that can be referenced from the interpreter instance itself.
-    pub fn transact(&mut self, tx: CheckedTransaction) -> Result<StateTransitionRef<'_>, InterpreterError> {
+    pub fn transact(&mut self, tx: CheckedTransaction) -> Result<ProgramState, InterpreterError> {
         let state_result = self.init_script(tx).and_then(|_| self.run());
 
         #[cfg(feature = "profile-any")]
         self.profiler.on_transaction(&state_result);
 
-        let state = state_result?;
-
-        let transition = StateTransitionRef::new(state, self.transaction(), self.receipts());
-
-        Ok(transition)
+        state_result
     }
 }

--- a/src/interpreter/executors/main.rs
+++ b/src/interpreter/executors/main.rs
@@ -4,8 +4,8 @@ use crate::crypto;
 use crate::error::{Bug, BugId, BugVariant, InterpreterError, RuntimeError};
 use crate::interpreter::Interpreter;
 use crate::predicate::RuntimePredicate;
-use crate::state::StateTransition;
 use crate::state::{ExecuteState, ProgramState};
+use crate::state::{StateTransition, StateTransitionRef};
 use crate::storage::{InterpreterStorage, PredicateStorage};
 
 use fuel_asm::PanicReason;
@@ -281,5 +281,10 @@ where
         self.profiler.on_transaction(&state_result);
 
         state_result
+    }
+
+    /// Get the state transaction from a new program state.
+    pub fn state_transition<'a>(&'a self, state: &'a ProgramState) -> StateTransitionRef<'a> {
+        StateTransitionRef::new(state, self.transaction(), self.receipts())
     }
 }

--- a/src/memory_client.rs
+++ b/src/memory_client.rs
@@ -9,23 +9,23 @@ use fuel_tx::{CheckedTransaction, ConsensusParameters, Receipt};
 
 #[derive(Debug, Default)]
 /// Client implementation with in-memory storage backend.
-pub struct MemoryClient<'a> {
-    transactor: Transactor<'a, MemoryStorage>,
+pub struct MemoryClient {
+    transactor: Transactor<MemoryStorage>,
 }
 
-impl<'a> AsRef<MemoryStorage> for MemoryClient<'a> {
+impl<'a> AsRef<MemoryStorage> for MemoryClient {
     fn as_ref(&self) -> &MemoryStorage {
         self.transactor.as_ref()
     }
 }
 
-impl<'a> AsMut<MemoryStorage> for MemoryClient<'a> {
+impl<'a> AsMut<MemoryStorage> for MemoryClient {
     fn as_mut(&mut self) -> &mut MemoryStorage {
         self.transactor.as_mut()
     }
 }
 
-impl<'a> MemoryClient<'a> {
+impl MemoryClient {
     /// Create a new instance of the memory client out of a provided storage.
     pub fn new(storage: MemoryStorage, params: ConsensusParameters) -> Self {
         Self {
@@ -34,7 +34,7 @@ impl<'a> MemoryClient<'a> {
     }
 
     /// Create a new instance of the memory client out of a provided storage.
-    pub fn from_txtor(transactor: Transactor<'a, MemoryStorage>) -> Self {
+    pub fn from_txtor(transactor: Transactor<MemoryStorage>) -> Self {
         Self { transactor }
     }
 
@@ -51,7 +51,7 @@ impl<'a> MemoryClient<'a> {
     }
 
     /// State transition representation after the execution of a transaction.
-    pub const fn state_transition(&self) -> Option<&StateTransitionRef<'_>> {
+    pub fn state_transition(&self) -> Option<StateTransitionRef<'_>> {
         self.transactor.state_transition()
     }
 
@@ -96,14 +96,14 @@ impl<'a> MemoryClient<'a> {
     }
 }
 
-impl<'a> From<MemoryStorage> for MemoryClient<'a> {
+impl<'a> From<MemoryStorage> for MemoryClient {
     fn from(s: MemoryStorage) -> Self {
         Self::new(s, Default::default())
     }
 }
 
-impl<'a> From<MemoryClient<'a>> for Transactor<'a, MemoryStorage> {
-    fn from(client: MemoryClient<'a>) -> Self {
+impl<'a> From<MemoryClient> for Transactor<MemoryStorage> {
+    fn from(client: MemoryClient) -> Self {
         client.transactor
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -165,14 +165,14 @@ impl From<StateTransition> for ProgramState {
 /// Zero-copy Representation of the result of a transaction execution bound to
 /// the lifetime of the VM.
 pub struct StateTransitionRef<'a> {
-    state: ProgramState,
+    state: &'a ProgramState,
     tx: &'a Transaction,
     receipts: &'a [Receipt],
 }
 
 impl<'a> StateTransitionRef<'a> {
     /// Create a new by reference state transition representation.
-    pub const fn new(state: ProgramState, tx: &'a Transaction, receipts: &'a [Receipt]) -> Self {
+    pub const fn new(state: &'a ProgramState, tx: &'a Transaction, receipts: &'a [Receipt]) -> Self {
         Self { state, tx, receipts }
     }
 
@@ -197,26 +197,20 @@ impl<'a> StateTransitionRef<'a> {
             .iter()
             .any(|r| matches!(r, Receipt::Revert { .. } | Receipt::Panic { .. }))
     }
-
-    /// Convert this instance into an owned state transition, cloning its
-    /// internals.
-    pub fn into_owned(self) -> StateTransition {
-        StateTransition::new(self.state, self.tx.clone(), self.receipts.to_vec())
-    }
 }
 
 impl<'a> From<&'a StateTransition> for StateTransitionRef<'a> {
     fn from(t: &'a StateTransition) -> StateTransitionRef<'a> {
         Self {
-            state: *t.state(),
+            state: t.state(),
             tx: t.tx(),
             receipts: t.receipts(),
         }
     }
 }
 
-impl<'a> From<StateTransitionRef<'a>> for ProgramState {
-    fn from(t: StateTransitionRef<'a>) -> ProgramState {
+impl<'a> From<StateTransitionRef<'a>> for &'a ProgramState {
+    fn from(t: StateTransitionRef<'a>) -> &'a ProgramState {
         t.state
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -165,14 +165,14 @@ impl From<StateTransition> for ProgramState {
 /// Zero-copy Representation of the result of a transaction execution bound to
 /// the lifetime of the VM.
 pub struct StateTransitionRef<'a> {
-    state: &'a ProgramState,
+    state: ProgramState,
     tx: &'a Transaction,
     receipts: &'a [Receipt],
 }
 
 impl<'a> StateTransitionRef<'a> {
     /// Create a new by reference state transition representation.
-    pub const fn new(state: &'a ProgramState, tx: &'a Transaction, receipts: &'a [Receipt]) -> Self {
+    pub const fn new(state: ProgramState, tx: &'a Transaction, receipts: &'a [Receipt]) -> Self {
         Self { state, tx, receipts }
     }
 
@@ -202,15 +202,15 @@ impl<'a> StateTransitionRef<'a> {
 impl<'a> From<&'a StateTransition> for StateTransitionRef<'a> {
     fn from(t: &'a StateTransition) -> StateTransitionRef<'a> {
         Self {
-            state: t.state(),
+            state: *t.state(),
             tx: t.tx(),
             receipts: t.receipts(),
         }
     }
 }
 
-impl<'a> From<StateTransitionRef<'a>> for &'a ProgramState {
-    fn from(t: StateTransitionRef<'a>) -> &'a ProgramState {
+impl<'a> From<StateTransitionRef<'a>> for ProgramState {
+    fn from(t: StateTransitionRef<'a>) -> ProgramState {
         t.state
     }
 }

--- a/src/transactor.rs
+++ b/src/transactor.rs
@@ -1,14 +1,12 @@
 //! State machine of the interpreter.
 
-use crate::backtrace::Backtrace;
 use crate::error::InterpreterError;
 use crate::interpreter::Interpreter;
-use crate::state::StateTransitionRef;
+use crate::state::{StateTransition, StateTransitionRef};
 use crate::storage::InterpreterStorage;
+use crate::{backtrace::Backtrace, state::ProgramState};
 
 use fuel_tx::{CheckedTransaction, ConsensusParameters, Receipt};
-
-use std::{mem, slice};
 
 #[derive(Debug)]
 /// State machine to execute transactions and provide runtime entities on
@@ -18,13 +16,13 @@ use std::{mem, slice};
 /// builder`.
 ///
 /// Based on <https://doc.rust-lang.org/1.5.0/style/ownership/builders.html#non-consuming-builders-preferred>
-pub struct Transactor<'a, S> {
+pub struct Transactor<S> {
     interpreter: Interpreter<S>,
-    state_transition: Option<StateTransitionRef<'a>>,
+    program_state: Option<ProgramState>,
     error: Option<InterpreterError>,
 }
 
-impl<'a, S> Transactor<'a, S> {
+impl<'a, S> Transactor<S> {
     /// Transactor constructor
     pub fn new(storage: S, params: ConsensusParameters) -> Self {
         Interpreter::with_storage(storage, params).into()
@@ -34,8 +32,30 @@ impl<'a, S> Transactor<'a, S> {
     ///
     /// Will be `None` if the last transaction resulted in a VM panic, or if no
     /// transaction was executed.
-    pub const fn state_transition(&self) -> Option<&StateTransitionRef<'a>> {
-        self.state_transition.as_ref()
+    pub fn state_transition(&'a self) -> Option<StateTransitionRef<'a>> {
+        match self.program_state.as_ref() {
+            Some(state) => Some(StateTransitionRef::new(
+                state,
+                self.interpreter.transaction(),
+                self.interpreter.receipts(),
+            )),
+            None => None,
+        }
+    }
+
+    /// State transition representation after the execution of a transaction.
+    ///
+    /// Will be `None` if the last transaction resulted in a VM panic, or if no
+    /// transaction was executed.
+    pub fn to_owned_state_transition(&self) -> Option<StateTransition> {
+        match self.program_state.clone() {
+            Some(state) => Some(StateTransition::new(
+                state,
+                self.interpreter.transaction().clone().into(),
+                self.interpreter.receipts().to_vec(),
+            )),
+            None => None,
+        }
     }
 
     /// Receipts after the execution of a transaction.
@@ -45,18 +65,7 @@ impl<'a, S> Transactor<'a, S> {
     pub fn receipts(&self) -> Option<&[Receipt]> {
         // TODO improve implementation without changing signature
 
-        self.state_transition().map(|s| {
-            let receipts = s.receipts();
-
-            let ptr = receipts.as_ptr();
-            let len = receipts.len();
-
-            // Safety: StateTransitionRef is bound to 'a
-            //
-            // We can enforce this as a compiler rule by requiring `receipts(&'a self)`, but
-            // then the consumers of this API will face unnecessary lifetime complexity
-            unsafe { slice::from_raw_parts(ptr, len) }
-        })
+        self.program_state.is_some().then(|| self.interpreter.receipts())
     }
 
     /// Interpreter error representation after the execution of a transaction.
@@ -82,7 +91,7 @@ impl<'a, S> Transactor<'a, S> {
 
     /// Returns true if last transaction execution was successful
     pub const fn is_success(&self) -> bool {
-        self.state_transition.is_some()
+        self.program_state.is_some()
     }
 
     /// Returns true if last transaction execution was erroneous
@@ -93,8 +102,8 @@ impl<'a, S> Transactor<'a, S> {
     /// Result representation of the last executed transaction.
     ///
     /// Will return `None` if no transaction was executed.
-    pub fn result(&self) -> Result<&StateTransitionRef<'a>, &InterpreterError> {
-        let state = self.state_transition.as_ref();
+    pub fn result(&'a self) -> Result<StateTransitionRef<'a>, &InterpreterError> {
+        let state = self.state_transition();
         let error = self.error.as_ref();
 
         match (state, error) {
@@ -125,7 +134,7 @@ impl<'a, S> Transactor<'a, S> {
     }
 }
 
-impl<S> Transactor<'_, S>
+impl<S> Transactor<S>
 where
     S: InterpreterStorage,
 {
@@ -133,64 +142,57 @@ where
     pub fn transact(&mut self, tx: CheckedTransaction) -> &mut Self {
         match self.interpreter.transact(tx) {
             Ok(s) => {
-                // Safety: cast `StateTransitionRef<'_>` to `StateTransitionRef<'a>` since it
-                // was generated with the same lifetime of `self.interpreter`
-                //
-                // `self.interpreter` is bound to `'a` since its bound to `self`
-                let s = unsafe { mem::transmute(s) };
-
-                self.state_transition.replace(s);
+                self.program_state.replace(s);
                 self.error.take();
             }
 
             Err(e) => {
-                self.state_transition.take();
+                self.program_state.take();
                 self.error.replace(e);
             }
         }
-
         self
     }
 }
 
-impl<S> From<Interpreter<S>> for Transactor<'_, S> {
+impl<S> From<Interpreter<S>> for Transactor<S> {
     fn from(interpreter: Interpreter<S>) -> Self {
-        let state_transition = None;
+        let program_state = None;
         let error = None;
 
         Self {
             interpreter,
-            state_transition,
+            program_state,
             error,
         }
     }
 }
 
-impl<S> From<Transactor<'_, S>> for Interpreter<S> {
+impl<S> From<Transactor<S>> for Interpreter<S> {
     fn from(transactor: Transactor<S>) -> Self {
         transactor.interpreter
     }
 }
 
-impl<S> AsRef<Interpreter<S>> for Transactor<'_, S> {
+impl<S> AsRef<Interpreter<S>> for Transactor<S> {
     fn as_ref(&self) -> &Interpreter<S> {
         &self.interpreter
     }
 }
 
-impl<S> AsRef<S> for Transactor<'_, S> {
+impl<S> AsRef<S> for Transactor<S> {
     fn as_ref(&self) -> &S {
         self.interpreter.as_ref()
     }
 }
 
-impl<S> AsMut<S> for Transactor<'_, S> {
+impl<S> AsMut<S> for Transactor<S> {
     fn as_mut(&mut self) -> &mut S {
         self.interpreter.as_mut()
     }
 }
 
-impl<S> Default for Transactor<'_, S>
+impl<S> Default for Transactor<S>
 where
     S: Default,
 {

--- a/src/transactor.rs
+++ b/src/transactor.rs
@@ -33,7 +33,7 @@ impl<'a, S> Transactor<S> {
     /// Will be `None` if the last transaction resulted in a VM panic, or if no
     /// transaction was executed.
     pub fn state_transition(&'a self) -> Option<StateTransitionRef<'a>> {
-        match self.program_state.as_ref() {
+        match self.program_state {
             Some(state) => Some(StateTransitionRef::new(
                 state,
                 self.interpreter.transaction(),
@@ -63,8 +63,6 @@ impl<'a, S> Transactor<S> {
     /// Follows the same criteria as [`Self::state_transition`] to return
     /// `None`.
     pub fn receipts(&self) -> Option<&[Receipt]> {
-        // TODO improve implementation without changing signature
-
         self.program_state.is_some().then(|| self.interpreter.receipts())
     }
 
@@ -142,7 +140,7 @@ where
     pub fn transact(&mut self, tx: CheckedTransaction) -> &mut Self {
         match self.interpreter.transact(tx) {
             Ok(s) => {
-                self.program_state.replace(s);
+                self.program_state.replace(s.into());
                 self.error.take();
             }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -315,7 +315,7 @@ pub mod test_helpers {
                 return Err(anyhow!("{:?}", e));
             }
 
-            let state = txtor.state_transition().unwrap().into_owned();
+            let state = txtor.to_owned_state_transition().unwrap();
 
             let interpreter = txtor.interpreter();
 

--- a/tests/blockchain.rs
+++ b/tests/blockchain.rs
@@ -1106,9 +1106,8 @@ fn smo_instruction_works() {
 
         assert!(success);
 
-        let (recipient, transferred) = client
-            .state_transition()
-            .expect("tx was executed")
+        let state = client.state_transition().expect("tx was executed");
+        let (recipient, transferred) = state
             .tx()
             .outputs()
             .iter()

--- a/tests/gas_factor.rs
+++ b/tests/gas_factor.rs
@@ -32,13 +32,11 @@ fn gas_factor_rounds_correctly() {
 
     let profiler = GasProfiler::default();
 
-    let mut interpreter = Interpreter::with_memory_storage();
-    interpreter.with_params(params).with_profiler(profiler.clone());
-    let state = interpreter
+    let change = Interpreter::with_memory_storage()
+        .with_params(params)
+        .with_profiler(profiler.clone())
         .transact(transaction)
-        .expect("failed to execute transaction");
-    let change = interpreter
-        .state_transition(&state)
+        .expect("failed to execute transaction")
         .tx()
         .outputs()
         .iter()

--- a/tests/gas_factor.rs
+++ b/tests/gas_factor.rs
@@ -32,11 +32,13 @@ fn gas_factor_rounds_correctly() {
 
     let profiler = GasProfiler::default();
 
-    let change = Interpreter::with_memory_storage()
-        .with_params(params)
-        .with_profiler(profiler.clone())
+    let mut interpreter = Interpreter::with_memory_storage();
+    interpreter.with_params(params).with_profiler(profiler.clone());
+    let state = interpreter
         .transact(transaction)
-        .expect("failed to execute transaction")
+        .expect("failed to execute transaction");
+    let change = interpreter
+        .state_transition(&state)
         .tx()
         .outputs()
         .iter()


### PR DESCRIPTION
Removes a transmute that is never actually used.
Also this transmute crates a self reference that is UB when the struct is moved.