### PR TITLE
Add `arith` module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,10 @@ quickcheck_macros = "1.0"
 serde_json = "1.0"
 
 [features]
+default = ["optimized"]
 arbitrary = ["fuel-asm/arbitrary"]
 debug = []
+optimized = []
 profile-gas = ["profile-any"]
 profile-coverage = ["profile-any"]
 profile-any = ["dyn-clone"] # All profiling features should depend on this

--- a/src/arith.rs
+++ b/src/arith.rs
@@ -1,0 +1,75 @@
+//! Arithmetic functions for the Fuel VM
+
+use fuel_asm::{PanicReason, Word};
+
+use crate::error::RuntimeError;
+
+/// Add two unchecked words, returning an error if overflow
+#[inline(always)]
+pub fn checked_add_word(a: Word, b: Word) -> Result<Word, PanicReason> {
+    a.checked_add(b).ok_or(PanicReason::ArithmeticOverflow)
+}
+
+/// Subtract two unchecked words, returning an error if overflow
+#[inline(always)]
+pub fn checked_sub_word(a: Word, b: Word) -> Result<Word, PanicReason> {
+    a.checked_sub(b).ok_or(PanicReason::ArithmeticOverflow)
+}
+
+/// Add two unchecked numbers, returning an error if overflow
+#[inline(always)]
+pub fn checked_add_usize(a: usize, b: usize) -> Result<usize, PanicReason> {
+    a.checked_add(b).ok_or(PanicReason::ArithmeticOverflow)
+}
+
+/// Subtract two unchecked numbers, returning an error if overflow
+#[inline(always)]
+pub fn checked_sub_usize(a: usize, b: usize) -> Result<usize, PanicReason> {
+    a.checked_sub(b).ok_or(PanicReason::ArithmeticOverflow)
+}
+
+/// Add two checked words. Might wrap if overflow
+///
+/// The function is inlined so it will be optimized to `a + b` if `optimized` feature is enabled so
+/// the operation is unchecked.
+///
+/// This should be used in contexts that are checked and guaranteed by the protocol to never
+/// overflow, but then they might due to some bug in the code.
+#[inline(always)]
+pub fn add_word(a: Word, b: Word) -> Result<Word, RuntimeError> {
+    #[cfg(feature = "optimized")]
+    #[allow(clippy::integer_arithmetic)]
+    return Ok(a + b);
+
+    #[cfg(not(feature = "optimized"))]
+    return a
+        .checked_add(b)
+        .ok_or_else(|| RuntimeError::unexpected_behavior("unexpected overflow"));
+}
+
+/// Subtract two checked words. Might wrap if overflow
+///
+/// The function is inlined so it will be optimized to `a + b` if `optimized` feature is enabled so
+/// the operation is unchecked.
+///
+/// This should be used in contexts that are checked and guaranteed by the protocol to never
+/// overflow, but then they might due to some bug in the code.
+#[inline(always)]
+pub fn sub_word(a: Word, b: Word) -> Result<Word, RuntimeError> {
+    #[cfg(feature = "optimized")]
+    #[allow(clippy::integer_arithmetic)]
+    return Ok(a - b);
+
+    #[cfg(not(feature = "optimized"))]
+    return a
+        .checked_sub(b)
+        .ok_or_else(|| RuntimeError::unexpected_behavior("unexpected underflow"));
+}
+
+/// Add two numbers. Should be used only in compile-time evaluations so the code won't compile in
+/// case of unexpected overflow.
+#[inline(always)]
+#[allow(clippy::integer_arithmetic)]
+pub const fn add_usize(a: usize, b: usize) -> usize {
+    a + b
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -153,6 +153,14 @@ impl RuntimeError {
     {
         Self::Halt(e.into())
     }
+
+    /// Unexpected behavior occurred
+    pub fn unexpected_behavior<E>(error: E) -> Self
+    where
+        E: Into<Box<dyn StdError + Send + Sync>>,
+    {
+        Self::Halt(io::Error::new(io::ErrorKind::Other, error))
+    }
 }
 
 impl PartialEq for RuntimeError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![warn(missing_docs)]
 
+pub mod arith;
 pub mod backtrace;
 pub mod call;
 pub mod consts;


### PR DESCRIPTION
This module aims to centralize all arithmetic operations so they can be easily updated whenever required.

It is desirable to run all protocol checked operations as unchecked code, but then it will be feasible only after we have comprehensive test coverage.

Closes #214
Relates to #170