### PR TITLE
Apply safe arith to call and crypto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ fuel-storage = "0.2"
 fuel-tx = "0.18"
 fuel-types = "0.5"
 itertools = "0.10"
-secp256k1 = { version = "0.24", features = ["recovery"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 sha3 = "0.10"
 strum = { version = "0.24", features = ["derive"], optional = true }
@@ -67,6 +66,11 @@ required-features = ["strum"]
 [[test]]
 name = "test-contract"
 path = "tests/contract.rs"
+required-features = ["random"]
+
+[[test]]
+name = "test-crypto"
+path = "tests/crypto.rs"
 required-features = ["random"]
 
 [[test]]

--- a/src/call.rs
+++ b/src/call.rs
@@ -53,7 +53,7 @@ impl Call {
 
 impl SizedBytes for Call {
     fn serialized_size(&self) -> usize {
-        WORD_SIZE.saturating_mul(2).saturating_add(ContractId::LEN)
+        ContractId::LEN + 2 * WORD_SIZE
     }
 }
 
@@ -148,34 +148,22 @@ impl CallFrame {
 
     /// Contract code memory offset.
     pub const fn code_offset() -> usize {
-        Self::code_size_offset().saturating_add(WORD_SIZE)
+        Self::code_size_offset() + WORD_SIZE
     }
 
     /// Contract code size memory offset.
     pub const fn code_size_offset() -> usize {
-        VM_REGISTER_COUNT
-            .saturating_add(2)
-            .saturating_mul(WORD_SIZE)
-            .saturating_add(ContractId::LEN)
-            .saturating_add(AssetId::LEN)
+        ContractId::LEN + AssetId::LEN + WORD_SIZE * (2 + VM_REGISTER_COUNT)
     }
 
     /// `a` argument memory offset.
     pub const fn a_offset() -> usize {
-        VM_REGISTER_COUNT
-            .saturating_add(1)
-            .saturating_mul(WORD_SIZE)
-            .saturating_add(ContractId::LEN)
-            .saturating_add(AssetId::LEN)
+        ContractId::LEN + AssetId::LEN + WORD_SIZE * (1 + VM_REGISTER_COUNT)
     }
 
     /// `b` argument memory offset.
     pub const fn b_offset() -> usize {
-        VM_REGISTER_COUNT
-            .saturating_add(2)
-            .saturating_mul(WORD_SIZE)
-            .saturating_add(ContractId::LEN)
-            .saturating_add(AssetId::LEN)
+        ContractId::LEN + AssetId::LEN + WORD_SIZE * (2 + VM_REGISTER_COUNT)
     }
 
     /// Registers prior to the called execution.
@@ -211,7 +199,7 @@ impl CallFrame {
 
 impl SizedBytes for CallFrame {
     fn serialized_size(&self) -> usize {
-        Self::code_offset().saturating_add(bytes::padded_len(self.code.as_ref()))
+        Self::code_offset() + bytes::padded_len(self.code.as_ref())
     }
 }
 

--- a/src/call.rs
+++ b/src/call.rs
@@ -7,6 +7,7 @@ use fuel_tx::Contract;
 use fuel_types::bytes::{self, SizedBytes};
 use fuel_types::{AssetId, ContractId, Word};
 
+use crate::arith::checked_add_usize;
 use std::io::{self, Write};
 use std::mem;
 
@@ -250,9 +251,7 @@ impl io::Write for CallFrame {
 
         let (bytes, code, _) = bytes::restore_raw_bytes(buf, code_len)?;
 
-        n = n
-            .checked_add(bytes)
-            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "io bytes overflow"))?;
+        n = checked_add_usize(n, bytes)?;
 
         self.to = to.into();
         self.asset_id = asset_id.into();

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -16,7 +16,7 @@ where
 
 #[test]
 #[cfg(feature = "random")]
-fn ephemeral_merkle_root_works() {
+fn ephemeral_merkle_root_returns_the_expected_root() {
     use fuel_crypto::Hasher;
     use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,52 +1,7 @@
 //! Crypto implementations for the instructions
 
 use fuel_merkle::binary::in_memory::MerkleTree;
-use fuel_types::{Bytes32, Bytes64};
-use secp256k1::ecdsa::{RecoverableSignature, RecoveryId};
-use secp256k1::Error as Secp256k1Error;
-use secp256k1::{Message, Secp256k1, SecretKey};
-
-/// Sign a given message and compress the `v` to the signature
-///
-/// The compression scheme is described in
-/// <https://github.com/lazyledger/lazyledger-specs/blob/master/specs/data_structures.md#public-key-cryptography>
-pub fn secp256k1_sign_compact_recoverable(secret: &[u8], message: &[u8]) -> Result<Bytes64, Secp256k1Error> {
-    let secret = SecretKey::from_slice(secret)?;
-    let message = Message::from_slice(message)?;
-
-    let signature = Secp256k1::new().sign_ecdsa_recoverable(&message, &secret);
-    let (v, mut signature) = signature.serialize_compact();
-
-    let v = v.to_i32();
-    signature[32] |= (v << 7) as u8;
-
-    Ok(signature.into())
-}
-
-/// Recover the public key from a signature performed with
-/// [`secp256k1_sign_compact_recoverable`]
-pub fn secp256k1_sign_compact_recover(signature: &[u8], message: &[u8]) -> Result<Bytes64, Secp256k1Error> {
-    let message = Message::from_slice(message)?;
-    let mut signature = Bytes64::try_from(signature).map_err(|_| Secp256k1Error::InvalidSignature)?;
-
-    let v = ((signature.as_mut()[32] & 0x80) >> 7) as i32;
-    signature.as_mut()[32] &= 0x7f;
-
-    let v = RecoveryId::from_i32(v)?;
-    let signature = RecoverableSignature::from_compact(signature.as_ref(), v)?;
-
-    let pk = Secp256k1::new()
-        .recover_ecdsa(&message, &signature)?
-        .serialize_uncompressed();
-
-    // Ignore the first byte of the compressed flag
-    let pk = &pk[1..];
-
-    // Safety: secp256k1 protocol specifies 65 bytes output
-    let pk = unsafe { Bytes64::from_slice_unchecked(pk) };
-
-    Ok(pk)
-}
+use fuel_types::Bytes32;
 
 /// Calculate a binary merkle root with in-memory storage
 pub fn ephemeral_merkle_root<L, I>(leaves: I) -> Bytes32
@@ -59,86 +14,54 @@ where
     tree.root().into()
 }
 
-#[cfg(all(test, feature = "random"))]
-mod tests {
-    use crate::crypto::{
-        ephemeral_merkle_root, secp256k1_sign_compact_recover, secp256k1_sign_compact_recoverable, Secp256k1,
-    };
-    use crate::prelude::*;
-
+#[test]
+#[cfg(feature = "random")]
+fn ephemeral_merkle_root_works() {
     use fuel_crypto::Hasher;
     use rand::rngs::StdRng;
-    use rand::{Rng, RngCore, SeedableRng};
-    use secp256k1::{PublicKey, SecretKey};
+    use rand::{Rng, SeedableRng};
 
-    #[test]
-    fn ecrecover() {
-        let secp = Secp256k1::new();
-        let mut rng = StdRng::seed_from_u64(2322u64);
-        let mut secret_seed = [0u8; 32];
-        let mut message = [0u8; 95];
+    use crate::prelude::*;
 
-        for _ in 0..10 {
-            rng.fill_bytes(&mut message);
-            rng.fill_bytes(&mut secret_seed);
+    let mut rng = StdRng::seed_from_u64(2322u64);
 
-            let secret = SecretKey::from_slice(&secret_seed).expect("Failed to generate random secret!");
-            let public = PublicKey::from_secret_key(&secp, &secret).serialize_uncompressed();
-            let public = Bytes64::try_from(&public[1..]).expect("Failed to parse public key!");
+    const LEAF_PREFIX: u8 = 0x00;
+    const NODE_PREFIX: u8 = 0x01;
 
-            let e = Hasher::hash(&message);
+    // Test for 0 leaves
+    //
+    // Expected root is `h()`
+    let empty: Vec<Address> = vec![];
 
-            let sig =
-                secp256k1_sign_compact_recoverable(secret.as_ref(), e.as_ref()).expect("Failed to generate signature");
-            let pk_p =
-                secp256k1_sign_compact_recover(sig.as_ref(), e.as_ref()).expect("Failed to recover PK from signature");
+    let root = ephemeral_merkle_root(empty.iter());
+    let empty = Hasher::default().digest();
 
-            assert_eq!(public, pk_p);
-        }
-    }
+    assert_eq!(empty, root);
 
-    #[test]
-    fn ephemeral_merkle_root_works() {
-        let mut rng = StdRng::seed_from_u64(2322u64);
+    // Test for 5 leaves
+    let a: Address = rng.gen();
+    let b: Address = rng.gen();
+    let c: Address = rng.gen();
+    let d: Address = rng.gen();
+    let e: Address = rng.gen();
 
-        const LEAF_PREFIX: u8 = 0x00;
-        const NODE_PREFIX: u8 = 0x01;
+    let initial = [a, b, c, d, e];
 
-        // Test for 0 leaves
-        //
-        // Expected root is `h()`
-        let empty: Vec<Address> = vec![];
+    let a = Hasher::default().chain(&[LEAF_PREFIX]).chain(a).digest();
+    let b = Hasher::default().chain(&[LEAF_PREFIX]).chain(b).digest();
+    let c = Hasher::default().chain(&[LEAF_PREFIX]).chain(c).digest();
+    let d = Hasher::default().chain(&[LEAF_PREFIX]).chain(d).digest();
+    let e = Hasher::default().chain(&[LEAF_PREFIX]).chain(e).digest();
 
-        let root = ephemeral_merkle_root(empty.iter());
-        let empty = Hasher::default().digest();
+    let a = Hasher::default().chain(&[NODE_PREFIX]).extend_chain([a, b]).digest();
+    let b = Hasher::default().chain(&[NODE_PREFIX]).extend_chain([c, d]).digest();
+    let c = e;
 
-        assert_eq!(empty, root);
+    let a = Hasher::default().chain(&[NODE_PREFIX]).extend_chain([a, b]).digest();
+    let b = c;
 
-        // Test for 5 leaves
-        let a: Address = rng.gen();
-        let b: Address = rng.gen();
-        let c: Address = rng.gen();
-        let d: Address = rng.gen();
-        let e: Address = rng.gen();
+    let root = Hasher::default().chain(&[NODE_PREFIX]).extend_chain([a, b]).digest();
+    let root_p = ephemeral_merkle_root(initial.iter());
 
-        let initial = [a, b, c, d, e];
-
-        let a = Hasher::default().chain(&[LEAF_PREFIX]).chain(a).digest();
-        let b = Hasher::default().chain(&[LEAF_PREFIX]).chain(b).digest();
-        let c = Hasher::default().chain(&[LEAF_PREFIX]).chain(c).digest();
-        let d = Hasher::default().chain(&[LEAF_PREFIX]).chain(d).digest();
-        let e = Hasher::default().chain(&[LEAF_PREFIX]).chain(e).digest();
-
-        let a = Hasher::default().chain(&[NODE_PREFIX]).extend_chain([a, b]).digest();
-        let b = Hasher::default().chain(&[NODE_PREFIX]).extend_chain([c, d]).digest();
-        let c = e;
-
-        let a = Hasher::default().chain(&[NODE_PREFIX]).extend_chain([a, b]).digest();
-        let b = c;
-
-        let root = Hasher::default().chain(&[NODE_PREFIX]).extend_chain([a, b]).digest();
-        let root_p = ephemeral_merkle_root(initial.iter());
-
-        assert_eq!(root, root_p);
-    }
+    assert_eq!(root, root_p);
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -229,10 +229,6 @@ pub enum BugId {
     ID007,
     ID008,
     ID009,
-    ID010,
-    ID011,
-    ID012,
-    ID013,
 }
 
 /// Traceable bug variants
@@ -252,9 +248,6 @@ pub enum BugVariant {
 
     /// The frame point has overflow
     FramePointerOverflow,
-
-    /// A register overflow
-    CheckedRegisterOverflow,
 }
 
 impl fmt::Display for BugVariant {
@@ -293,13 +286,6 @@ impl fmt::Display for BugVariant {
                 r#"The frame pointer cannot overflow under checked operations.
 
                 This overflow means the registers are corrupted."#
-            ),
-
-            Self::CheckedRegisterOverflow => write!(
-                f,
-                r#"A register was checked and should not overflow.
-
-                This overflow means the registers code is not implemented correctly."#
             ),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -229,6 +229,10 @@ pub enum BugId {
     ID007,
     ID008,
     ID009,
+    ID010,
+    ID011,
+    ID012,
+    ID013,
 }
 
 /// Traceable bug variants
@@ -248,6 +252,9 @@ pub enum BugVariant {
 
     /// The frame point has overflow
     FramePointerOverflow,
+
+    /// A register overflow
+    CheckedRegisterOverflow,
 }
 
 impl fmt::Display for BugVariant {
@@ -286,6 +293,13 @@ impl fmt::Display for BugVariant {
                 r#"The frame pointer cannot overflow under checked operations.
 
                 This overflow means the registers are corrupted."#
+            ),
+
+            Self::CheckedRegisterOverflow => write!(
+                f,
+                r#"A register was checked and should not overflow.
+
+                This overflow means the registers code is not implemented correctly."#
             ),
         }
     }

--- a/src/interpreter/crypto.rs
+++ b/src/interpreter/crypto.rs
@@ -4,7 +4,6 @@ use crate::error::RuntimeError;
 
 use crate::arith::{checked_add_word, checked_sub_word};
 use fuel_asm::PanicReason;
-use fuel_asm::PanicReason::ArithmeticOverflow;
 use fuel_crypto::{Hasher, Message, PublicKey, Signature};
 use fuel_types::{Bytes32, Bytes64, Word};
 

--- a/src/interpreter/crypto.rs
+++ b/src/interpreter/crypto.rs
@@ -1,7 +1,8 @@
 use super::Interpreter;
-use crate::consts::{MEM_MAX_ACCESS_SIZE, VM_MAX_RAM};
+use crate::consts::{MEM_MAX_ACCESS_SIZE, MIN_VM_MAX_RAM_USIZE_MAX, VM_MAX_RAM};
 use crate::error::RuntimeError;
 
+use crate::arith::checked_add_word;
 use fuel_asm::PanicReason;
 use fuel_asm::PanicReason::ArithmeticOverflow;
 use fuel_crypto::{Hasher, Message, PublicKey, Signature};
@@ -9,15 +10,10 @@ use fuel_types::{Bytes32, Bytes64, Word};
 
 impl<S> Interpreter<S> {
     pub(crate) fn ecrecover(&mut self, a: Word, b: Word, c: Word) -> Result<(), RuntimeError> {
-        let bx = b.checked_add(Bytes64::LEN as Word).ok_or_else(|| ArithmeticOverflow)?;
-        let cx = c.checked_add(Bytes32::LEN as Word).ok_or_else(|| ArithmeticOverflow)?;
+        let bx = checked_add_word(b, Bytes64::LEN as Word)?;
+        let cx = checked_add_word(c, Bytes32::LEN as Word)?;
 
-        if a > VM_MAX_RAM - Bytes64::LEN as Word
-            || bx > usize::MAX as Word
-            || bx > VM_MAX_RAM
-            || cx > usize::MAX as Word
-            || cx > VM_MAX_RAM
-        {
+        if a > VM_MAX_RAM - Bytes64::LEN as Word || bx > MIN_VM_MAX_RAM_USIZE_MAX || cx > MIN_VM_MAX_RAM_USIZE_MAX {
             return Err(PanicReason::MemoryOverflow.into());
         }
 
@@ -44,13 +40,9 @@ impl<S> Interpreter<S> {
     pub(crate) fn keccak256(&mut self, a: Word, b: Word, c: Word) -> Result<(), RuntimeError> {
         use sha3::{Digest, Keccak256};
 
-        let bc = b.checked_add(c).ok_or_else(|| ArithmeticOverflow)?;
+        let bc = checked_add_word(b, c)?;
 
-        if a > VM_MAX_RAM - Bytes32::LEN as Word
-            || c > MEM_MAX_ACCESS_SIZE
-            || bc > usize::MAX as Word
-            || bc > VM_MAX_RAM
-        {
+        if a > VM_MAX_RAM - Bytes32::LEN as Word || c > MEM_MAX_ACCESS_SIZE || bc > MIN_VM_MAX_RAM_USIZE_MAX {
             return Err(PanicReason::MemoryOverflow.into());
         }
 
@@ -66,13 +58,9 @@ impl<S> Interpreter<S> {
     }
 
     pub(crate) fn sha256(&mut self, a: Word, b: Word, c: Word) -> Result<(), RuntimeError> {
-        let bc = b.checked_add(c).ok_or_else(|| ArithmeticOverflow)?;
+        let bc = checked_add_word(b, c)?;
 
-        if a > VM_MAX_RAM - Bytes32::LEN as Word
-            || c > MEM_MAX_ACCESS_SIZE
-            || bc > usize::MAX as Word
-            || bc > VM_MAX_RAM
-        {
+        if a > VM_MAX_RAM - Bytes32::LEN as Word || c > MEM_MAX_ACCESS_SIZE || bc > MIN_VM_MAX_RAM_USIZE_MAX {
             return Err(PanicReason::MemoryOverflow.into());
         }
 

--- a/src/interpreter/crypto.rs
+++ b/src/interpreter/crypto.rs
@@ -2,7 +2,7 @@ use super::Interpreter;
 use crate::consts::{MEM_MAX_ACCESS_SIZE, MIN_VM_MAX_RAM_USIZE_MAX, VM_MAX_RAM};
 use crate::error::RuntimeError;
 
-use crate::arith::checked_add_word;
+use crate::arith::{checked_add_word, checked_sub_word};
 use fuel_asm::PanicReason;
 use fuel_asm::PanicReason::ArithmeticOverflow;
 use fuel_crypto::{Hasher, Message, PublicKey, Signature};
@@ -13,7 +13,10 @@ impl<S> Interpreter<S> {
         let bx = checked_add_word(b, Bytes64::LEN as Word)?;
         let cx = checked_add_word(c, Bytes32::LEN as Word)?;
 
-        if a > VM_MAX_RAM - Bytes64::LEN as Word || bx > MIN_VM_MAX_RAM_USIZE_MAX || cx > MIN_VM_MAX_RAM_USIZE_MAX {
+        if a > checked_sub_word(VM_MAX_RAM, Bytes64::LEN as Word)?
+            || bx > MIN_VM_MAX_RAM_USIZE_MAX
+            || cx > MIN_VM_MAX_RAM_USIZE_MAX
+        {
             return Err(PanicReason::MemoryOverflow.into());
         }
 
@@ -42,7 +45,10 @@ impl<S> Interpreter<S> {
 
         let bc = checked_add_word(b, c)?;
 
-        if a > VM_MAX_RAM - Bytes32::LEN as Word || c > MEM_MAX_ACCESS_SIZE || bc > MIN_VM_MAX_RAM_USIZE_MAX {
+        if a > checked_sub_word(VM_MAX_RAM, Bytes32::LEN as Word)?
+            || c > MEM_MAX_ACCESS_SIZE
+            || bc > MIN_VM_MAX_RAM_USIZE_MAX
+        {
             return Err(PanicReason::MemoryOverflow.into());
         }
 
@@ -60,7 +66,10 @@ impl<S> Interpreter<S> {
     pub(crate) fn sha256(&mut self, a: Word, b: Word, c: Word) -> Result<(), RuntimeError> {
         let bc = checked_add_word(b, c)?;
 
-        if a > VM_MAX_RAM - Bytes32::LEN as Word || c > MEM_MAX_ACCESS_SIZE || bc > MIN_VM_MAX_RAM_USIZE_MAX {
+        if a > checked_sub_word(VM_MAX_RAM, Bytes32::LEN as Word)?
+            || c > MEM_MAX_ACCESS_SIZE
+            || bc > MIN_VM_MAX_RAM_USIZE_MAX
+        {
             return Err(PanicReason::MemoryOverflow.into());
         }
 

--- a/src/interpreter/crypto.rs
+++ b/src/interpreter/crypto.rs
@@ -24,8 +24,8 @@ impl<S> Interpreter<S> {
         let message = unsafe { Message::as_ref_unchecked(&self.memory[c..cx]) };
 
         match signature.recover(message) {
-            Ok(public) => {
-                self.try_mem_write(a, public.as_ref())?;
+            Ok(pub_key) => {
+                self.try_mem_write(a, pub_key.as_ref())?;
                 self.clear_err();
             }
             Err(_) => {

--- a/src/interpreter/crypto.rs
+++ b/src/interpreter/crypto.rs
@@ -1,6 +1,6 @@
 use super::Interpreter;
 use crate::consts::{MEM_MAX_ACCESS_SIZE, VM_MAX_RAM};
-use crate::error::RuntimeError;
+use crate::error::{Bug, BugId, BugVariant, RuntimeError};
 
 use fuel_asm::PanicReason;
 use fuel_crypto::{Hasher, Message, PublicKey, Signature};
@@ -8,17 +8,22 @@ use fuel_types::{Bytes32, Bytes64, Word};
 
 impl<S> Interpreter<S> {
     pub(crate) fn ecrecover(&mut self, a: Word, b: Word, c: Word) -> Result<(), RuntimeError> {
-        if a > VM_MAX_RAM.saturating_sub(Bytes64::LEN as Word)
-            || b > VM_MAX_RAM.saturating_sub(Bytes64::LEN as Word)
-            || c > VM_MAX_RAM.saturating_sub(Bytes32::LEN as Word)
+        if a > VM_MAX_RAM - Bytes64::LEN as Word
+            || b > VM_MAX_RAM - Bytes64::LEN as Word
+            || c > VM_MAX_RAM - Bytes32::LEN as Word
         {
             return Err(PanicReason::MemoryOverflow.into());
         }
 
         let (a, b, c) = (a as usize, b as usize, c as usize);
 
-        let bx = b.saturating_add(Bytes64::LEN);
-        let cx = c.saturating_add(Bytes32::LEN);
+        let bx = b
+            .checked_add(Bytes64::LEN)
+            .ok_or_else(|| Bug::new(BugId::ID010, BugVariant::CheckedRegisterOverflow))?;
+
+        let cx = c
+            .checked_add(Bytes32::LEN)
+            .ok_or_else(|| Bug::new(BugId::ID011, BugVariant::CheckedRegisterOverflow))?;
 
         // Safety: memory bounds are checked
         let signature = unsafe { Signature::as_ref_unchecked(&self.memory[b..bx]) };
@@ -41,15 +46,15 @@ impl<S> Interpreter<S> {
     pub(crate) fn keccak256(&mut self, a: Word, b: Word, c: Word) -> Result<(), RuntimeError> {
         use sha3::{Digest, Keccak256};
 
-        if a > VM_MAX_RAM.saturating_sub(Bytes32::LEN as Word)
-            || c > MEM_MAX_ACCESS_SIZE
-            || b > VM_MAX_RAM.saturating_sub(c)
-        {
+        if a > VM_MAX_RAM - Bytes32::LEN as Word || c > MEM_MAX_ACCESS_SIZE || b > VM_MAX_RAM - c {
             return Err(PanicReason::MemoryOverflow.into());
         }
 
         let (a, b, c) = (a as usize, b as usize, c as usize);
-        let bc = b.saturating_add(c);
+
+        let bc = b
+            .checked_add(c)
+            .ok_or_else(|| Bug::new(BugId::ID012, BugVariant::CheckedRegisterOverflow))?;
 
         let mut h = Keccak256::new();
 
@@ -61,15 +66,14 @@ impl<S> Interpreter<S> {
     }
 
     pub(crate) fn sha256(&mut self, a: Word, b: Word, c: Word) -> Result<(), RuntimeError> {
-        if a > VM_MAX_RAM.saturating_sub(Bytes32::LEN as Word)
-            || c > MEM_MAX_ACCESS_SIZE
-            || b > VM_MAX_RAM.saturating_sub(c)
-        {
+        if a > VM_MAX_RAM - Bytes32::LEN as Word || c > MEM_MAX_ACCESS_SIZE || b > VM_MAX_RAM - c {
             return Err(PanicReason::MemoryOverflow.into());
         }
 
         let (a, b, c) = (a as usize, b as usize, c as usize);
-        let bc = b.saturating_add(c);
+        let bc = b
+            .checked_add(c)
+            .ok_or_else(|| Bug::new(BugId::ID013, BugVariant::CheckedRegisterOverflow))?;
 
         self.try_mem_write(a, Hasher::hash(&self.memory[b..bc]).as_ref())?;
 

--- a/src/interpreter/crypto.rs
+++ b/src/interpreter/crypto.rs
@@ -1,37 +1,36 @@
 use super::Interpreter;
 use crate::consts::{MEM_MAX_ACCESS_SIZE, VM_MAX_RAM};
-use crate::crypto;
 use crate::error::RuntimeError;
 
 use fuel_asm::PanicReason;
-use fuel_crypto::Hasher;
+use fuel_crypto::{Hasher, Message, PublicKey, Signature};
 use fuel_types::{Bytes32, Bytes64, Word};
 
 impl<S> Interpreter<S> {
     pub(crate) fn ecrecover(&mut self, a: Word, b: Word, c: Word) -> Result<(), RuntimeError> {
-        if a > VM_MAX_RAM - Bytes64::LEN as Word
-            || b > VM_MAX_RAM - Bytes64::LEN as Word
-            || c > VM_MAX_RAM - Bytes32::LEN as Word
+        if a > VM_MAX_RAM.saturating_sub(Bytes64::LEN as Word)
+            || b > VM_MAX_RAM.saturating_sub(Bytes64::LEN as Word)
+            || c > VM_MAX_RAM.saturating_sub(Bytes32::LEN as Word)
         {
             return Err(PanicReason::MemoryOverflow.into());
         }
 
         let (a, b, c) = (a as usize, b as usize, c as usize);
 
-        let bx = b + Bytes64::LEN;
-        let cx = c + Bytes32::LEN;
+        let bx = b.saturating_add(Bytes64::LEN);
+        let cx = c.saturating_add(Bytes32::LEN);
 
-        let e = &self.memory[c..cx];
-        let sig = &self.memory[b..bx];
+        // Safety: memory bounds are checked
+        let signature = unsafe { Signature::as_ref_unchecked(&self.memory[b..bx]) };
+        let message = unsafe { Message::as_ref_unchecked(&self.memory[c..cx]) };
 
-        match crypto::secp256k1_sign_compact_recover(sig, e) {
-            Ok(pk) => {
-                self.try_mem_write(a, pk.as_ref())?;
+        match signature.recover(message) {
+            Ok(public) => {
+                self.try_mem_write(a, public.as_ref())?;
                 self.clear_err();
             }
-
             Err(_) => {
-                self.try_zeroize(a, Bytes64::LEN)?;
+                self.try_zeroize(a, PublicKey::LEN)?;
                 self.set_err();
             }
         }
@@ -42,12 +41,15 @@ impl<S> Interpreter<S> {
     pub(crate) fn keccak256(&mut self, a: Word, b: Word, c: Word) -> Result<(), RuntimeError> {
         use sha3::{Digest, Keccak256};
 
-        if a > VM_MAX_RAM - Bytes32::LEN as Word || c > MEM_MAX_ACCESS_SIZE || b > VM_MAX_RAM - c {
+        if a > VM_MAX_RAM.saturating_sub(Bytes32::LEN as Word)
+            || c > MEM_MAX_ACCESS_SIZE
+            || b > VM_MAX_RAM.saturating_sub(c)
+        {
             return Err(PanicReason::MemoryOverflow.into());
         }
 
         let (a, b, c) = (a as usize, b as usize, c as usize);
-        let bc = b + c;
+        let bc = b.saturating_add(c);
 
         let mut h = Keccak256::new();
 
@@ -59,12 +61,15 @@ impl<S> Interpreter<S> {
     }
 
     pub(crate) fn sha256(&mut self, a: Word, b: Word, c: Word) -> Result<(), RuntimeError> {
-        if a > VM_MAX_RAM - Bytes32::LEN as Word || c > MEM_MAX_ACCESS_SIZE || b > VM_MAX_RAM - c {
+        if a > VM_MAX_RAM.saturating_sub(Bytes32::LEN as Word)
+            || c > MEM_MAX_ACCESS_SIZE
+            || b > VM_MAX_RAM.saturating_sub(c)
+        {
             return Err(PanicReason::MemoryOverflow.into());
         }
 
         let (a, b, c) = (a as usize, b as usize, c as usize);
-        let bc = b + c;
+        let bc = b.saturating_add(c);
 
         self.try_mem_write(a, Hasher::hash(&self.memory[b..bc]).as_ref())?;
 

--- a/src/interpreter/executors/main.rs
+++ b/src/interpreter/executors/main.rs
@@ -1,9 +1,10 @@
 use crate::consts::*;
+use crate::context::Context;
 use crate::crypto;
-use crate::error::InterpreterError;
+use crate::error::{Bug, BugId, BugVariant, InterpreterError, RuntimeError};
 use crate::interpreter::Interpreter;
 use crate::predicate::RuntimePredicate;
-use crate::prelude::*;
+use crate::state::StateTransition;
 use crate::state::{ExecuteState, ProgramState, StateTransitionRef};
 use crate::storage::{InterpreterStorage, PredicateStorage};
 

--- a/tests/crypto.rs
+++ b/tests/crypto.rs
@@ -56,7 +56,7 @@ fn ecrecover() {
         .finalize_checked(height, &params);
 
     let receipts = client.transact(tx);
-    let success = receipts.iter().any(|r| matches!(r, Receipt::Log{ ra, .. } if ra == &1));
+    let success = receipts.iter().any(|r| matches!(r, Receipt::Log{ ra, .. } if *ra == 1));
 
     assert!(success);
 }
@@ -97,7 +97,7 @@ fn sha256() {
         .finalize_checked(height, &params);
 
     let receipts = client.transact(tx);
-    let success = receipts.iter().any(|r| matches!(r, Receipt::Log{ ra, .. } if ra == &1));
+    let success = receipts.iter().any(|r| matches!(r, Receipt::Log{ ra, .. } if *ra == 1));
 
     assert!(success);
 }
@@ -141,7 +141,7 @@ fn keccak256() {
         .finalize_checked(height, &params);
 
     let receipts = client.transact(tx);
-    let success = receipts.iter().any(|r| matches!(r, Receipt::Log{ ra, .. } if ra == &1));
+    let success = receipts.iter().any(|r| matches!(r, Receipt::Log{ ra, .. } if *ra == 1));
 
     assert!(success);
 }

--- a/tests/crypto.rs
+++ b/tests/crypto.rs
@@ -1,15 +1,17 @@
 use fuel_crypto::Hasher;
-use fuel_vm::consts::*;
-use fuel_vm::crypto;
-use fuel_vm::prelude::*;
+use fuel_tx::TransactionBuilder;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use sha3::{Digest, Keccak256};
 
-use std::str::FromStr;
+use fuel_vm::consts::*;
+use fuel_vm::prelude::*;
 
 #[test]
 fn ecrecover() {
-    use secp256k1::{PublicKey, Secp256k1, SecretKey};
+    let rng = &mut StdRng::seed_from_u64(2322u64);
 
-    let storage = MemoryStorage::default();
+    let mut client = MemoryClient::default();
 
     let gas_price = 0;
     let gas_limit = 1_000_000;
@@ -17,92 +19,51 @@ fn ecrecover() {
     let height = 0;
     let params = ConsensusParameters::default();
 
-    let secp = Secp256k1::new();
-    let secret = SecretKey::from_str("3b940b5586823dfd02ae3b461bb4336b5ecbaefd6627aa922efc048fec0c881c").unwrap();
-    let public = PublicKey::from_secret_key(&secp, &secret).serialize_uncompressed();
-    let public = Bytes64::try_from(&public[1..]).expect("Failed to parse public key!");
+    let secret = SecretKey::random(rng);
+    let public = secret.public_key();
 
     let message = b"The gift of words is the gift of deception and illusion.";
-    let e = Hasher::hash(&message[..]);
-    let sig =
-        crypto::secp256k1_sign_compact_recoverable(secret.as_ref(), e.as_ref()).expect("Failed to generate signature");
+    let message = Message::new(message);
 
-    let alloc = e.len() + sig.len() + public.len() + public.len(); // Computed public key
+    let signature = Signature::sign(&secret, &message);
 
-    let mut script = vec![Opcode::MOVI(0x20, alloc as Immediate18), Opcode::ALOC(0x20)];
+    #[rustfmt::skip]
+    let script = vec![
+        Opcode::gtf(0x20, 0x00, GTFArgs::ScriptData),
+        Opcode::ADDI(0x21, 0x20, signature.as_ref().len() as Immediate12),
+        Opcode::ADDI(0x22, 0x21, message.as_ref().len() as Immediate12),
+        Opcode::MOVI(0x10, PublicKey::LEN as Immediate18),
+        Opcode::ALOC(0x10),
+        Opcode::ADDI(0x11, REG_HP, 1),
+        Opcode::ECR(0x11, 0x20, 0x21),
+        Opcode::MEQ(0x12, 0x22, 0x11, 0x10),
+        Opcode::LOG(0x12, 0x00, 0x00, 0x00),
+        Opcode::RET(REG_ONE),
+    ].into_iter().collect();
 
-    e.iter()
-        .chain(sig.iter())
-        .chain(public.iter())
-        .enumerate()
-        .for_each(|(i, b)| {
-            script.push(Opcode::MOVI(0x21, *b as Immediate18));
-            script.push(Opcode::SB(REG_HP, 0x21, (i + 1) as Immediate12));
-        });
+    let script_data = signature
+        .as_ref()
+        .iter()
+        .copied()
+        .chain(message.as_ref().iter().copied())
+        .chain(public.as_ref().iter().copied())
+        .collect();
 
-    // Set `e` address to 0x30
-    script.push(Opcode::ADDI(0x30, REG_HP, 1));
+    let tx = TransactionBuilder::script(script, script_data)
+        .gas_price(gas_price)
+        .gas_limit(gas_limit)
+        .maturity(maturity)
+        .finalize_checked(height, &params);
 
-    // Set `sig` address to 0x31
-    script.push(Opcode::ADDI(0x31, 0x30, e.len() as Immediate12));
+    let receipts = client.transact(tx);
+    let success = receipts.iter().any(|r| matches!(r, Receipt::Log{ ra, .. } if ra == &1));
 
-    // Set `public` address to 0x32
-    script.push(Opcode::ADDI(0x32, 0x31, sig.len() as Immediate12));
-
-    // Set computed public key address to 0x33
-    script.push(Opcode::ADDI(0x33, 0x32, public.len() as Immediate12));
-
-    // Set public key length to 0x34
-    script.push(Opcode::MOVI(0x34, public.len() as Immediate18));
-
-    // Compute the ECRECOVER
-    // m[computed public key] := ecrecover(sig, e)
-    // r[0x10] := m[public] == m[computed public key]
-    script.push(Opcode::ECR(0x33, 0x31, 0x30));
-    script.push(Opcode::MEQ(0x10, 0x32, 0x33, 0x34));
-    script.push(Opcode::LOG(0x10, 0, 0, 0));
-
-    // Corrupt the signature
-    // m[sig][0] := !m[sig][0]
-    script.push(Opcode::LB(0x10, 0x30, 0));
-    script.push(Opcode::NOT(0x10, 0x10));
-    script.push(Opcode::SB(0x30, 0x10, 0));
-
-    // Compute the corrupted ECRECOVER
-    // m[computed public key] := ecrecover(sig', e)
-    // r[0x10] := m[public] == m[computed public key]
-    script.push(Opcode::ECR(0x33, 0x31, 0x30));
-    script.push(Opcode::MEQ(0x10, 0x32, 0x33, 0x34));
-    script.push(Opcode::LOG(0x10, 0, 0, 0));
-
-    script.push(Opcode::RET(REG_ONE));
-
-    let tx = Transaction::script(
-        gas_price,
-        gas_limit,
-        maturity,
-        script.into_iter().collect(),
-        vec![],
-        vec![],
-        vec![],
-        vec![],
-    )
-    .check(height, &params)
-    .expect("failed to check tx");
-
-    let receipts = Transactor::new(storage, Default::default())
-        .transact(tx)
-        .receipts()
-        .expect("Failed to execute script!")
-        .to_owned();
-
-    assert_eq!(receipts[0].ra().expect("$ra expected in receipt"), 1);
-    assert_eq!(receipts[1].ra().expect("$ra expected in receipt"), 0);
+    assert!(success);
 }
 
 #[test]
 fn sha256() {
-    let storage = MemoryStorage::default();
+    let mut client = MemoryClient::default();
 
     let gas_price = 0;
     let gas_limit = 1_000_000;
@@ -111,85 +72,39 @@ fn sha256() {
     let params = ConsensusParameters::default();
 
     let message = b"I say let the world go to hell, but I should always have my tea.";
-    let length = message.len() as Immediate12;
     let hash = Hasher::hash(message);
 
-    let alloc = length  // message
-        + 32 // reference hash
-        + 32; // computed hash
+    #[rustfmt::skip]
+    let script = vec![
+        Opcode::gtf(0x20, 0x00, GTFArgs::ScriptData),
+        Opcode::ADDI(0x21, 0x20, message.len() as Immediate12),
+        Opcode::MOVI(0x10, Bytes32::LEN as Immediate18),
+        Opcode::ALOC(0x10),
+        Opcode::ADDI(0x11, REG_HP, 1),
+        Opcode::MOVI(0x12, message.len() as Immediate18),
+        Opcode::S256(0x11, 0x20, 0x12),
+        Opcode::MEQ(0x13, 0x11, 0x21, 0x10),
+        Opcode::LOG(0x13, 0x00, 0x00, 0x00),
+        Opcode::RET(REG_ONE),
+    ].into_iter().collect();
 
-    let mut script = vec![Opcode::MOVI(0x20, alloc as Immediate18), Opcode::ALOC(0x20)];
+    let script_data = message.iter().copied().chain(hash.as_ref().iter().copied()).collect();
 
-    message.iter().chain(hash.iter()).enumerate().for_each(|(i, b)| {
-        script.push(Opcode::MOVI(0x21, *b as Immediate18));
-        script.push(Opcode::SB(REG_HP, 0x21, (i + 1) as Immediate12));
-    });
+    let tx = TransactionBuilder::script(script, script_data)
+        .gas_price(gas_price)
+        .gas_limit(gas_limit)
+        .maturity(maturity)
+        .finalize_checked(height, &params);
 
-    // Set message address to 0x30
-    script.push(Opcode::ADDI(0x30, REG_HP, 1));
+    let receipts = client.transact(tx);
+    let success = receipts.iter().any(|r| matches!(r, Receipt::Log{ ra, .. } if ra == &1));
 
-    // Set hash address to 0x31
-    script.push(Opcode::ADDI(0x31, 0x30, length));
-
-    // Set computed hash address to 0x32
-    script.push(Opcode::ADDI(0x32, 0x31, 32));
-
-    // Set message length to 0x33
-    script.push(Opcode::MOVI(0x33, length as Immediate18));
-
-    // Set hash length to 0x34
-    script.push(Opcode::MOVI(0x34, 32));
-
-    // Compute the Keccak256
-    // m[computed hash] := keccack256(m[message, length])
-    // r[0x10] := m[hash] == m[computed hash]
-    script.push(Opcode::S256(0x32, 0x30, 0x33));
-    script.push(Opcode::MEQ(0x10, 0x31, 0x32, 0x34));
-    script.push(Opcode::LOG(0x10, 0, 0, 0));
-
-    // Corrupt the message
-    // m[message][0] := !m[message][0]
-    script.push(Opcode::LB(0x10, 0x30, 0));
-    script.push(Opcode::NOT(0x10, 0x10));
-    script.push(Opcode::SB(0x30, 0x10, 0));
-
-    // Compute the Keccak256
-    // m[computed hash] := keccack256(m[message, length])
-    // r[0x10] := m[hash] == m[computed hash]
-    script.push(Opcode::K256(0x32, 0x30, 0x33));
-    script.push(Opcode::MEQ(0x10, 0x31, 0x32, 0x34));
-    script.push(Opcode::LOG(0x10, 0, 0, 0));
-
-    script.push(Opcode::RET(REG_ONE));
-
-    let tx = Transaction::script(
-        gas_price,
-        gas_limit,
-        maturity,
-        script.into_iter().collect(),
-        vec![],
-        vec![],
-        vec![],
-        vec![],
-    )
-    .check(height, &params)
-    .expect("failed to check tx");
-
-    let receipts = Transactor::new(storage, Default::default())
-        .transact(tx)
-        .receipts()
-        .expect("Failed to execute script!")
-        .to_owned();
-
-    assert_eq!(receipts[0].ra().expect("$ra expected in receipt"), 1);
-    assert_eq!(receipts[1].ra().expect("$ra expected in receipt"), 0);
+    assert!(success);
 }
 
 #[test]
 fn keccak256() {
-    use sha3::{Digest, Keccak256};
-
-    let storage = MemoryStorage::default();
+    let mut client = MemoryClient::default();
 
     let gas_price = 0;
     let gas_limit = 1_000_000;
@@ -198,79 +113,35 @@ fn keccak256() {
     let params = ConsensusParameters::default();
 
     let message = b"...and, moreover, I consider it my duty to warn you that the cat is an ancient, inviolable animal.";
-    let length = message.len() as Immediate12;
 
     let mut hasher = Keccak256::new();
     hasher.update(message);
     let hash = hasher.finalize();
 
-    let alloc = length  // message
-        + 32 // reference hash
-        + 32; // computed hash
+    #[rustfmt::skip]
+    let script = vec![
+        Opcode::gtf(0x20, 0x00, GTFArgs::ScriptData),
+        Opcode::ADDI(0x21, 0x20, message.len() as Immediate12),
+        Opcode::MOVI(0x10, Bytes32::LEN as Immediate18),
+        Opcode::ALOC(0x10),
+        Opcode::ADDI(0x11, REG_HP, 1),
+        Opcode::MOVI(0x12, message.len() as Immediate18),
+        Opcode::K256(0x11, 0x20, 0x12),
+        Opcode::MEQ(0x13, 0x11, 0x21, 0x10),
+        Opcode::LOG(0x13, 0x00, 0x00, 0x00),
+        Opcode::RET(REG_ONE),
+    ].into_iter().collect();
 
-    let mut script = vec![Opcode::MOVI(0x20, alloc as Immediate18), Opcode::ALOC(0x20)];
+    let script_data = message.iter().copied().chain(hash.iter().copied()).collect();
 
-    message.iter().chain(hash.iter()).enumerate().for_each(|(i, b)| {
-        script.push(Opcode::MOVI(0x21, *b as Immediate18));
-        script.push(Opcode::SB(REG_HP, 0x21, (i + 1) as Immediate12));
-    });
+    let tx = TransactionBuilder::script(script, script_data)
+        .gas_price(gas_price)
+        .gas_limit(gas_limit)
+        .maturity(maturity)
+        .finalize_checked(height, &params);
 
-    // Set message address to 0x30
-    script.push(Opcode::ADDI(0x30, REG_HP, 1));
+    let receipts = client.transact(tx);
+    let success = receipts.iter().any(|r| matches!(r, Receipt::Log{ ra, .. } if ra == &1));
 
-    // Set hash address to 0x31
-    script.push(Opcode::ADDI(0x31, 0x30, length));
-
-    // Set computed hash address to 0x32
-    script.push(Opcode::ADDI(0x32, 0x31, 32));
-
-    // Set message length to 0x33
-    script.push(Opcode::MOVI(0x33, length as Immediate18));
-
-    // Set hash length to 0x34
-    script.push(Opcode::MOVI(0x34, 32));
-
-    // Compute the Keccak256
-    // m[computed hash] := keccack256(m[message, length])
-    // r[0x10] := m[hash] == m[computed hash]
-    script.push(Opcode::K256(0x32, 0x30, 0x33));
-    script.push(Opcode::MEQ(0x10, 0x31, 0x32, 0x34));
-    script.push(Opcode::LOG(0x10, 0, 0, 0));
-
-    // Corrupt the message
-    // m[message][0] := !m[message][0]
-    script.push(Opcode::LB(0x10, 0x30, 0));
-    script.push(Opcode::NOT(0x10, 0x10));
-    script.push(Opcode::SB(0x30, 0x10, 0));
-
-    // Compute the Keccak256
-    // m[computed hash] := keccack256(m[message, length])
-    // r[0x10] := m[hash] == m[computed hash]
-    script.push(Opcode::K256(0x32, 0x30, 0x33));
-    script.push(Opcode::MEQ(0x10, 0x31, 0x32, 0x34));
-    script.push(Opcode::LOG(0x10, 0, 0, 0));
-
-    script.push(Opcode::RET(REG_ONE));
-
-    let tx = Transaction::script(
-        gas_price,
-        gas_limit,
-        maturity,
-        script.into_iter().collect(),
-        vec![],
-        vec![],
-        vec![],
-        vec![],
-    )
-    .check(height, &params)
-    .expect("failed to check tx");
-
-    let receipts = Transactor::new(storage, Default::default())
-        .transact(tx)
-        .receipts()
-        .expect("Failed to execute script!")
-        .to_owned();
-
-    assert_eq!(receipts[0].ra().expect("$ra expected in receipt"), 1);
-    assert_eq!(receipts[1].ra().expect("$ra expected in receipt"), 0);
+    assert!(success);
 }


### PR DESCRIPTION
This commit applies safe arithmetic to call and crypto interpreter
modules.

The deprecated implementation of secp256k1 was not using safe
arithmetic. Instead of updating it, the module was deprecated in favor
of fuel-crypto.