### PR TITLE
State Range Ops on InterpreterStorage trait

### DIFF
--- a/src/storage/interpreter.rs
+++ b/src/storage/interpreter.rs
@@ -138,7 +138,8 @@ pub trait InterpreterStorage:
     }
 
     /// Fetch a range of values from a key-value mapping in a contract storage.
-    /// Returns None if any of the slots in the range are unset.
+    /// Returns the full range requested using optional values in case
+    /// that a particular storage slot is unset.  
     fn merkle_contract_state_range(
         &self,
         id: &ContractId,

--- a/src/storage/interpreter.rs
+++ b/src/storage/interpreter.rs
@@ -8,7 +8,7 @@ use crate::storage::{ContractsAssets, ContractsInfo, ContractsRawCode, Contracts
 use std::borrow::Cow;
 use std::error::Error as StdError;
 use std::io;
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 
 /// When this trait is implemented, the underlying interpreter is guaranteed to
 /// have full functionality
@@ -144,10 +144,8 @@ pub trait InterpreterStorage:
         &self,
         id: &ContractId,
         start_key: &Bytes32,
-        #[allow(unused)] range: Word,
-    ) -> Result<Vec<Option<Cow<Bytes32>>>, Self::DataError> {
-        self.storage::<ContractsState>().get(&(id, start_key)).map(|v| vec![v])
-    }
+        range: Word,
+    ) -> Result<&[Option<Cow<Bytes32>>], Self::DataError>;
 
     /// Insert a range of key-value mappings into contract storage.
     /// Returns None if any of the keys in the range were previously unset.
@@ -155,13 +153,8 @@ pub trait InterpreterStorage:
         &mut self,
         contract: &ContractId,
         start_key: &Bytes32,
-        #[allow(unused)] range: Word,
-        value: &[Bytes32],
-    ) -> Result<Option<()>, Self::DataError> {
-        self.storage::<ContractsState>()
-            .insert(&(contract, start_key), &value[0])
-            .map(|v| v.map(|_| ()))
-    }
+        values: &[Bytes32],
+    ) -> Result<Option<()>, Self::DataError>;
 
     /// Remove a range of key-values from contract storage.
     /// Returns None if any of the keys in the range were already unset.
@@ -169,12 +162,8 @@ pub trait InterpreterStorage:
         &mut self,
         contract: &ContractId,
         start_key: &Bytes32,
-        #[allow(unused)] range: Word,
-    ) -> Result<Option<()>, Self::DataError> {
-        self.storage::<ContractsState>()
-            .remove(&(contract, start_key))
-            .map(|v| v.map(|_| ()))
-    }
+        range: Word,
+    ) -> Result<Option<()>, Self::DataError>;
 
     /// Fetch the balance of an asset ID in a contract storage.
     fn merkle_contract_asset_id_balance(
@@ -221,5 +210,32 @@ where
 
     fn coinbase(&self) -> Result<Address, Self::DataError> {
         <S as InterpreterStorage>::coinbase(self.deref())
+    }
+
+    fn merkle_contract_state_range(
+        &self,
+        id: &ContractId,
+        start_key: &Bytes32,
+        range: Word,
+    ) -> Result<&[Option<Cow<Bytes32>>], Self::DataError> {
+        <S as InterpreterStorage>::merkle_contract_state_range(self.deref(), id, start_key, range)
+    }
+
+    fn merkle_contract_state_insert_range(
+        &mut self,
+        contract: &ContractId,
+        start_key: &Bytes32,
+        values: &[Bytes32],
+    ) -> Result<Option<()>, Self::DataError> {
+        <S as InterpreterStorage>::merkle_contract_state_insert_range(self.deref_mut(), contract, start_key, values)
+    }
+
+    fn merkle_contract_state_remove_range(
+        &mut self,
+        contract: &ContractId,
+        start_key: &Bytes32,
+        range: Word,
+    ) -> Result<Option<()>, Self::DataError> {
+        <S as InterpreterStorage>::merkle_contract_state_remove_range(self.deref_mut(), contract, start_key, range)
     }
 }

--- a/src/storage/interpreter.rs
+++ b/src/storage/interpreter.rs
@@ -145,7 +145,7 @@ pub trait InterpreterStorage:
         id: &ContractId,
         start_key: &Bytes32,
         range: Word,
-    ) -> Result<&[Option<Cow<Bytes32>>], Self::DataError>;
+    ) -> Result<Vec<Option<Cow<Bytes32>>>, Self::DataError>;
 
     /// Insert a range of key-value mappings into contract storage.
     /// Returns None if any of the keys in the range were previously unset.

--- a/src/storage/interpreter.rs
+++ b/src/storage/interpreter.rs
@@ -138,6 +138,7 @@ pub trait InterpreterStorage:
     }
 
     /// Fetch a range of values from a key-value mapping in a contract storage.
+    /// Returns None if any of the slots in the range are unset.
     fn merkle_contract_state_range(
         &self,
         id: &ContractId,

--- a/src/storage/interpreter.rs
+++ b/src/storage/interpreter.rs
@@ -137,6 +137,43 @@ pub trait InterpreterStorage:
         self.storage::<ContractsState>().remove(&(contract, key))
     }
 
