### PR TITLE
Append TransferOut receipt for transfer_output

### DIFF
--- a/src/interpreter/contract.rs
+++ b/src/interpreter/contract.rs
@@ -163,6 +163,17 @@ where
 
         self.set_variable_output(out_idx, variable)?;
 
+        let receipt = Receipt::transfer_out(
+            internal_context.unwrap_or_default(),
+            to,
+            amount,
+            asset_id,
+            self.registers[REG_PC],
+            self.registers[REG_IS],
+        );
+
+        self.append_receipt(receipt);
+
         self.inc_pc()
     }
 


### PR DESCRIPTION
Closes #237.

## Changelog
- Adds `TransferOut` receipt to receipt output for `transfer_output()`

## Testing Plan
All tests pass.

(First PR in fuel-vm; let me know if I should do something else)