### PR TITLE
Avoid rounding issues in MLOG instruction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-vm"
-version = "0.18.2"
+version = "0.19.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["concurrency", "cryptography::cryptocurrencies", "emulators"]
 edition = "2021"

--- a/src/interpreter/executors/instruction.rs
+++ b/src/interpreter/executors/instruction.rs
@@ -132,13 +132,7 @@ where
 
             OpcodeRepr::MLOG => {
                 self.gas_charge(GAS_MLOG)?;
-                self.alu_error(
-                    ra,
-                    |b, c| (b as f64).log(c as f64).trunc() as Word,
-                    b,
-                    c,
-                    b == 0 || c <= 1,
-                )?;
+                self.alu_error(ra, |b, c| unchecked_ilog(b, c) as Word, b, c, b == 0 || c <= 1)?;
             }
 
             OpcodeRepr::MOD => {
@@ -493,6 +487,40 @@ where
         }
 
         Ok(ExecuteState::Proceed)
+    }
+}
+
+/// Computes logarithm for given exponent and base.
+/// Diverges when exp == 0 or base <= 1.
+#[inline(always)] // Force copy of each invocation for optimization, see comments below
+const fn _unchecked_ilog_inner(exp: Word, base: Word) -> u32 {
+    let mut n = 0;
+    let mut r = exp;
+    while r >= base {
+        r /= base;
+        n += 1;
+    }
+    return n;
+}
+
+/// Logarithm for given exponent and an arbitrary base, rounded
+/// rounded down to nearest integer value.
+///
+/// Must not be called if the exponent == 0, or if the base <= 1,
+/// as that causes either division by zero, or an infinite loop.
+///
+/// TODO: when https://github.com/rust-lang/rust/issues/70887 is stabilized,
+/// consider using that instead.
+const fn unchecked_ilog(exp: Word, base: Word) -> u32 {
+    // Generate separately optimized paths for some common and/or expensive bases.
+    // See https://github.com/FuelLabs/fuel-vm/issues/150#issuecomment-1288797787 for benchmark.
+    match base {
+        2 => _unchecked_ilog_inner(exp, 2),
+        3 => _unchecked_ilog_inner(exp, 3),
+        4 => _unchecked_ilog_inner(exp, 4),
+        5 => _unchecked_ilog_inner(exp, 5),
+        10 => _unchecked_ilog_inner(exp, 10),
+        n => _unchecked_ilog_inner(exp, n),
     }
 }
 

--- a/src/interpreter/executors/instruction.rs
+++ b/src/interpreter/executors/instruction.rs
@@ -132,7 +132,13 @@ where
 
             OpcodeRepr::MLOG => {
                 self.gas_charge(GAS_MLOG)?;
-                self.alu_error(ra, |b, c| unchecked_ilog(b, c) as Word, b, c, b == 0 || c <= 1)?;
+                self.alu_error(
+                    ra,
+                    |b, c| checked_ilog(b, c).expect("checked_ilog returned None for valid values") as Word,
+                    b,
+                    c,
+                    b == 0 || c <= 1,
+                )?;
             }
 
             OpcodeRepr::MOD => {
@@ -492,6 +498,11 @@ where
 
 /// Computes logarithm for given exponent and base.
 /// Diverges when exp == 0 or base <= 1.
+///
+/// This code is originally from [rust corelib][rust-corelib-impl],
+/// but with all additional clutter removed.
+///
+/// [rust-corelib-impl]: https://github.com/rust-lang/rust/blob/415d8fcc3e17f8c1324a81cf2aa7127b4fcfa32e/library/core/src/num/uint_macros.rs#L774
 #[inline(always)] // Force copy of each invocation for optimization, see comments below
 const fn _unchecked_ilog_inner(exp: Word, base: Word) -> u32 {
     let mut n = 0;
@@ -506,22 +517,25 @@ const fn _unchecked_ilog_inner(exp: Word, base: Word) -> u32 {
 /// Logarithm for given exponent and an arbitrary base, rounded
 /// rounded down to nearest integer value.
 ///
-/// Must not be called if the exponent == 0, or if the base <= 1,
-/// as that causes either division by zero, or an infinite loop.
+/// Returns `None` if the exponent == 0, or if the base <= 1.
 ///
-/// TODO: when https://github.com/rust-lang/rust/issues/70887 is stabilized,
+/// TODO: when <https://github.com/rust-lang/rust/issues/70887> is stabilized,
 /// consider using that instead.
-const fn unchecked_ilog(exp: Word, base: Word) -> u32 {
+const fn checked_ilog(exp: Word, base: Word) -> Option<u32> {
+    if exp <= 0 || base <= 1 {
+        return None;
+    }
+
     // Generate separately optimized paths for some common and/or expensive bases.
-    // See https://github.com/FuelLabs/fuel-vm/issues/150#issuecomment-1288797787 for benchmark.
-    match base {
+    // See <https://github.com/FuelLabs/fuel-vm/issues/150#issuecomment-1288797787> for benchmark.
+    Some(match base {
         2 => _unchecked_ilog_inner(exp, 2),
         3 => _unchecked_ilog_inner(exp, 3),
         4 => _unchecked_ilog_inner(exp, 4),
         5 => _unchecked_ilog_inner(exp, 5),
         10 => _unchecked_ilog_inner(exp, 10),
         n => _unchecked_ilog_inner(exp, n),
-    }
+    })
 }
 
 #[cfg(test)]

--- a/src/interpreter/executors/instruction/tests.rs
+++ b/src/interpreter/executors/instruction/tests.rs
@@ -2,4 +2,5 @@ use super::*;
 use fuel_asm::Opcode;
 use fuel_asm::PanicReason::ReservedRegisterNotWritable;
 
+mod math_operations;
 mod reserved_registers;

--- a/src/interpreter/executors/instruction/tests/math_operations.rs
+++ b/src/interpreter/executors/instruction/tests/math_operations.rs
@@ -1,0 +1,9 @@
+use super::unchecked_ilog;
+
+/// Check for https://github.com/FuelLabs/fuel-vm/issues/150
+#[test]
+fn mlog_rounding_issues() {
+    assert_eq!(unchecked_ilog(999, 10), 2);
+    assert_eq!(unchecked_ilog(1000, 10), 3);
+    assert_eq!(unchecked_ilog(1001, 10), 3);
+}

--- a/src/interpreter/executors/instruction/tests/math_operations.rs
+++ b/src/interpreter/executors/instruction/tests/math_operations.rs
@@ -1,9 +1,9 @@
-use super::unchecked_ilog;
+use super::checked_ilog;
 
 /// Check for https://github.com/FuelLabs/fuel-vm/issues/150
 #[test]
 fn mlog_rounding_issues() {
-    assert_eq!(unchecked_ilog(999, 10), 2);
-    assert_eq!(unchecked_ilog(1000, 10), 3);
-    assert_eq!(unchecked_ilog(1001, 10), 3);
+    assert_eq!(checked_ilog(999, 10), Some(2));
+    assert_eq!(checked_ilog(1000, 10), Some(3));
+    assert_eq!(checked_ilog(1001, 10), Some(3));
 }


### PR DESCRIPTION
Closes #150.

See https://github.com/FuelLabs/fuel-vm/issues/150#issuecomment-1288797787 for detailed explanation and benchmark.

This is a minor breaking change: it fixes a bug, but it's unlikely that anything is depending on the broken behavior.

This contains a performance regression, but correctness is more important here. ~~In any case, this has to be benchmarked and gas cost adjusted.~~ Initial benchmarking shows no significant impact. Either the benchmark needs to be changed to add the edge cases, or the pricing is good enough already.