### PR TITLE
Added a temporary field used by `Receipt::Panic` to fill `contract_id` if any

### DIFF
--- a/src/interpreter/constructors.rs
+++ b/src/interpreter/constructors.rs
@@ -3,6 +3,7 @@
 use super::{ExecutableTransaction, Interpreter, RuntimeBalances};
 use crate::consts::*;
 use crate::context::Context;
+use crate::interpreter::PanicContext;
 use crate::state::Debugger;
 use crate::storage::MemoryStorage;
 
@@ -35,6 +36,7 @@ where
             #[cfg(feature = "profile-any")]
             profiler: Profiler::default(),
             params,
+            panic_context: PanicContext::None,
         }
     }
 

--- a/src/interpreter/contract.rs
+++ b/src/interpreter/contract.rs
@@ -1,6 +1,7 @@
 use super::{ExecutableTransaction, Interpreter};
 use crate::consts::*;
 use crate::error::RuntimeError;
+use crate::interpreter::PanicContext;
 use crate::storage::InterpreterStorage;
 
 use fuel_asm::{PanicReason, RegisterId, Word};
@@ -45,6 +46,7 @@ where
         let contract = unsafe { ContractId::as_ref_unchecked(&self.memory[c..cx]) };
 
         if !self.transaction().input_contracts().any(|input| contract == input) {
+            self.panic_context = PanicContext::ContractId(contract.clone());
             return Err(PanicReason::ContractNotInInputs.into());
         }
 
@@ -81,6 +83,7 @@ where
             .input_contracts()
             .any(|contract| &destination == contract)
         {
+            self.panic_context = PanicContext::ContractId(destination);
             return Err(PanicReason::ContractNotInInputs.into());
         }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -409,7 +409,13 @@ pub mod test_helpers {
     ) {
         let receipts = client.transact(checked_tx);
 
-        if let Receipt::Panic { id: _, reason, .. } = receipts.get(0).expect("No receipt") {
+        if let Receipt::Panic {
+            id: _,
+            reason,
+            contract_id,
+            ..
+        } = receipts.get(0).expect("No receipt")
+        {
             assert_eq!(
                 &expected_reason,
                 reason.reason(),
@@ -417,6 +423,10 @@ pub mod test_helpers {
                 expected_reason,
                 reason.reason()
             );
+            match expected_reason {
+                PanicReason::ContractNotInInputs => assert!(contract_id.is_some()),
+                _ => {}
+            };
         } else {
             panic!("Script should have panicked");
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -409,13 +409,7 @@ pub mod test_helpers {
     ) {
         let receipts = client.transact(checked_tx);
 
-        if let Receipt::Panic {
-            id: _,
-            reason,
-            contract_id,
-            ..
-        } = receipts.get(0).expect("No receipt")
-        {
+        if let Receipt::Panic { id: _, reason, .. } = receipts.get(0).expect("No receipt") {
             assert_eq!(
                 &expected_reason,
                 reason.reason(),
@@ -423,13 +417,6 @@ pub mod test_helpers {
                 expected_reason,
                 reason.reason()
             );
-            match expected_reason {
-                PanicReason::ContractNotInInputs => {
-                    assert!(contract_id.is_some());
-                    assert_ne!(contract_id.unwrap(), ContractId::zeroed());
-                }
-                _ => {}
-            };
         } else {
             panic!("Script should have panicked");
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -424,7 +424,10 @@ pub mod test_helpers {
                 reason.reason()
             );
             match expected_reason {
-                PanicReason::ContractNotInInputs => assert!(contract_id.is_some()),
+                PanicReason::ContractNotInInputs => {
+                    assert!(contract_id.is_some());
+                    assert_ne!(contract_id.unwrap(), ContractId::zeroed());
+                }
                 _ => {}
             };
         } else {


### PR DESCRIPTION
Fix for https://github.com/FuelLabs/fuel-vm/pull/255 and https://github.com/FuelLabs/fuel-vm/pull/233