### PR TITLE
Add `InterpreterStorage::deploy_contract`

### DIFF
--- a/src/interpreter/executors/main.rs
+++ b/src/interpreter/executors/main.rs
@@ -100,18 +100,8 @@ where
                 }
 
                 storage
-                    .storage_contract_insert(&id, &contract)
+                    .deploy_contract_with_id(salt, storage_slots, &contract, &root, &id)
                     .map_err(InterpreterError::from_io)?;
-
-                storage
-                    .storage_contract_root_insert(&id, salt, &root)
-                    .map_err(InterpreterError::from_io)?;
-
-                for storage_slot in storage_slots {
-                    storage
-                        .merkle_contract_state_insert(&id, storage_slot.key(), storage_slot.value())
-                        .map_err(InterpreterError::from_io)?;
-                }
 
                 ProgramState::Return(1)
             }


### PR DESCRIPTION
Consumers of the VM might want to replicate the contract deployment also to emulate the behavior of storages.

Currently, the only way to do that is via a `Create` transaction, but then we might want to facilitate this operation without creating the whole transaction requirements in order to allow complex operations such as benchmarking.

This commit introduces the ability to add a contract into an interpreter storage using the same strategy that transaction execution would use. It is added as part of the storage because the responsibility for the implementation is a concrete aspect of the database backend.