### PR TITLE
Add `Interpreter::prepare_call`

### DIFF
--- a/src/interpreter/flow.rs
+++ b/src/interpreter/flow.rs
@@ -11,7 +11,7 @@ use fuel_tx::{PanicReason, Receipt};
 use fuel_types::bytes::SerializableVec;
 use fuel_types::{AssetId, Bytes32, Word};
 
-use std::cmp;
+use std::{cmp, io};
 
 impl<S> Interpreter<S> {
     pub(crate) fn jump(&mut self, j: Word) -> Result<(), RuntimeError> {
@@ -224,12 +224,31 @@ where
         rc: RegisterId,
         rd: RegisterId,
     ) -> Result<(), RuntimeError> {
-        let (a, b, c, d) = (
-            self.registers[ra],
-            self.registers[rb],
-            self.registers[rc],
-            self.registers[rd],
-        );
+        const M: &'static str = "the provided id is not a valid register";
+
+        let a = self
+            .registers
+            .get(ra)
+            .copied()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, M))?;
+
+        let b = self
+            .registers
+            .get(rb)
+            .copied()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, M))?;
+
+        let c = self
+            .registers
+            .get(rc)
+            .copied()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, M))?;
+
+        let d = self
+            .registers
+            .get(rd)
+            .copied()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, M))?;
 
         self._prepare_call(a, b, c, d)
     }


### PR DESCRIPTION
This commit introduces a function to allow users to simulate a call operation without executing the loaded code/context.

This operation is desirable for bug reproduction or isolated analysis of instruction executions. Prior to this commit, its impossible to execute contract instructions in isolation.

This function is expected by the benchmark so an analysis can be done of the contract operations without the need to correct the results with the call overhead.