### PR TITLE
Bump version to `0.19.0` for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-vm"
-version = "0.18.2"
+version = "0.19.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["concurrency", "cryptography::cryptocurrencies", "emulators"]
 edition = "2021"


### PR DESCRIPTION
## What's Changed
* Test safe arithmetic checks in blockchain.rs by @mitch-fuel in https://github.com/FuelLabs/fuel-vm/pull/202
* Apply safe arith to call and crypto by @vlopes11 in https://github.com/FuelLabs/fuel-vm/pull/203
* Tests for Safe Arithmetic Checks in crypto.rs by @mitch-fuel in https://github.com/FuelLabs/fuel-vm/pull/207
* Use common utility functions over duplicate implementation in blockchain.rs by @mitch-fuel in https://github.com/FuelLabs/fuel-vm/pull/224
* Fix bug in `RETD` which throws `MemoryOverflow` for buffers at the very top of RAM. by @otrho in https://github.com/FuelLabs/fuel-vm/pull/229
* Remove transmute by @freesig in https://github.com/FuelLabs/fuel-vm/pull/199
* Add warning comment to gas_cost_const by @freesig in https://github.com/FuelLabs/fuel-vm/pull/198
* Add gas initial costs by @vlopes11 in https://github.com/FuelLabs/fuel-vm/pull/234
* Pass the contract id value to Panic by @Salka1988 in https://github.com/FuelLabs/fuel-vm/pull/233
* Append TransferOut receipt for transfer_output by @deekerno in https://github.com/FuelLabs/fuel-vm/pull/238

## New Contributors
* @otrho made their first contribution in https://github.com/FuelLabs/fuel-vm/pull/229
* @freesig made their first contribution in https://github.com/FuelLabs/fuel-vm/pull/199
* @Salka1988 made their first contribution in https://github.com/FuelLabs/fuel-vm/pull/233
* @deekerno made their first contribution in https://github.com/FuelLabs/fuel-vm/pull/238

**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.18.2...v0.19.0