### PR TITLE
Support `Mint` transaction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,4 +111,4 @@ path = "tests/predicate.rs"
 required-features = ["random"]
 
 [patch.crates-io]
-fuel-tx = { git = "https://github.com/FuelLabs/fuel-tx/" }
+fuel-tx = { git = "https://github.com/FuelLabs/fuel-tx/", branch = "feature/mint-transaction-2" }


### PR DESCRIPTION
After refactoring https://github.com/FuelLabs/fuel-vm/pull/235 we need to do nothing to support `Mint`.

Close https://github.com/FuelLabs/fuel-vm/issues/225