### PR TITLE
Avoid cloning and deserializing contract code

### DIFF
--- a/src/interpreter/blockchain.rs
+++ b/src/interpreter/blockchain.rs
@@ -103,7 +103,7 @@ where
 
         // update frame pointer, if we have a stack frame (e.g. fp > 0)
         if fp > 0 {
-            let fpx = add_usize(fp, CallFrame::code_size_offset());
+            let fpx = add_usize(fp, CallFrame::len());
 
             self.memory[fp..fpx].copy_from_slice(&length.to_be_bytes());
         }

--- a/src/interpreter/frame.rs
+++ b/src/interpreter/frame.rs
@@ -13,10 +13,9 @@ where
     pub(crate) fn call_frame(&self, call: Call, asset_id: AssetId) -> Result<CallFrame, RuntimeError> {
         let (to, a, b) = call.into_inner();
 
-        let code = self.contract(&to)?.into_owned();
         let registers = self.registers;
 
-        let frame = CallFrame::new(to, asset_id, registers, a, b, code);
+        let frame = CallFrame::new(to, asset_id, registers, a, b);
 
         Ok(frame)
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -22,6 +22,29 @@ impl Mappable for ContractsRawCode {
     type GetValue = Contract;
 }
 
+/// A trait that allows reading contract code directly into
+/// a memory buffer and avoid serialization.
+pub trait ReadContractBytes {
+    /// The error that can be returned if
+    /// the read fails.
+    type Error: std::fmt::Debug;
+
+    /// Read the contract word aligned bytes into the given buffer.
+    /// Returns `None` if the [`ContractId`] is not found.
+    /// Returns the number of bytes read into the buffer.
+    fn read_contract_bytes(&self, key: &ContractId, buf: &mut [u8]) -> Result<Option<usize>, Self::Error>;
+}
+
+impl<S> ReadContractBytes for &mut S
+where
+    S: ReadContractBytes,
+{
+    type Error = S::Error;
+
+    fn read_contract_bytes(&self, key: &ContractId, buf: &mut [u8]) -> Result<Option<usize>, Self::Error> {
+        (**self).read_contract_bytes(key, buf)
+    }
+}
 /// The storage table for contract's additional information as salt, root hash, etc.
 pub struct ContractsInfo;
 

--- a/src/storage/interpreter.rs
+++ b/src/storage/interpreter.rs
@@ -10,6 +10,8 @@ use std::error::Error as StdError;
 use std::io;
 use std::ops::{Deref, DerefMut};
 
+use super::ReadContractBytes;
+
 /// When this trait is implemented, the underlying interpreter is guaranteed to
 /// have full functionality
 pub trait InterpreterStorage:
@@ -17,6 +19,7 @@ pub trait InterpreterStorage:
     + StorageMutate<ContractsInfo, Error = Self::DataError>
     + for<'a> MerkleRootStorage<ContractId, ContractsAssets<'a>, Error = Self::DataError>
     + for<'a> MerkleRootStorage<ContractId, ContractsState<'a>, Error = Self::DataError>
+    + ReadContractBytes
     + Sized
 {
     /// Error implementation for reasons unspecified in the protocol.

--- a/src/storage/predicate.rs
+++ b/src/storage/predicate.rs
@@ -7,6 +7,8 @@ use fuel_asm::Word;
 use fuel_storage::{Mappable, MerkleRoot, MerkleRootStorage, StorageInspect, StorageMutate};
 use fuel_types::{Address, Bytes32, ContractId};
 
+use super::ReadContractBytes;
+
 /// No-op storage used for predicate operations.
 ///
 /// The storage implementations are expected to provide KV-like operations for contract operations.
@@ -43,6 +45,14 @@ impl<Type: Mappable> StorageMutate<Type> for PredicateStorage {
 
 impl<Key, Type: Mappable> MerkleRootStorage<Key, Type> for PredicateStorage {
     fn root(&mut self, _parent: &Key) -> Result<MerkleRoot, InterpreterError> {
+        Err(InterpreterError::PredicateFailure)
+    }
+}
+
+impl ReadContractBytes for PredicateStorage {
+    type Error = InterpreterError;
+
+    fn read_contract_bytes(&self, _key: &ContractId, _buf: &mut [u8]) -> Result<Option<usize>, Self::Error> {
         Err(InterpreterError::PredicateFailure)
     }
 }

--- a/tests/encoding.rs
+++ b/tests/encoding.rs
@@ -77,7 +77,6 @@ fn call_frame() {
                     [rng.gen(); VM_REGISTER_COUNT],
                     rng.gen(),
                     rng.gen(),
-                    vec![rng.gen(); 200].into(),
                 )
             })
             .collect::<Vec<CallFrame>>()

--- a/tests/flow.rs
+++ b/tests/flow.rs
@@ -306,10 +306,9 @@ fn call_frame_code_offset() {
     vm.transact(script).expect("Failed to call deployed contract");
 
     let asset_id = AssetId::default();
-    let contract = Contract::from(program.as_ref());
 
-    let mut frame = CallFrame::new(id, asset_id, [0; VM_REGISTER_COUNT], 0, 0, contract);
-    let stack = frame.to_bytes().len() as Word;
+    let mut frame = CallFrame::new(id, asset_id, [0; VM_REGISTER_COUNT], 0, 0);
+    let stack = (frame.to_bytes().len() + WORD_SIZE + program.len()) as Word;
 
     let receipts = vm.receipts();
 


### PR DESCRIPTION
This PR allows the contract code to be copied directly to the vm memory which also avoid needless serialization. This is a substantial saving for the `Call` op. This PR will need to be merged and released together with an accompanying PR on fuel-core so I am marking this as a draft even though it's ready for review.