### PR TITLE
Remove owner field from MessageInputs 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ description = "FuelVM interpreter."
 anyhow = { version = "1.0", optional = true }
 backtrace = { version = "0.3", optional = true } # requires debug symbols to work
 dyn-clone = { version = "1.0", optional = true }
-fuel-asm = "0.8"
+fuel-asm = "0.9"
 fuel-crypto = "0.6"
 fuel-merkle = "0.3"
 fuel-storage = "0.2"
-fuel-tx = "0.18"
+fuel-tx = "0.19"
 fuel-types = "0.5"
 itertools = "0.10"
 secp256k1 = { version = "0.24", features = ["recovery"] }
@@ -31,7 +31,7 @@ rand = { version = "0.8", optional = true }
 tai64 = "4.0"
 
 [dev-dependencies]
-fuel-tx = { version = "0.18", features = ["builder", "internals"] }
+fuel-tx = { version = "0.19", features = ["builder", "internals"] }
 fuel-vm = { path = ".", default-features = false, features = ["test-helpers"] }
 glob = "0.3"
 regex = "1.6"

--- a/src/interpreter/metadata.rs
+++ b/src/interpreter/metadata.rs
@@ -299,16 +299,6 @@ impl<S> Interpreter<S> {
                 .filter(|i| i.is_message())
                 .and_then(Input::nonce)
                 .ok_or(PanicReason::InputNotFound)?,
-            GTFArgs::InputMessageOwner => {
-                (ofs + tx
-                    .inputs()
-                    .get(b)
-                    .filter(|i| i.is_message())
-                    .map(Input::repr)
-                    .and_then(|r| r.owner_offset())
-                    .and_then(|ofs| tx.input_offset(b).map(|o| o + ofs))
-                    .ok_or(PanicReason::InputNotFound)?) as Word
-            }
             GTFArgs::InputMessageWitnessIndex => tx
                 .inputs()
                 .get(b)

--- a/src/predicate.rs
+++ b/src/predicate.rs
@@ -83,7 +83,6 @@ fn from_tx_works() {
         rng.gen(),
         rng.gen(),
         rng.gen(),
-        owner,
         vec![],
         predicate.clone(),
         predicate_data,

--- a/tests/alu.rs
+++ b/tests/alu.rs
@@ -145,10 +145,8 @@ fn alu_wrapping(
 
     assert_eq!(log_receipt.ra().expect("$ra expected"), expected);
 
-    assert_eq!(
-        log_receipt.rb().expect("$rb (value of REG_OF) expected"),
-        expected_of.try_into().unwrap()
-    );
+    let expected_of: u64 = expected_of.try_into().unwrap();
+    assert_eq!(log_receipt.rb().expect("$rb (value of REG_OF) expected"), expected_of);
 }
 
 fn alu_err(registers_init: &[(RegisterId, Immediate18)], op: Opcode, reg: RegisterId, expected: Word) {

--- a/tests/blockchain.rs
+++ b/tests/blockchain.rs
@@ -490,7 +490,6 @@ fn smo_instruction_works() {
 
         let secret = SecretKey::random(rng);
         let sender = rng.gen();
-        let recipient = rng.gen();
         let nonce = rng.gen();
 
         let message = Output::message(Address::zeroed(), 0);
@@ -512,7 +511,7 @@ fn smo_instruction_works() {
             .gas_price(gas_price)
             .gas_limit(gas_limit)
             .maturity(maturity)
-            .add_unsigned_message_input(secret, sender, recipient, nonce, balance, data)
+            .add_unsigned_message_input(secret, sender, nonce, balance, data)
             .add_output(message)
             .finalize_checked(block_height, params);
 

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -234,10 +234,9 @@ fn get_transaction_fields() {
     let message_predicate = Input::message_predicate(
         rng.gen(),
         rng.gen(),
-        rng.gen(),
+        owner,
         7_500,
         0xdead,
-        owner,
         m_data.clone(),
         m_predicate.clone(),
         m_predicate_data.clone(),
@@ -266,7 +265,6 @@ fn get_transaction_fields() {
         .add_output(Output::contract(contract_input_index, rng.gen(), state_root))
         .add_witness(Witness::from(b"some-data".to_vec()))
         .add_unsigned_message_input(
-            rng.gen(),
             rng.gen(),
             rng.gen(),
             message_nonce,
@@ -306,19 +304,18 @@ fn get_transaction_fields() {
         inputs[2].contract_id().unwrap().to_vec(), // 12 - InputContractId
         inputs[3].message_id().unwrap().to_vec(), // 13 - InputMessageId
         inputs[3].sender().unwrap().to_vec(), // 14 - InputMessageSender
-        inputs[3].recipient().unwrap().to_vec(), // 15 - InputMessageRecipient
-        inputs[3].input_owner().unwrap().to_vec(), // 16 - InputMessageOwner
-        m_data.clone(), // 17 - InputMessageData
-        m_predicate.clone(), // 18 - InputMessagePredicate
-        m_predicate_data.clone(), // 19 - InputMessagePredicateData
-        outputs[2].to().unwrap().to_vec(), // 20 - OutputCoinTo
-        outputs[2].asset_id().unwrap().to_vec(), // 21 - OutputCoinAssetId
-        outputs[1].balance_root().unwrap().to_vec(), // 22 - OutputContractBalanceRoot
-        outputs[1].state_root().unwrap().to_vec(), // 23 - OutputContractStateRoot
-        outputs[3].recipient().unwrap().to_vec(), // 24 - OutputMessageRecipient
-        witnesses[1].as_ref().to_vec(), // 25 - WitnessData
-        inputs[0].tx_pointer().unwrap().clone().to_bytes(), // 26 - InputCoinTxPointer
-        inputs[2].tx_pointer().unwrap().clone().to_bytes(), // 27 - InputContractTxPointer
+        inputs[3].recipient().unwrap().to_vec(), // 15 - InputMessageRecipient        
+        m_data.clone(), // 16 - InputMessageData
+        m_predicate.clone(), // 17 - InputMessagePredicate
+        m_predicate_data.clone(), // 18 - InputMessagePredicateData
+        outputs[2].to().unwrap().to_vec(), // 19 - OutputCoinTo
+        outputs[2].asset_id().unwrap().to_vec(), // 20 - OutputCoinAssetId
+        outputs[1].balance_root().unwrap().to_vec(), // 21 - OutputContractBalanceRoot
+        outputs[1].state_root().unwrap().to_vec(), // 22 - OutputContractStateRoot
+        outputs[3].recipient().unwrap().to_vec(), // 23 - OutputMessageRecipient
+        witnesses[1].as_ref().to_vec(), // 24 - WitnessData
+        inputs[0].tx_pointer().unwrap().clone().to_bytes(), // 25 - InputCoinTxPointer
+        inputs[2].tx_pointer().unwrap().clone().to_bytes(), // 26 - InputContractTxPointer
     ];
 
     // hardcoded metadata of script len so it can be checked at runtime
@@ -589,12 +586,7 @@ fn get_transaction_fields() {
         Opcode::EQ(0x10, 0x10, 0x11),
         Opcode::AND(0x20, 0x20, 0x10),
 
-        Opcode::MOVI(0x19, 0x03),
-        Opcode::gtf(0x10, 0x19, GTFArgs::InputMessageOwner),
-        Opcode::MOVI(0x11, cases[16].len() as Immediate18),
-        Opcode::MEQ(0x10, 0x10, 0x30, 0x11),
-        Opcode::ADD(0x30, 0x30, 0x11),
-        Opcode::AND(0x20, 0x20, 0x10),
+        
 
         Opcode::MOVI(0x11, 0x02),
         Opcode::MOVI(0x19, 0x03),
@@ -622,21 +614,21 @@ fn get_transaction_fields() {
 
         Opcode::MOVI(0x19, 0x04),
         Opcode::gtf(0x10, 0x19, GTFArgs::InputMessageData),
-        Opcode::MOVI(0x11, cases[17].len() as Immediate18),
+        Opcode::MOVI(0x11, cases[16].len() as Immediate18),
         Opcode::MEQ(0x10, 0x10, 0x30, 0x11),
         Opcode::ADD(0x30, 0x30, 0x11),
         Opcode::AND(0x20, 0x20, 0x10),
 
         Opcode::MOVI(0x19, 0x04),
         Opcode::gtf(0x10, 0x19, GTFArgs::InputMessagePredicate),
-        Opcode::MOVI(0x11, cases[18].len() as Immediate18),
+        Opcode::MOVI(0x11, cases[17].len() as Immediate18),
         Opcode::MEQ(0x10, 0x10, 0x30, 0x11),
         Opcode::ADD(0x30, 0x30, 0x11),
         Opcode::AND(0x20, 0x20, 0x10),
 
         Opcode::MOVI(0x19, 0x04),
         Opcode::gtf(0x10, 0x19, GTFArgs::InputMessagePredicateData),
-        Opcode::MOVI(0x11, cases[19].len() as Immediate18),
+        Opcode::MOVI(0x11, cases[18].len() as Immediate18),
         Opcode::MEQ(0x10, 0x10, 0x30, 0x11),
         Opcode::ADD(0x30, 0x30, 0x11),
         Opcode::AND(0x20, 0x20, 0x10),
@@ -649,7 +641,7 @@ fn get_transaction_fields() {
 
         Opcode::MOVI(0x19, 0x02),
         Opcode::gtf(0x10, 0x19, GTFArgs::OutputCoinTo),
-        Opcode::MOVI(0x11, cases[20].len() as Immediate18),
+        Opcode::MOVI(0x11, cases[19].len() as Immediate18),
         Opcode::MEQ(0x10, 0x10, 0x30, 0x11),
         Opcode::ADD(0x30, 0x30, 0x11),
         Opcode::AND(0x20, 0x20, 0x10),
@@ -662,7 +654,7 @@ fn get_transaction_fields() {
 
         Opcode::MOVI(0x19, 0x02),
         Opcode::gtf(0x10, 0x19, GTFArgs::OutputCoinAssetId),
-        Opcode::MOVI(0x11, cases[21].len() as Immediate18),
+        Opcode::MOVI(0x11, cases[20].len() as Immediate18),
         Opcode::MEQ(0x10, 0x10, 0x30, 0x11),
         Opcode::ADD(0x30, 0x30, 0x11),
         Opcode::AND(0x20, 0x20, 0x10),
@@ -681,21 +673,21 @@ fn get_transaction_fields() {
 
         Opcode::MOVI(0x19, 0x01),
         Opcode::gtf(0x10, 0x19, GTFArgs::OutputContractBalanceRoot),
-        Opcode::MOVI(0x11, cases[22].len() as Immediate18),
+        Opcode::MOVI(0x11, cases[21].len() as Immediate18),
         Opcode::MEQ(0x10, 0x10, 0x30, 0x11),
         Opcode::ADD(0x30, 0x30, 0x11),
         Opcode::AND(0x20, 0x20, 0x10),
 
         Opcode::MOVI(0x19, 0x01),
         Opcode::gtf(0x10, 0x19, GTFArgs::OutputContractStateRoot),
-        Opcode::MOVI(0x11, cases[23].len() as Immediate18),
+        Opcode::MOVI(0x11, cases[22].len() as Immediate18),
         Opcode::MEQ(0x10, 0x10, 0x30, 0x11),
         Opcode::ADD(0x30, 0x30, 0x11),
         Opcode::AND(0x20, 0x20, 0x10),
 
         Opcode::MOVI(0x19, 0x03),
         Opcode::gtf(0x10, 0x19, GTFArgs::OutputMessageRecipient),
-        Opcode::MOVI(0x11, cases[24].len() as Immediate18),
+        Opcode::MOVI(0x11, cases[23].len() as Immediate18),
         Opcode::MEQ(0x10, 0x10, 0x30, 0x11),
         Opcode::ADD(0x30, 0x30, 0x11),
         Opcode::AND(0x20, 0x20, 0x10),
@@ -714,21 +706,21 @@ fn get_transaction_fields() {
 
         Opcode::MOVI(0x19, 0x01),
         Opcode::gtf(0x10, 0x19, GTFArgs::WitnessData),
-        Opcode::MOVI(0x11, cases[25].len() as Immediate18),
+        Opcode::MOVI(0x11, cases[24].len() as Immediate18),
         Opcode::MEQ(0x10, 0x10, 0x30, 0x11),
         Opcode::ADD(0x30, 0x30, 0x11),
         Opcode::AND(0x20, 0x20, 0x10),
 
         Opcode::MOVI(0x19, 0),
         Opcode::gtf(0x10, 0x19, GTFArgs::InputCoinTxPointer),
-        Opcode::MOVI(0x11, cases[26].len() as Immediate18),
+        Opcode::MOVI(0x11, cases[25].len() as Immediate18),
         Opcode::MEQ(0x10, 0x10, 0x30, 0x11),
         Opcode::ADD(0x30, 0x30, 0x11),
         Opcode::AND(0x20, 0x20, 0x10),
 
         Opcode::MOVI(0x19, contract_input_index as Immediate18),
         Opcode::gtf(0x10, 0x19, GTFArgs::InputContractTxPointer),
-        Opcode::MOVI(0x11, cases[27].len() as Immediate18),
+        Opcode::MOVI(0x11, cases[26].len() as Immediate18),
         Opcode::MEQ(0x10, 0x10, 0x30, 0x11),
         Opcode::ADD(0x30, 0x30, 0x11),
         Opcode::AND(0x20, 0x20, 0x10),


### PR DESCRIPTION
closes #204 

In order to remove it - I have updated fuel-tx and fuel-asm to latest versions where the `owner` field is already removed.
Then I have updated the code and the tests.