### PR TITLE
Fix bug in load byte

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,3 +111,8 @@ required-features = ["random"]
 name = "test-predicate"
 path = "tests/predicate.rs"
 required-features = ["random"]
+
+[[test]]
+name = "test-memory"
+path = "tests/memory.rs"
+required-features = ["random"]

--- a/src/interpreter/executors/instruction.rs
+++ b/src/interpreter/executors/instruction.rs
@@ -308,7 +308,7 @@ where
 
             OpcodeRepr::LB => {
                 self.gas_charge(GAS_LB)?;
-                self.load_byte(ra, rb, imm)?;
+                self.load_byte(ra, b, imm)?;
             }
 
             OpcodeRepr::LW => {

--- a/src/interpreter/memory.rs
+++ b/src/interpreter/memory.rs
@@ -301,10 +301,10 @@ where
         }
     }
 
-    pub(crate) fn load_byte(&mut self, ra: RegisterId, b: RegisterId, c: Word) -> Result<(), RuntimeError> {
+    pub(crate) fn load_byte(&mut self, ra: RegisterId, b: Word, c: Word) -> Result<(), RuntimeError> {
         Self::is_register_writable(ra)?;
 
-        let bc = b.saturating_add(c as RegisterId);
+        let bc = b.saturating_add(c) as usize;
 
         if bc >= VM_MAX_RAM as RegisterId {
             Err(PanicReason::MemoryOverflow.into())

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -1,0 +1,56 @@
+use fuel_vm::consts::*;
+use fuel_vm::prelude::*;
+
+fn setup(ops: Vec<Opcode>) -> Transactor<MemoryStorage, Script> {
+    let storage = MemoryStorage::default();
+
+    let gas_price = 0;
+    let gas_limit = 1_000_000;
+    let maturity = 0;
+    let height = 0;
+    let params = ConsensusParameters::default();
+
+    let script = ops.into_iter().collect();
+
+    let tx = Transaction::script(gas_price, gas_limit, maturity, script, vec![], vec![], vec![], vec![])
+        .into_checked(height, &params)
+        .expect("failed to check tx");
+
+    let mut vm = Transactor::new(storage, Default::default());
+    vm.transact(tx);
+    vm
+}
+
+#[test]
+fn test_lw() {
+    let ops = vec![
+        Opcode::MOVI(0x10, 8),
+        Opcode::MOVI(0x11, 1),
+        Opcode::ALOC(0x10),
+        Opcode::ADDI(0x10, REG_HP, 1),
+        Opcode::SW(0x10, 0x11, 0),
+        Opcode::LW(0x13, 0x10, 0),
+        Opcode::RET(REG_ONE),
+    ];
+    let vm = setup(ops);
+    let vm: &Interpreter<MemoryStorage, Script> = vm.as_ref();
+    let result = vm.registers()[0x13 as usize];
+    assert_eq!(1, result);
+}
+
+#[test]
+fn test_lb() {
+    let ops = vec![
+        Opcode::MOVI(0x10, 8),
+        Opcode::MOVI(0x11, 1),
+        Opcode::ALOC(0x10),
+        Opcode::ADDI(0x10, REG_HP, 1),
+        Opcode::SB(0x10, 0x11, 0),
+        Opcode::LB(0x13, 0x10, 0),
+        Opcode::RET(REG_ONE),
+    ];
+    let vm = setup(ops);
+    let vm: &Interpreter<MemoryStorage, Script> = vm.as_ref();
+    let result = vm.registers()[0x13 as usize] as u8;
+    assert_eq!(1, result);
+}


### PR DESCRIPTION
fixes https://github.com/FuelLabs/sway/issues/3436
Load byte was using the `RegisterId` instead of the actual registers value as the memory offset.