+    /// Fetch a range of values from a key-value mapping in a contract storage.
+    fn merkle_contract_state_range(
+        &self,
+        id: &ContractId,
+        start_key: &Bytes32,
+        #[allow(unused)] range: Word,
+    ) -> Result<Vec<Option<Cow<Bytes32>>>, Self::DataError> {
+        self.storage::<ContractsState>().get(&(id, start_key)).map(|v| vec![v])
+    }
+
+    /// Insert a range of key-value mappings into contract storage.
+    /// Returns None if any of the keys in the range were previously unset.
+    fn merkle_contract_state_insert_range(
+        &mut self,
+        contract: &ContractId,
+        start_key: &Bytes32,
+        #[allow(unused)] range: Word,
+        value: &[Bytes32],
+    ) -> Result<Option<()>, Self::DataError> {
+        self.storage::<ContractsState>()
+            .insert(&(contract, start_key), &value[0])
+            .map(|v| v.map(|_| ()))
+    }
+
+    /// Remove a range of key-values from contract storage.
+    /// Returns None if any of the keys in the range were already unset.
+    fn merkle_contract_state_remove_range(
+        &mut self,
+        contract: &ContractId,
+        start_key: &Bytes32,
+        #[allow(unused)] range: Word,
+    ) -> Result<Option<()>, Self::DataError> {
+        self.storage::<ContractsState>()
+            .remove(&(contract, start_key))
+            .map(|v| v.map(|_| ()))
+    }
+
     /// Fetch the balance of an asset ID in a contract storage.
     fn merkle_contract_asset_id_balance(
         &self,

--- a/src/storage/interpreter.rs
+++ b/src/storage/interpreter.rs
@@ -217,7 +217,7 @@ where
         id: &ContractId,
         start_key: &Bytes32,
         range: Word,
-    ) -> Result<&[Option<Cow<Bytes32>>], Self::DataError> {
+    ) -> Result<Vec<Option<Cow<Bytes32>>>, Self::DataError> {
         <S as InterpreterStorage>::merkle_contract_state_range(self.deref(), id, start_key, range)
     }
 

--- a/src/storage/interpreter.rs
+++ b/src/storage/interpreter.rs
@@ -139,7 +139,7 @@ pub trait InterpreterStorage:
 
     /// Fetch a range of values from a key-value mapping in a contract storage.
     /// Returns the full range requested using optional values in case
-    /// that a particular storage slot is unset.  
+    /// a requested slot is unset.  
     fn merkle_contract_state_range(
         &self,
         id: &ContractId,

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -250,4 +250,31 @@ impl InterpreterStorage for MemoryStorage {
     fn coinbase(&self) -> Result<Address, Infallible> {
         Ok(self.coinbase)
     }
+
+    fn merkle_contract_state_range(
+        &self,
+        _id: &ContractId,
+        _start_key: &Bytes32,
+        _range: Word,
+    ) -> Result<&[Option<Cow<Bytes32>>], Self::DataError> {
+        unimplemented!()
+    }
+
+    fn merkle_contract_state_insert_range(
+        &mut self,
+        _contract: &ContractId,
+        _start_key: &Bytes32,
+        _values: &[Bytes32],
+    ) -> Result<Option<()>, Self::DataError> {
+        unimplemented!()
+    }
+
+    fn merkle_contract_state_remove_range(
+        &mut self,
+        _contract: &ContractId,
+        _start_key: &Bytes32,
+        _range: Word,
+    ) -> Result<Option<()>, Self::DataError> {
+        unimplemented!()
+    }
 }

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -256,7 +256,7 @@ impl InterpreterStorage for MemoryStorage {
         _id: &ContractId,
         _start_key: &Bytes32,
         _range: Word,
-    ) -> Result<&[Option<Cow<Bytes32>>], Self::DataError> {
+    ) -> Result<Vec<Option<Cow<Bytes32>>>, Self::DataError> {
         unimplemented!()
     }
 

--- a/src/storage/predicate.rs
+++ b/src/storage/predicate.rs
@@ -5,7 +5,7 @@ use crate::storage::InterpreterStorage;
 
 use fuel_asm::Word;
 use fuel_storage::{Mappable, MerkleRoot, MerkleRootStorage, StorageInspect, StorageMutate};
-use fuel_types::{Address, Bytes32};
+use fuel_types::{Address, Bytes32, ContractId};
 
 /// No-op storage used for predicate operations.
 ///
@@ -63,6 +63,33 @@ impl InterpreterStorage for PredicateStorage {
     }
 
     fn coinbase(&self) -> Result<Address, InterpreterError> {
+        Err(InterpreterError::PredicateFailure)
+    }
+
+    fn merkle_contract_state_range(
+        &self,
+        _id: &ContractId,
+        _start_key: &Bytes32,
+        _range: Word,
+    ) -> Result<&[Option<Cow<Bytes32>>], Self::DataError> {
+        Err(InterpreterError::PredicateFailure)
+    }
+
+    fn merkle_contract_state_insert_range(
+        &mut self,
+        _contract: &ContractId,
+        _start_key: &Bytes32,
+        _values: &[Bytes32],
+    ) -> Result<Option<()>, Self::DataError> {
+        Err(InterpreterError::PredicateFailure)
+    }
+
+    fn merkle_contract_state_remove_range(
+        &mut self,
+        _contract: &ContractId,
+        _start_key: &Bytes32,
+        _range: Word,
+    ) -> Result<Option<()>, Self::DataError> {
         Err(InterpreterError::PredicateFailure)
     }
 }

--- a/src/storage/predicate.rs
+++ b/src/storage/predicate.rs
@@ -71,7 +71,7 @@ impl InterpreterStorage for PredicateStorage {
         _id: &ContractId,
         _start_key: &Bytes32,
         _range: Word,
-    ) -> Result<&[Option<Cow<Bytes32>>], Self::DataError> {
+    ) -> Result<Vec<Option<Cow<Bytes32>>>, Self::DataError> {
         Err(InterpreterError::PredicateFailure)
     }
 


### PR DESCRIPTION
add breaking interface changes now so we can patch in range functionality later without breaking version changes. 

This is in support of https://github.com/FuelLabs/fuel-specs/pull/414