### PR TITLE
Include the `fuel-crypto` repo in the great "Summon the MonoRepo" merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           - command: check
             args: --all-targets --all-features
           - command: check
-            args: --verbose -p fuel-asm -p fuel-storage --target thumbv6m-none-eabi --no-default-features
+            args: --target thumbv6m-none-eabi -p fuel-asm -p fuel-storage --no-default-features
           - command: test
             args: --all-targets --all-features
           - command: test
@@ -59,6 +59,23 @@ jobs:
         with:
           command: ${{ matrix.command }}
           args: ${{ matrix.args }}
+
+  # We include this in its own job as we are unable to specify multiple targets
+  # using `actions-rs/toolchain@v1`. See this issue:
+  # https://github.com/actions-rs/toolchain/issues/165
+  cargo-check-wasm32:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+      - name: cargo check wasm32
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --target wasm32-unknown-unknown -p fuel-crypto --no-default-features
 
   cargo-toml-fmt-check:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "fuel-asm",
+    "fuel-crypto",
     "fuel-storage",
     "fuel-types",
     "fuel-tx",
@@ -8,10 +9,3 @@ members = [
     "fuel-types",
     "fuel-vm",
 ]
-
-# We have a dependency cycle between repositories where `fuel-crypto` depends
-# on `fuel-types`, while `fuel-tx` depends on both `fuel-crypto` and
-# `fuel-types`. This temporarily works around the issue by forcing all
-# instances of `fuel-types` within the graph to point to our local copy.
-[patch.crates-io]
-fuel-types = { path = "./fuel-types" }

--- a/fuel-crypto/Cargo.toml
+++ b/fuel-crypto/Cargo.toml
@@ -1,0 +1,73 @@
+[package]
+name = "fuel-crypto"
+version = "0.6.2"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+categories = ["cryptography::cryptocurrencies", "data-structures"]
+edition = "2021"
+homepage = "https://fuel.network/"
+keywords = ["blockchain", "cryptocurrencies"]
+license = "Apache-2.0"
+repository = "https://github.com/FuelLabs/fuel-crypto"
+description = "Fuel cryptographic primitives."
+
+[dependencies]
+borrown = "0.1"
+coins-bip32 = { version = "0.7", default-features = false, optional = true }
+coins-bip39 = { version = "0.7", default-features = false, optional = true }
+fuel-types = { version = "0.5", default-features = false }
+lazy_static = { version = "1.4", optional = true }
+rand = { version = "0.8", default-features = false, optional = true }
+secp256k1 = { version = "0.24", default-features = false, features = ["recovery"], optional = true }
+serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
+sha2 = { version = "0.10", default-features = false }
+zeroize = { version = "1.5", features = ["derive"] }
+
+[dev-dependencies]
+bincode = { version = "1.3", default-features = false }
+criterion = "0.3"
+fuel-crypto = { path = ".", default-features = false, features = ["random"] }
+k256 = { version = "0.11", features = [ "ecdsa" ] }
+rand = { version = "0.8", default-features = false, features = ["std_rng"] }
+sha2 = "0.10"
+
+[features]
+default = ["fuel-types/default", "std"]
+alloc = ["rand/alloc", "secp256k1/alloc"]
+random = ["fuel-types/random", "rand"]
+serde = ["dep:serde", "fuel-types/serde"]
+# `rand-std` is used to further protect the blinders from side-channel attacks and won't compromise
+# the deterministic arguments of the signature (key, nonce, message), as defined in the RFC-6979
+std = ["alloc", "coins-bip32", "coins-bip39", "fuel-types/std", "lazy_static", "rand/std_rng", "secp256k1/rand-std", "serde?/default"]
+wasm = ["secp256k1/rand"]
+
+[[test]]
+name = "test-mnemonic"
+path = "tests/mnemonic.rs"
+required-features = ["std"]
+
+[[test]]
+name = "test-serde"
+path = "tests/serde.rs"
+required-features = ["serde", "std"]
+
+[[test]]
+name = "test-signature"
+path = "tests/signature.rs"
+required-features = ["std"]
+
+[[test]]
+name = "test-signer"
+path = "tests/signer.rs"
+required-features = ["std"]
+
+[[bench]]
+name = "signature"
+harness = false
+required-features = ["std"]
+
+# docs.rs-specific configuration
+[package.metadata.docs.rs]
+# document all features
+all-features = true
+# defines the configuration attribute `docsrs`
+rustdoc-args = ["--cfg", "docsrs"]

--- a/fuel-crypto/Cargo.toml
+++ b/fuel-crypto/Cargo.toml
@@ -7,20 +7,26 @@ edition = "2021"
 homepage = "https://fuel.network/"
 keywords = ["blockchain", "cryptocurrencies"]
 license = "Apache-2.0"
-repository = "https://github.com/FuelLabs/fuel-crypto"
+repository = "https://github.com/FuelLabs/fuel-vm"
 description = "Fuel cryptographic primitives."
 
 [dependencies]
 borrown = "0.1"
 coins-bip32 = { version = "0.7", default-features = false, optional = true }
 coins-bip39 = { version = "0.7", default-features = false, optional = true }
-fuel-types = { version = "0.5", default-features = false }
+fuel-types = { version = "0.5", path = "../fuel-types", default-features = false }
 lazy_static = { version = "1.4", optional = true }
 rand = { version = "0.8", default-features = false, optional = true }
 secp256k1 = { version = "0.24", default-features = false, features = ["recovery"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 sha2 = { version = "0.10", default-features = false }
 zeroize = { version = "1.5", features = ["derive"] }
+
+# Note that, while we don't use this dependency directly, we must specify it in
+# order to enable the transitive dependency's "js" feature which is required
+# for supporting the wasm32-unknown-unknown target.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2.8", default-features = false, features = ["js"] }
 
 [dev-dependencies]
 bincode = { version = "1.3", default-features = false }

--- a/fuel-crypto/LICENSE
+++ b/fuel-crypto/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/fuel-crypto/README.md
+++ b/fuel-crypto/README.md
@@ -1,6 +1,6 @@
 # Fuel Crypto
 
-[![build](https://github.com/FuelLabs/fuel-crypto/actions/workflows/ci.yml/badge.svg)](https://github.com/FuelLabs/fuel-crypto/actions/workflows/ci.yml)
+[![build](https://github.com/FuelLabs/fuel-vm/actions/workflows/ci.yml/badge.svg)](https://github.com/FuelLabs/fuel-vm/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/fuel-crypto?label=latest)](https://crates.io/crates/fuel-crypto)
 [![docs](https://docs.rs/fuel-crypto/badge.svg)](https://docs.rs/fuel-crypto/)
 [![discord](https://img.shields.io/badge/chat%20on-discord-orange?&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/xfpK4Pe)

--- a/fuel-crypto/README.md
+++ b/fuel-crypto/README.md
@@ -1,0 +1,14 @@
+# Fuel Crypto
+
+[![build](https://github.com/FuelLabs/fuel-crypto/actions/workflows/ci.yml/badge.svg)](https://github.com/FuelLabs/fuel-crypto/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/fuel-crypto?label=latest)](https://crates.io/crates/fuel-crypto)
+[![docs](https://docs.rs/fuel-crypto/badge.svg)](https://docs.rs/fuel-crypto/)
+[![discord](https://img.shields.io/badge/chat%20on-discord-orange?&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/xfpK4Pe)
+
+Fuel cryptographic primitives.
+
+## Compile features
+
+- `std`: Unless set, the crate will link to the core-crate instead of the std-crate. More info [here](https://docs.rust-embedded.org/book/intro/no-std.html).
+- `random`: Implement `no-std` [rand](https://crates.io/crates/rand) features for the provided types.
+- `serde`: Add support for [serde](https://crates.io/crates/serde) for the provided types.

--- a/fuel-crypto/benches/signature.rs
+++ b/fuel-crypto/benches/signature.rs
@@ -17,9 +17,7 @@ fn signatures(c: &mut Criterion) {
         let public = key.public_key();
         let signature = Signature::sign(&key, &message);
 
-        signature
-            .verify(&public, &message)
-            .expect("verification failed");
+        signature.verify(&public, &message).expect("verification failed");
 
         let x = signature.recover(&message).expect("failed to recover");
 
@@ -29,16 +27,7 @@ fn signatures(c: &mut Criterion) {
     };
 
     // secp256k1
-    let (
-        s2_secp,
-        s2_secp_signing,
-        s2_secp_verification,
-        s2_key,
-        s2_public,
-        s2_message,
-        s2_signature,
-        s2_recoverable,
-    ) = {
+    let (s2_secp, s2_secp_signing, s2_secp_verification, s2_key, s2_public, s2_message, s2_signature, s2_recoverable) = {
         use secp256k1::{Message, PublicKey, Secp256k1, SecretKey};
 
         let secp = Secp256k1::new();
@@ -46,9 +35,8 @@ fn signatures(c: &mut Criterion) {
         let secp_verification = Secp256k1::verification_only();
 
         let key = [
-            0x3b, 0x94, 0xb, 0x55, 0x86, 0x82, 0x3d, 0xfd, 0x2, 0xae, 0x3b, 0x46, 0x1b, 0xb4, 0x33,
-            0x6b, 0x5e, 0xcb, 0xae, 0xfd, 0x66, 0x27, 0xaa, 0x92, 0x2e, 0xfc, 0x4, 0x8f, 0xec, 0xc,
-            0x88, 0x1c,
+            0x3b, 0x94, 0xb, 0x55, 0x86, 0x82, 0x3d, 0xfd, 0x2, 0xae, 0x3b, 0x46, 0x1b, 0xb4, 0x33, 0x6b, 0x5e, 0xcb,
+            0xae, 0xfd, 0x66, 0x27, 0xaa, 0x92, 0x2e, 0xfc, 0x4, 0x8f, 0xec, 0xc, 0x88, 0x1c,
         ];
         let key = SecretKey::from_slice(&key).expect("Failed to create secret key");
 
@@ -62,9 +50,7 @@ fn signatures(c: &mut Criterion) {
             .verify_ecdsa(&message, &signature, &public)
             .expect("failed to verify secp");
 
-        let x = secp
-            .recover_ecdsa(&message, &recoverable)
-            .expect("failed to recover");
+        let x = secp.recover_ecdsa(&message, &recoverable).expect("failed to recover");
 
         assert_eq!(public, x);
 
@@ -90,9 +76,8 @@ fn signatures(c: &mut Criterion) {
         let digest = Sha256::new().chain(message);
 
         let key = [
-            0x0c, 0xbf, 0xdc, 0xe0, 0xb6, 0xa6, 0x88, 0x89, 0x1a, 0x43, 0xea, 0xfb, 0x43, 0x68,
-            0x2e, 0xde, 0x02, 0xc9, 0x1d, 0x61, 0xa9, 0x89, 0xd0, 0xb4, 0x39, 0x16, 0x25, 0xec,
-            0x80, 0x93, 0xfb, 0xa1,
+            0x0c, 0xbf, 0xdc, 0xe0, 0xb6, 0xa6, 0x88, 0x89, 0x1a, 0x43, 0xea, 0xfb, 0x43, 0x68, 0x2e, 0xde, 0x02, 0xc9,
+            0x1d, 0x61, 0xa9, 0x89, 0xd0, 0xb4, 0x39, 0x16, 0x25, 0xec, 0x80, 0x93, 0xfb, 0xa1,
         ];
         let key = SigningKey::from_bytes(&key).expect("failed to create key");
         let verifying = VerifyingKey::from(key.clone());
@@ -119,32 +104,24 @@ fn signatures(c: &mut Criterion) {
         b.iter(|| fuel_crypto::Signature::sign(black_box(key), black_box(message)))
     });
 
-    group_sign.bench_with_input(
-        "fuel-crypto-digest",
-        &(fc_key, message),
-        |b, (key, message)| {
-            b.iter(|| {
-                let message = fuel_crypto::Message::new(black_box(message));
+    group_sign.bench_with_input("fuel-crypto-digest", &(fc_key, message), |b, (key, message)| {
+        b.iter(|| {
+            let message = fuel_crypto::Message::new(black_box(message));
 
-                fuel_crypto::Signature::sign(black_box(key), black_box(&message))
-            })
-        },
-    );
+            fuel_crypto::Signature::sign(black_box(key), black_box(&message))
+        })
+    });
 
     group_sign.bench_with_input(
         "secp256k1",
         &(s2_secp_signing, s2_key, s2_message),
-        |b, (secp_signing, key, message)| {
-            b.iter(|| secp_signing.sign_ecdsa(black_box(message), black_box(key)))
-        },
+        |b, (secp_signing, key, message)| b.iter(|| secp_signing.sign_ecdsa(black_box(message), black_box(key))),
     );
 
     group_sign.bench_with_input(
         "secp256k1-recoverable",
         &(s2_secp.clone(), s2_key, s2_message),
-        |b, (secp, key, message)| {
-            b.iter(|| secp.sign_ecdsa_recoverable(black_box(message), black_box(key)))
-        },
+        |b, (secp, key, message)| b.iter(|| secp.sign_ecdsa_recoverable(black_box(message), black_box(key))),
     );
 
     group_sign.bench_with_input("k256", &(k2_key, k2_digest.clone()), |b, (key, digest)| {
@@ -164,22 +141,14 @@ fn signatures(c: &mut Criterion) {
     group_verify.bench_with_input(
         "fuel-crypto",
         &(fc_public, fc_signature, fc_message),
-        |b, (public, signature, message)| {
-            b.iter(|| signature.verify(black_box(public), black_box(message)))
-        },
+        |b, (public, signature, message)| b.iter(|| signature.verify(black_box(public), black_box(message))),
     );
 
     group_verify.bench_with_input(
         "secp256k1",
         &(s2_secp_verification, s2_public, s2_signature, s2_message),
         |b, (secp_verification, public, signature, message)| {
-            b.iter(|| {
-                secp_verification.verify_ecdsa(
-                    black_box(message),
-                    black_box(signature),
-                    black_box(public),
-                )
-            })
+            b.iter(|| secp_verification.verify_ecdsa(black_box(message), black_box(signature), black_box(public)))
         },
     );
 
@@ -199,27 +168,19 @@ fn signatures(c: &mut Criterion) {
 
     let mut group_recover = c.benchmark_group("recover");
 
-    group_recover.bench_with_input(
-        "fuel-crypto",
-        &(fc_signature, fc_message),
-        |b, (signature, message)| b.iter(|| signature.recover(black_box(message))),
-    );
+    group_recover.bench_with_input("fuel-crypto", &(fc_signature, fc_message), |b, (signature, message)| {
+        b.iter(|| signature.recover(black_box(message)))
+    });
 
     group_recover.bench_with_input(
         "secp256k1",
         &(s2_secp, s2_recoverable, s2_message),
-        |b, (secp, recoverable, message)| {
-            b.iter(|| secp.recover_ecdsa(black_box(message), black_box(recoverable)))
-        },
+        |b, (secp, recoverable, message)| b.iter(|| secp.recover_ecdsa(black_box(message), black_box(recoverable))),
     );
 
-    group_recover.bench_with_input(
-        "k256",
-        &(k2_recoverable, k2_digest),
-        |b, (recoverable, digest)| {
-            b.iter(|| recoverable.recover_verifying_key_from_digest(black_box(digest.clone())))
-        },
-    );
+    group_recover.bench_with_input("k256", &(k2_recoverable, k2_digest), |b, (recoverable, digest)| {
+        b.iter(|| recoverable.recover_verifying_key_from_digest(black_box(digest.clone())))
+    });
 
     group_recover.finish();
 }

--- a/fuel-crypto/benches/signature.rs
+++ b/fuel-crypto/benches/signature.rs
@@ -1,0 +1,228 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use sha2::digest::Update;
+
+fn signatures(c: &mut Criterion) {
+    let message = b"New opinions are always suspected, and usually opposed, without any other reason but because they are not common.";
+
+    // fuel-crypto
+    let (fc_key, fc_public, fc_message, fc_signature) = {
+        use fuel_crypto::{Message, SecretKey, Signature};
+        use rand::rngs::StdRng;
+        use rand::SeedableRng;
+
+        let rng = &mut StdRng::seed_from_u64(8586);
+
+        let message = Message::new(message);
+        let key = SecretKey::random(rng);
+        let public = key.public_key();
+        let signature = Signature::sign(&key, &message);
+
+        signature
+            .verify(&public, &message)
+            .expect("verification failed");
+
+        let x = signature.recover(&message).expect("failed to recover");
+
+        assert_eq!(x, public);
+
+        (key, public, message, signature)
+    };
+
+    // secp256k1
+    let (
+        s2_secp,
+        s2_secp_signing,
+        s2_secp_verification,
+        s2_key,
+        s2_public,
+        s2_message,
+        s2_signature,
+        s2_recoverable,
+    ) = {
+        use secp256k1::{Message, PublicKey, Secp256k1, SecretKey};
+
+        let secp = Secp256k1::new();
+        let secp_signing = Secp256k1::signing_only();
+        let secp_verification = Secp256k1::verification_only();
+
+        let key = [
+            0x3b, 0x94, 0xb, 0x55, 0x86, 0x82, 0x3d, 0xfd, 0x2, 0xae, 0x3b, 0x46, 0x1b, 0xb4, 0x33,
+            0x6b, 0x5e, 0xcb, 0xae, 0xfd, 0x66, 0x27, 0xaa, 0x92, 0x2e, 0xfc, 0x4, 0x8f, 0xec, 0xc,
+            0x88, 0x1c,
+        ];
+        let key = SecretKey::from_slice(&key).expect("Failed to create secret key");
+
+        let public = PublicKey::from_secret_key(&secp, &key);
+        let message = fuel_crypto::Message::new(message);
+        let message = Message::from_slice(message.as_ref()).expect("failed to create secp message");
+        let signature = secp_signing.sign_ecdsa(&message, &key);
+        let recoverable = secp.sign_ecdsa_recoverable(&message, &key);
+
+        secp_verification
+            .verify_ecdsa(&message, &signature, &public)
+            .expect("failed to verify secp");
+
+        let x = secp
+            .recover_ecdsa(&message, &recoverable)
+            .expect("failed to recover");
+
+        assert_eq!(public, x);
+
+        (
+            secp,
+            secp_signing,
+            secp_verification,
+            key,
+            public,
+            message,
+            signature,
+            recoverable,
+        )
+    };
+
+    // k256
+    let (k2_key, k2_verifying, k2_digest, k2_signature, k2_recoverable) = {
+        use k256::ecdsa::recoverable::Signature as Recoverable;
+        use k256::ecdsa::signature::{DigestSigner, DigestVerifier};
+        use k256::ecdsa::{Signature, SigningKey, VerifyingKey};
+        use sha2::{Digest, Sha256};
+
+        let digest = Sha256::new().chain(message);
+
+        let key = [
+            0x0c, 0xbf, 0xdc, 0xe0, 0xb6, 0xa6, 0x88, 0x89, 0x1a, 0x43, 0xea, 0xfb, 0x43, 0x68,
+            0x2e, 0xde, 0x02, 0xc9, 0x1d, 0x61, 0xa9, 0x89, 0xd0, 0xb4, 0x39, 0x16, 0x25, 0xec,
+            0x80, 0x93, 0xfb, 0xa1,
+        ];
+        let key = SigningKey::from_bytes(&key).expect("failed to create key");
+        let verifying = VerifyingKey::from(key.clone());
+
+        let signature: Signature = key.sign_digest(digest.clone());
+        let recoverable: Recoverable = key.sign_digest(digest.clone());
+
+        verifying
+            .verify_digest(digest.clone(), &signature)
+            .expect("failed to verify");
+
+        let x = recoverable
+            .recover_verifying_key_from_digest(digest.clone())
+            .expect("failed to recover");
+
+        assert_eq!(x, verifying);
+
+        (key, verifying, digest, signature, recoverable)
+    };
+
+    let mut group_sign = c.benchmark_group("sign");
+
+    group_sign.bench_with_input("fuel-crypto", &(fc_key, fc_message), |b, (key, message)| {
+        b.iter(|| fuel_crypto::Signature::sign(black_box(key), black_box(message)))
+    });
+
+    group_sign.bench_with_input(
+        "fuel-crypto-digest",
+        &(fc_key, message),
+        |b, (key, message)| {
+            b.iter(|| {
+                let message = fuel_crypto::Message::new(black_box(message));
+
+                fuel_crypto::Signature::sign(black_box(key), black_box(&message))
+            })
+        },
+    );
+
+    group_sign.bench_with_input(
+        "secp256k1",
+        &(s2_secp_signing, s2_key, s2_message),
+        |b, (secp_signing, key, message)| {
+            b.iter(|| secp_signing.sign_ecdsa(black_box(message), black_box(key)))
+        },
+    );
+
+    group_sign.bench_with_input(
+        "secp256k1-recoverable",
+        &(s2_secp.clone(), s2_key, s2_message),
+        |b, (secp, key, message)| {
+            b.iter(|| secp.sign_ecdsa_recoverable(black_box(message), black_box(key)))
+        },
+    );
+
+    group_sign.bench_with_input("k256", &(k2_key, k2_digest.clone()), |b, (key, digest)| {
+        b.iter(|| {
+            use k256::ecdsa::signature::DigestSigner;
+
+            let sig: k256::ecdsa::Signature = key.sign_digest(black_box(digest.clone()));
+
+            sig
+        })
+    });
+
+    group_sign.finish();
+
+    let mut group_verify = c.benchmark_group("verify");
+
+    group_verify.bench_with_input(
+        "fuel-crypto",
+        &(fc_public, fc_signature, fc_message),
+        |b, (public, signature, message)| {
+            b.iter(|| signature.verify(black_box(public), black_box(message)))
+        },
+    );
+
+    group_verify.bench_with_input(
+        "secp256k1",
+        &(s2_secp_verification, s2_public, s2_signature, s2_message),
+        |b, (secp_verification, public, signature, message)| {
+            b.iter(|| {
+                secp_verification.verify_ecdsa(
+                    black_box(message),
+                    black_box(signature),
+                    black_box(public),
+                )
+            })
+        },
+    );
+
+    group_verify.bench_with_input(
+        "k256",
+        &(k2_verifying, k2_digest.clone(), k2_signature),
+        |b, (verifying, digest, signature)| {
+            b.iter(|| {
+                use k256::ecdsa::signature::DigestVerifier;
+
+                verifying.verify_digest(black_box(digest.clone()), black_box(signature))
+            })
+        },
+    );
+
+    group_verify.finish();
+
+    let mut group_recover = c.benchmark_group("recover");
+
+    group_recover.bench_with_input(
+        "fuel-crypto",
+        &(fc_signature, fc_message),
+        |b, (signature, message)| b.iter(|| signature.recover(black_box(message))),
+    );
+
+    group_recover.bench_with_input(
+        "secp256k1",
+        &(s2_secp, s2_recoverable, s2_message),
+        |b, (secp, recoverable, message)| {
+            b.iter(|| secp.recover_ecdsa(black_box(message), black_box(recoverable)))
+        },
+    );
+
+    group_recover.bench_with_input(
+        "k256",
+        &(k2_recoverable, k2_digest),
+        |b, (recoverable, digest)| {
+            b.iter(|| recoverable.recover_verifying_key_from_digest(black_box(digest.clone())))
+        },
+    );
+
+    group_recover.finish();
+}
+
+criterion_group!(benches, signatures);
+criterion_main!(benches);

--- a/fuel-crypto/src/error.rs
+++ b/fuel-crypto/src/error.rs
@@ -1,0 +1,101 @@
+use core::convert::Infallible;
+
+/// Crypto error variants
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum Error {
+    /// Invalid secp256k1 secret key
+    InvalidSecretKey,
+
+    /// Invalid secp256k1 public key
+    InvalidPublicKey,
+
+    /// Invalid secp256k1 signature message
+    InvalidMessage,
+
+    /// Invalid secp256k1 signature
+    InvalidSignature,
+
+    /// The provided key wasn't found
+    KeyNotFound,
+
+    /// The keystore isn't available or is corrupted
+    KeystoreNotAvailable,
+
+    /// Out of preallocated memory
+    NotEnoughMemory,
+
+    /// Invalid mnemonic phrase
+    InvalidMnemonic,
+
+    /// Bip32-related error
+    Bip32Error,
+}
+
+impl From<Error> for Infallible {
+    fn from(_: Error) -> Infallible {
+        unreachable!()
+    }
+}
+
+impl From<Infallible> for Error {
+    fn from(_: Infallible) -> Error {
+        unreachable!()
+    }
+}
+
+#[cfg(feature = "std")]
+mod use_std {
+    use super::*;
+    use coins_bip39::MnemonicError;
+    use secp256k1::Error as Secp256k1Error;
+    use std::{error, fmt, io};
+
+    impl From<Secp256k1Error> for Error {
+        fn from(secp: Secp256k1Error) -> Self {
+            match secp {
+                Secp256k1Error::IncorrectSignature
+                | Secp256k1Error::InvalidSignature
+                | Secp256k1Error::InvalidTweak
+                | Secp256k1Error::InvalidSharedSecret
+                | Secp256k1Error::InvalidPublicKeySum
+                | Secp256k1Error::InvalidParityValue(_)
+                | Secp256k1Error::InvalidRecoveryId => Self::InvalidSignature,
+                Secp256k1Error::InvalidMessage => Self::InvalidMessage,
+                Secp256k1Error::InvalidPublicKey => Self::InvalidPublicKey,
+                Secp256k1Error::InvalidSecretKey => Self::InvalidSecretKey,
+                Secp256k1Error::NotEnoughMemory => Self::NotEnoughMemory,
+            }
+        }
+    }
+
+    impl From<MnemonicError> for Error {
+        fn from(_: MnemonicError) -> Self {
+            Self::InvalidMnemonic
+        }
+    }
+
+    impl From<coins_bip32::Bip32Error> for Error {
+        fn from(_: coins_bip32::Bip32Error) -> Self {
+            Self::Bip32Error
+        }
+    }
+
+    impl fmt::Display for Error {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "{:?}", self)
+        }
+    }
+
+    impl error::Error for Error {
+        fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+            None
+        }
+    }
+
+    impl From<Error> for io::Error {
+        fn from(e: Error) -> io::Error {
+            io::Error::new(io::ErrorKind::Other, e)
+        }
+    }
+}

--- a/fuel-crypto/src/hasher.rs
+++ b/fuel-crypto/src/hasher.rs
@@ -1,0 +1,88 @@
+use fuel_types::Bytes32;
+use sha2::{digest::Update, Digest, Sha256};
+
+use core::iter;
+
+/// Standard hasher
+#[derive(Debug, Default, Clone)]
+pub struct Hasher(Sha256);
+
+impl Hasher {
+    /// Length of the output
+    pub const OUTPUT_LEN: usize = Bytes32::LEN;
+
+    /// Append data to the hasher
+    pub fn input<B>(&mut self, data: B)
+    where
+        B: AsRef<[u8]>,
+    {
+        sha2::Digest::update(&mut self.0, data)
+    }
+
+    /// Consume, append data and return the hasher
+    pub fn chain<B>(self, data: B) -> Self
+    where
+        B: AsRef<[u8]>,
+    {
+        Self(self.0.chain(data))
+    }
+
+    /// Consume, append the items of the iterator and return the hasher
+    pub fn extend_chain<B, I>(mut self, iter: I) -> Self
+    where
+        B: AsRef<[u8]>,
+        I: IntoIterator<Item = B>,
+    {
+        self.extend(iter);
+
+        self
+    }
+
+    /// Reset the hasher to the default state
+    pub fn reset(&mut self) {
+        self.0.reset();
+    }
+
+    /// Hash the provided data, returning its digest
+    pub fn hash<B>(data: B) -> Bytes32
+    where
+        B: AsRef<[u8]>,
+    {
+        let mut hasher = Sha256::new();
+
+        sha2::Digest::update(&mut hasher, data);
+
+        <[u8; Bytes32::LEN]>::from(hasher.finalize()).into()
+    }
+
+    /// Consume the hasher, returning the digest
+    pub fn finalize(self) -> Bytes32 {
+        <[u8; Bytes32::LEN]>::from(self.0.finalize()).into()
+    }
+
+    /// Return the digest without consuming the hasher
+    pub fn digest(&self) -> Bytes32 {
+        <[u8; Bytes32::LEN]>::from(self.0.clone().finalize()).into()
+    }
+}
+
+impl<B> iter::FromIterator<B> for Hasher
+where
+    B: AsRef<[u8]>,
+{
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = B>,
+    {
+        iter.into_iter().fold(Hasher::default(), Hasher::chain)
+    }
+}
+
+impl<B> Extend<B> for Hasher
+where
+    B: AsRef<[u8]>,
+{
+    fn extend<T: IntoIterator<Item = B>>(&mut self, iter: T) {
+        iter.into_iter().for_each(|b| self.input(b))
+    }
+}

--- a/fuel-crypto/src/keystore.rs
+++ b/fuel-crypto/src/keystore.rs
@@ -21,9 +21,7 @@ pub trait Keystore {
     #[cfg(feature = "std")]
     fn public(&self, id: &Self::KeyId) -> Result<Option<Borrown<'_, PublicKey>>, Self::Error> {
         let secret = self.secret(id)?;
-        let public = secret
-            .map(|s| PublicKey::from(s.as_ref()))
-            .map(Borrown::Owned);
+        let public = secret.map(|s| PublicKey::from(s.as_ref())).map(Borrown::Owned);
 
         Ok(public)
     }

--- a/fuel-crypto/src/keystore.rs
+++ b/fuel-crypto/src/keystore.rs
@@ -1,0 +1,30 @@
+use crate::{Error, PublicKey, SecretKey};
+
+use borrown::Borrown;
+
+/// Keys container
+pub trait Keystore {
+    /// Keystore error implementation
+    type Error: From<Error>;
+
+    /// Identifier for the keypair
+    type KeyId;
+
+    /// Secret key for a given id
+    fn secret(&self, id: &Self::KeyId) -> Result<Option<Borrown<'_, SecretKey>>, Self::Error>;
+
+    /// Public key for a given id
+    #[cfg(not(feature = "std"))]
+    fn public(&self, id: &Self::KeyId) -> Result<Option<Borrown<'_, PublicKey>>, Self::Error>;
+
+    /// Public key for a given id
+    #[cfg(feature = "std")]
+    fn public(&self, id: &Self::KeyId) -> Result<Option<Borrown<'_, PublicKey>>, Self::Error> {
+        let secret = self.secret(id)?;
+        let public = secret
+            .map(|s| PublicKey::from(s.as_ref()))
+            .map(Borrown::Owned);
+
+        Ok(public)
+    }
+}

--- a/fuel-crypto/src/lib.rs
+++ b/fuel-crypto/src/lib.rs
@@ -1,0 +1,47 @@
+//! Fuel cryptographic primitives.
+
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
+#![warn(missing_docs)]
+// Wrong clippy convention; check
+// https://rust-lang.github.io/api-guidelines/naming.html
+#![allow(clippy::wrong_self_convention)]
+
+/// Required export to implement [`Keystore`].
+#[doc(no_inline)]
+pub use borrown;
+/// Required export for using mnemonic keygen on [`SecretKey::new_from_mnemonic`]
+#[cfg(feature = "std")]
+#[doc(no_inline)]
+pub use coins_bip32;
+/// Required export for using mnemonic keygen on [`SecretKey::new_from_mnemonic`]
+#[cfg(feature = "std")]
+#[doc(no_inline)]
+pub use coins_bip39;
+/// Required export to use various public interfaces in this crate
+#[doc(no_inline)]
+pub use fuel_types;
+#[cfg(feature = "random")]
+#[doc(no_inline)]
+/// Required export to use randomness features
+pub use rand;
+
+mod error;
+mod hasher;
+mod keystore;
+mod message;
+mod mnemonic;
+mod public;
+mod secret;
+mod signature;
+mod signer;
+
+pub use error::Error;
+pub use hasher::Hasher;
+pub use keystore::Keystore;
+pub use message::Message;
+pub use mnemonic::FuelMnemonic;
+pub use public::PublicKey;
+pub use secret::SecretKey;
+pub use signature::Signature;
+pub use signer::Signer;

--- a/fuel-crypto/src/message.rs
+++ b/fuel-crypto/src/message.rs
@@ -1,0 +1,140 @@
+use crate::Hasher;
+
+pub use fuel_types::Bytes32;
+
+use core::fmt;
+use core::ops::Deref;
+
+/// Normalized signature message
+#[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[repr(transparent)]
+pub struct Message(Bytes32);
+
+impl Message {
+    /// Memory length of the type
+    pub const LEN: usize = Bytes32::LEN;
+
+    /// Normalize a message for signature
+    pub fn new<M>(message: M) -> Self
+    where
+        M: AsRef<[u8]>,
+    {
+        Self(Hasher::hash(message))
+    }
+
+    /// Add a conversion from arbitrary slices into owned
+    ///
+    /// # Safety
+    ///
+    /// There is no guarantee the provided bytes will be the product of a cryptographically secure
+    /// hash. Using insecure messages might compromise the security of the signature.
+    pub unsafe fn from_bytes_unchecked(bytes: [u8; Self::LEN]) -> Self {
+        Self(bytes.into())
+    }
+
+    /// Add a conversion from arbitrary slices into owned
+    ///
+    /// # Safety
+    ///
+    /// This function will not panic if the length of the slice is smaller than
+    /// `Self::LEN`. Instead, it will cause undefined behavior and read random
+    /// disowned bytes.
+    ///
+    /// This function extends the unsafety of [`Self::from_bytes_unchecked`].
+    pub unsafe fn from_slice_unchecked(bytes: &[u8]) -> Self {
+        Self(Bytes32::from_slice_unchecked(bytes))
+    }
+
+    /// Copy-free reference cast
+    ///
+    /// # Safety
+    ///
+    /// Inputs smaller than `Self::LEN` will cause undefined behavior.
+    ///
+    /// This function extends the unsafety of [`Self::from_bytes_unchecked`].
+    pub unsafe fn as_ref_unchecked(bytes: &[u8]) -> &Self {
+        // The interpreter will frequently make references to keys and values using
+        // logically checked slices.
+        //
+        // This function will avoid unnecessary copy to owned slices for the interpreter
+        // access
+        &*(bytes.as_ptr() as *const Self)
+    }
+}
+
+impl Deref for Message {
+    type Target = [u8; Message::LEN];
+
+    fn deref(&self) -> &[u8; Message::LEN] {
+        self.0.deref()
+    }
+}
+
+impl AsRef<[u8]> for Message {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl From<Message> for [u8; Message::LEN] {
+    fn from(message: Message) -> [u8; Message::LEN] {
+        message.0.into()
+    }
+}
+
+impl From<&Hasher> for Message {
+    fn from(hasher: &Hasher) -> Self {
+        // Safety: `Hasher` is a cryptographic hash
+        unsafe { Self::from_bytes_unchecked(*hasher.digest()) }
+    }
+}
+
+impl From<Hasher> for Message {
+    fn from(hasher: Hasher) -> Self {
+        // Safety: `Hasher` is a cryptographic hash
+        unsafe { Self::from_bytes_unchecked(*hasher.finalize()) }
+    }
+}
+
+impl fmt::LowerHex for Message {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl fmt::UpperHex for Message {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl fmt::Debug for Message {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl fmt::Display for Message {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[cfg(feature = "std")]
+mod use_std {
+    use crate::Message;
+
+    use secp256k1::Message as Secp256k1Message;
+
+    impl Message {
+        pub(crate) fn to_secp(&self) -> Secp256k1Message {
+            // The only validation performed by `Message::from_slice` is to check if it is
+            // 32 bytes. This validation exists to prevent users from signing
+            // non-hashed messages, which is a severe violation of the protocol
+            // security.
+            debug_assert_eq!(Self::LEN, secp256k1::constants::MESSAGE_SIZE);
+            Secp256k1Message::from_slice(self.as_ref()).expect("Unreachable error")
+        }
+    }
+}

--- a/fuel-crypto/src/mnemonic.rs
+++ b/fuel-crypto/src/mnemonic.rs
@@ -16,10 +16,7 @@ mod use_std {
         /// Generates a random mnemonic phrase given a random number generator and
         /// the number of words to generate, `count`.
         #[cfg(feature = "random")]
-        pub fn generate_mnemonic_phrase<R: Rng>(
-            rng: &mut R,
-            count: usize,
-        ) -> Result<String, Error> {
+        pub fn generate_mnemonic_phrase<R: Rng>(rng: &mut R, count: usize) -> Result<String, Error> {
             Ok(Mnemonic::<W>::new_with_count(rng, count)?.to_phrase()?)
         }
     }

--- a/fuel-crypto/src/mnemonic.rs
+++ b/fuel-crypto/src/mnemonic.rs
@@ -1,0 +1,26 @@
+/// FuelMnemonic is a simple mnemonic phrase generator.
+pub struct FuelMnemonic;
+
+#[cfg(feature = "std")]
+mod use_std {
+    use super::FuelMnemonic;
+    use crate::Error;
+    use coins_bip39::{English, Mnemonic};
+
+    pub type W = English;
+
+    #[cfg(feature = "random")]
+    use rand::Rng;
+
+    impl FuelMnemonic {
+        /// Generates a random mnemonic phrase given a random number generator and
+        /// the number of words to generate, `count`.
+        #[cfg(feature = "random")]
+        pub fn generate_mnemonic_phrase<R: Rng>(
+            rng: &mut R,
+            count: usize,
+        ) -> Result<String, Error> {
+            Ok(Mnemonic::<W>::new_with_count(rng, count)?.to_phrase()?)
+        }
+    }
+}

--- a/fuel-crypto/src/public.rs
+++ b/fuel-crypto/src/public.rs
@@ -199,10 +199,7 @@ mod use_std {
         fn try_from(b: Bytes64) -> Result<Self, Self::Error> {
             let public = PublicKey(b);
 
-            public
-                .is_in_curve()
-                .then_some(public)
-                .ok_or(Error::InvalidPublicKey)
+            public.is_in_curve().then_some(public).ok_or(Error::InvalidPublicKey)
         }
     }
 

--- a/fuel-crypto/src/public.rs
+++ b/fuel-crypto/src/public.rs
@@ -1,0 +1,242 @@
+use crate::Hasher;
+
+use fuel_types::{Bytes32, Bytes64};
+
+use core::fmt;
+use core::ops::Deref;
+
+/// Asymmetric public key
+#[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[repr(transparent)]
+pub struct PublicKey(Bytes64);
+
+impl PublicKey {
+    /// Memory length of the type
+    pub const LEN: usize = Bytes64::LEN;
+
+    /// Copy-free reference cast
+    ///
+    /// # Safety
+    ///
+    /// This function will not panic if the length of the slice is smaller than
+    /// `Self::LEN`. Instead, it will cause undefined behavior and read random
+    /// disowned bytes.
+    ///
+    /// There is no guarantee the provided bytes will fit the curve.
+    pub unsafe fn as_ref_unchecked(bytes: &[u8]) -> &Self {
+        // The interpreter will frequently make references to keys and values using
+        // logically checked slices.
+        //
+        // This function will save unnecessary copy to owned slices for the interpreter
+        // access
+        &*(bytes.as_ptr() as *const Self)
+    }
+
+    /// Add a conversion from arbitrary slices into owned
+    ///
+    /// # Safety
+    ///
+    /// There is no guarantee the provided bytes will fit the curve. The curve
+    /// security can be checked with [`PublicKey::is_in_curve`].
+    pub unsafe fn from_bytes_unchecked(bytes: [u8; Self::LEN]) -> Self {
+        Self(bytes.into())
+    }
+
+    /// Add a conversion from arbitrary slices into owned
+    ///
+    /// # Safety
+    ///
+    /// This function will not panic if the length of the slice is smaller than
+    /// `Self::LEN`. Instead, it will cause undefined behavior and read random
+    /// disowned bytes.
+    ///
+    /// There is no guarantee the provided bytes will fit the curve.
+    pub unsafe fn from_slice_unchecked(bytes: &[u8]) -> Self {
+        Self(Bytes64::from_slice_unchecked(bytes))
+    }
+
+    /// Hash of the public key
+    pub fn hash(&self) -> Bytes32 {
+        Hasher::hash(self.as_ref())
+    }
+}
+
+impl Deref for PublicKey {
+    type Target = [u8; PublicKey::LEN];
+
+    fn deref(&self) -> &[u8; PublicKey::LEN] {
+        self.0.deref()
+    }
+}
+
+impl AsRef<[u8]> for PublicKey {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl AsMut<[u8]> for PublicKey {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.0.as_mut()
+    }
+}
+
+impl From<PublicKey> for [u8; PublicKey::LEN] {
+    fn from(pk: PublicKey) -> [u8; PublicKey::LEN] {
+        pk.0.into()
+    }
+}
+
+impl fmt::LowerHex for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl fmt::UpperHex for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl fmt::Debug for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl fmt::Display for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[cfg(feature = "std")]
+mod use_std {
+    use super::*;
+    use crate::{Error, SecretKey};
+
+    use secp256k1::{Error as Secp256k1Error, PublicKey as Secp256k1PublicKey, Secp256k1};
+
+    use core::borrow::Borrow;
+    use core::str;
+
+    const UNCOMPRESSED_PUBLIC_KEY_SIZE: usize = 65;
+
+    // Internal secp256k1 identifier for uncompressed point
+    //
+    // https://github.com/rust-bitcoin/rust-secp256k1/blob/ecb62612b57bf3aa8d8017d611d571f86bfdb5dd/secp256k1-sys/depend/secp256k1/include/secp256k1.h#L196
+    const SECP_UNCOMPRESSED_FLAG: u8 = 4;
+
+    impl PublicKey {
+        /// Check if the provided slice represents a public key that is in the
+        /// curve.
+        ///
+        /// # Safety
+        ///
+        /// This function extends the unsafety of
+        /// [`PublicKey::as_ref_unchecked`].
+        pub unsafe fn is_slice_in_curve_unchecked(slice: &[u8]) -> bool {
+            use secp256k1::ffi::{self, CPtr};
+
+            let public = Self::as_ref_unchecked(slice);
+
+            let mut public_with_flag = [0u8; UNCOMPRESSED_PUBLIC_KEY_SIZE];
+
+            public_with_flag[1..].copy_from_slice(public.as_ref());
+
+            // Safety: FFI call
+            let curve = ffi::secp256k1_ec_pubkey_parse(
+                ffi::secp256k1_context_no_precomp,
+                &mut ffi::PublicKey::new(),
+                public_with_flag.as_c_ptr(),
+                UNCOMPRESSED_PUBLIC_KEY_SIZE,
+            );
+
+            curve == 1
+        }
+
+        /// Check if the secret key representation is in the curve.
+        pub fn is_in_curve(&self) -> bool {
+            // Safety: struct is guaranteed to reference itself with correct len
+            unsafe { Self::is_slice_in_curve_unchecked(self.as_ref()) }
+        }
+
+        pub(crate) fn from_secp(pk: &Secp256k1PublicKey) -> PublicKey {
+            debug_assert_eq!(
+                UNCOMPRESSED_PUBLIC_KEY_SIZE,
+                secp256k1::constants::UNCOMPRESSED_PUBLIC_KEY_SIZE
+            );
+
+            let pk = pk.serialize_uncompressed();
+
+            debug_assert_eq!(SECP_UNCOMPRESSED_FLAG, pk[0]);
+
+            // Ignore the first byte of the compression flag
+            let pk = &pk[1..];
+
+            // Safety: compile-time assertion of size correctness
+            unsafe { Self::from_slice_unchecked(pk) }
+        }
+
+        pub(crate) fn _to_secp(&self) -> Result<Secp256k1PublicKey, Error> {
+            let mut pk = [SECP_UNCOMPRESSED_FLAG; UNCOMPRESSED_PUBLIC_KEY_SIZE];
+
+            debug_assert_eq!(SECP_UNCOMPRESSED_FLAG, pk[0]);
+
+            pk[1..].copy_from_slice(self.as_ref());
+
+            let pk = Secp256k1PublicKey::from_slice(&pk)?;
+
+            Ok(pk)
+        }
+    }
+
+    impl TryFrom<Bytes64> for PublicKey {
+        type Error = Error;
+
+        fn try_from(b: Bytes64) -> Result<Self, Self::Error> {
+            let public = PublicKey(b);
+
+            public
+                .is_in_curve()
+                .then_some(public)
+                .ok_or(Error::InvalidPublicKey)
+        }
+    }
+
+    impl TryFrom<&[u8]> for PublicKey {
+        type Error = Error;
+
+        fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
+            Bytes64::try_from(slice)
+                .map_err(|_| Secp256k1Error::InvalidPublicKey.into())
+                .and_then(PublicKey::try_from)
+        }
+    }
+
+    impl From<&SecretKey> for PublicKey {
+        fn from(s: &SecretKey) -> PublicKey {
+            let secp = Secp256k1::new();
+
+            let secret = s.borrow();
+
+            // Copy here is unavoidable since there is no API in secp256k1 to create
+            // uncompressed keys directly
+            let public = Secp256k1PublicKey::from_secret_key(&secp, secret);
+
+            Self::from_secp(&public)
+        }
+    }
+
+    impl str::FromStr for PublicKey {
+        type Err = Error;
+
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            Bytes64::from_str(s)
+                .map_err(|_| Secp256k1Error::InvalidPublicKey.into())
+                .and_then(PublicKey::try_from)
+        }
+    }
+}

--- a/fuel-crypto/src/secret.rs
+++ b/fuel-crypto/src/secret.rs
@@ -142,12 +142,8 @@ mod use_std {
                 rng.fill(secret.as_mut());
 
                 // Safety: FFI call
-                let overflow = unsafe {
-                    ffi::secp256k1_ec_seckey_verify(
-                        ffi::secp256k1_context_no_precomp,
-                        secret.as_c_ptr(),
-                    )
-                };
+                let overflow =
+                    unsafe { ffi::secp256k1_ec_seckey_verify(ffi::secp256k1_context_no_precomp, secret.as_c_ptr()) };
 
                 if overflow != 0 {
                     break;
@@ -191,10 +187,7 @@ mod use_std {
             let secret = Self::as_ref_unchecked(slice);
 
             // Safety: FFI call
-            let overflow = ffi::secp256k1_ec_seckey_verify(
-                ffi::secp256k1_context_no_precomp,
-                secret.as_c_ptr(),
-            );
+            let overflow = ffi::secp256k1_ec_seckey_verify(ffi::secp256k1_context_no_precomp, secret.as_c_ptr());
 
             overflow != 0
         }
@@ -220,10 +213,7 @@ mod use_std {
         fn try_from(b: Bytes32) -> Result<Self, Self::Error> {
             let secret = SecretKey(b);
 
-            secret
-                .is_in_field()
-                .then_some(secret)
-                .ok_or(Error::InvalidSecretKey)
+            secret.is_in_field().then_some(secret).ok_or(Error::InvalidSecretKey)
         }
     }
 

--- a/fuel-crypto/src/secret.rs
+++ b/fuel-crypto/src/secret.rs
@@ -1,0 +1,273 @@
+use fuel_types::Bytes32;
+
+use core::fmt;
+use core::ops::Deref;
+
+use zeroize::Zeroize;
+
+/// Asymmetric secret key
+#[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Zeroize)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[repr(transparent)]
+pub struct SecretKey(Bytes32);
+
+impl SecretKey {
+    /// Memory length of the type
+    pub const LEN: usize = Bytes32::LEN;
+
+    /// Add a conversion from arbitrary slices into owned
+    ///
+    /// # Safety
+    ///
+    /// There is no guarantee the provided bytes will fit the field. The field
+    /// security can be checked with [`SecretKey::is_in_field`].
+    pub unsafe fn from_bytes_unchecked(bytes: [u8; Self::LEN]) -> Self {
+        Self(bytes.into())
+    }
+
+    /// Add a conversion from arbitrary slices into owned
+    ///
+    /// # Safety
+    ///
+    /// This function will not panic if the length of the slice is smaller than
+    /// `Self::LEN`. Instead, it will cause undefined behavior and read random
+    /// disowned bytes.
+    ///
+    /// There is no guarantee the provided bytes will fit the field.
+    pub unsafe fn from_slice_unchecked(bytes: &[u8]) -> Self {
+        Self(Bytes32::from_slice_unchecked(bytes))
+    }
+
+    /// Copy-free reference cast
+    ///
+    /// There is no guarantee the provided bytes will fit the field.
+    ///
+    /// # Safety
+    ///
+    /// Inputs smaller than `Self::LEN` will cause undefined behavior.
+    pub unsafe fn as_ref_unchecked(bytes: &[u8]) -> &Self {
+        // The interpreter will frequently make references to keys and values using
+        // logically checked slices.
+        //
+        // This function will avoid unnecessary copy to owned slices for the interpreter
+        // access
+        &*(bytes.as_ptr() as *const Self)
+    }
+}
+
+impl Deref for SecretKey {
+    type Target = [u8; SecretKey::LEN];
+
+    fn deref(&self) -> &[u8; SecretKey::LEN] {
+        self.0.deref()
+    }
+}
+
+impl AsRef<[u8]> for SecretKey {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl From<SecretKey> for [u8; SecretKey::LEN] {
+    fn from(salt: SecretKey) -> [u8; SecretKey::LEN] {
+        salt.0.into()
+    }
+}
+
+impl fmt::LowerHex for SecretKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl fmt::UpperHex for SecretKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl fmt::Debug for SecretKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl fmt::Display for SecretKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[cfg(feature = "std")]
+mod use_std {
+    use super::*;
+    use crate::{Error, PublicKey};
+    use coins_bip32::path::DerivationPath;
+    use coins_bip39::{English, Mnemonic};
+    use core::borrow::Borrow;
+    use core::str;
+    use secp256k1::{Error as Secp256k1Error, SecretKey as Secp256k1SecretKey};
+    use std::str::FromStr;
+
+    #[cfg(feature = "random")]
+    use rand::{
+        distributions::{Distribution, Standard},
+        Rng,
+    };
+
+    pub type W = English;
+
+    impl SecretKey {
+        /// Create a new random secret
+        #[cfg(feature = "random")]
+        pub fn random<R>(rng: &mut R) -> Self
+        where
+            R: rand::Rng + ?Sized,
+        {
+            // TODO there is no clear API to generate a scalar for secp256k1. This code is
+            // very inefficient and not constant time; it was copied from
+            // https://github.com/rust-bitcoin/rust-secp256k1/blob/ada3f98ab65e6f12cf1550edb0b7ae064ecac153/src/key.rs#L101
+            //
+            // Need to improve; generate random bytes and truncate to the field.
+            //
+            // We don't call `Secp256k1SecretKey::new` here because the `rand` requirements
+            // are outdated and inconsistent.
+
+            use secp256k1::ffi::{self, CPtr};
+
+            let mut secret = Bytes32::zeroed();
+
+            loop {
+                rng.fill(secret.as_mut());
+
+                // Safety: FFI call
+                let overflow = unsafe {
+                    ffi::secp256k1_ec_seckey_verify(
+                        ffi::secp256k1_context_no_precomp,
+                        secret.as_c_ptr(),
+                    )
+                };
+
+                if overflow != 0 {
+                    break;
+                }
+            }
+
+            Self(secret)
+        }
+
+        /// Generate a new secret key from a mnemonic phrase and its derivation path.
+        /// Both are passed as `&str`. If you want to manually create a `DerivationPath`
+        /// and `Mnemonic`, use [`SecretKey::new_from_mnemonic`].
+        /// The derivation path is a list of integers, each representing a child index.
+        pub fn new_from_mnemonic_phrase_with_path(phrase: &str, path: &str) -> Result<Self, Error> {
+            let mnemonic = Mnemonic::<W>::new_from_phrase(phrase)?;
+            let path = DerivationPath::from_str(path)?;
+            Self::new_from_mnemonic(path, mnemonic)
+        }
+
+        /// Generate a new secret key from a `DerivationPath` and `Mnemonic`.
+        /// If you want to pass strings instead, use [`SecretKey::new_from_mnemonic_phrase_with_path`].
+        pub fn new_from_mnemonic(d: DerivationPath, m: Mnemonic<W>) -> Result<Self, Error> {
+            let derived_priv_key = m.derive_key(d, None)?;
+            let key: &coins_bip32::prelude::SigningKey = derived_priv_key.as_ref();
+
+            // Safety: this slice will always be of the expected length (`Bytes32`)
+            // because it will be a `Secp256k` secret key, coming from
+            // `coins_bip32::prelude::SigningKey`, which is a 256-bit (32-byte) scalar.
+            Ok(unsafe { SecretKey::from_slice_unchecked(key.to_bytes().as_ref()) })
+        }
+
+        /// Check if the provided slice represents a scalar that fits the field.
+        ///
+        /// # Safety
+        ///
+        /// This function extends the unsafety of
+        /// [`SecretKey::as_ref_unchecked`].
+        pub unsafe fn is_slice_in_field_unchecked(slice: &[u8]) -> bool {
+            use secp256k1::ffi::{self, CPtr};
+
+            let secret = Self::as_ref_unchecked(slice);
+
+            // Safety: FFI call
+            let overflow = ffi::secp256k1_ec_seckey_verify(
+                ffi::secp256k1_context_no_precomp,
+                secret.as_c_ptr(),
+            );
+
+            overflow != 0
+        }
+
+        /// Check if the secret key representation fits the scalar field.
+        pub fn is_in_field(&self) -> bool {
+            // Safety: struct is guaranteed to reference itself with correct len
+            unsafe { Self::is_slice_in_field_unchecked(self.as_ref()) }
+        }
+
+        /// Return the curve representation of this secret.
+        ///
+        /// The discrete logarithm property guarantees this is a one-way
+        /// function.
+        pub fn public_key(&self) -> PublicKey {
+            PublicKey::from(self)
+        }
+    }
+
+    impl TryFrom<Bytes32> for SecretKey {
+        type Error = Error;
+
+        fn try_from(b: Bytes32) -> Result<Self, Self::Error> {
+            let secret = SecretKey(b);
+
+            secret
+                .is_in_field()
+                .then_some(secret)
+                .ok_or(Error::InvalidSecretKey)
+        }
+    }
+
+    impl TryFrom<&[u8]> for SecretKey {
+        type Error = Error;
+
+        fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
+            Bytes32::try_from(slice)
+                .map_err(|_| Secp256k1Error::InvalidSecretKey.into())
+                .and_then(SecretKey::try_from)
+        }
+    }
+
+    impl str::FromStr for SecretKey {
+        type Err = Error;
+
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            Bytes32::from_str(s)
+                .map_err(|_| Secp256k1Error::InvalidSecretKey.into())
+                .and_then(SecretKey::try_from)
+        }
+    }
+
+    impl Borrow<Secp256k1SecretKey> for SecretKey {
+        fn borrow(&self) -> &Secp256k1SecretKey {
+            // Safety: field checked. The memory representation of the secp256k1 key is
+            // `[u8; 32]`
+            unsafe { &*(self.as_ref().as_ptr() as *const Secp256k1SecretKey) }
+        }
+    }
+
+    #[cfg(feature = "random")]
+    impl rand::Fill for SecretKey {
+        fn try_fill<R: rand::Rng + ?Sized>(&mut self, rng: &mut R) -> Result<(), rand::Error> {
+            *self = Self::random(rng);
+
+            Ok(())
+        }
+    }
+
+    #[cfg(feature = "random")]
+    impl Distribution<SecretKey> for Standard {
+        fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> SecretKey {
+            SecretKey::random(rng)
+        }
+    }
+}

--- a/fuel-crypto/src/signature.rs
+++ b/fuel-crypto/src/signature.rs
@@ -157,11 +157,9 @@ mod use_std {
             let v = RecoveryId::from_i32(v)
                 .unwrap_or_else(|_| RecoveryId::from_i32(0).expect("0 is infallible recovery ID"));
 
-            let signature = SecpRecoverableSignature::from_compact(self.as_ref(), v)
-                .unwrap_or_else(|_| {
-                    SecpRecoverableSignature::from_compact(&[0u8; 64], v)
-                        .expect("Zeroed signature is infallible")
-                });
+            let signature = SecpRecoverableSignature::from_compact(self.as_ref(), v).unwrap_or_else(|_| {
+                SecpRecoverableSignature::from_compact(&[0u8; 64], v).expect("Zeroed signature is infallible")
+            });
 
             signature
         }

--- a/fuel-crypto/src/signature.rs
+++ b/fuel-crypto/src/signature.rs
@@ -1,0 +1,230 @@
+use crate::Error;
+
+use fuel_types::Bytes64;
+
+use core::ops::Deref;
+use core::{fmt, str};
+
+#[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[repr(transparent)]
+/// Secp256k1 signature implementation
+pub struct Signature(Bytes64);
+
+impl Signature {
+    /// Memory length of the type
+    pub const LEN: usize = Bytes64::LEN;
+
+    /// Add a conversion from arbitrary slices into owned
+    ///
+    /// # Safety
+    ///
+    /// There is no guarantee the provided bytes will be a valid signature. Internally, some FFI
+    /// calls to `secp256k1` are performed and we might have undefined behavior in case the bytes
+    /// are not canonically encoded to a valid `secp256k1` signature.
+    pub unsafe fn from_bytes_unchecked(bytes: [u8; Self::LEN]) -> Self {
+        Self(bytes.into())
+    }
+
+    /// Add a conversion from arbitrary slices into owned
+    ///
+    /// # Safety
+    ///
+    /// This function will not panic if the length of the slice is smaller than
+    /// `Self::LEN`. Instead, it will cause undefined behavior and read random
+    /// disowned bytes.
+    ///
+    /// There is no guarantee the provided bytes will be a valid signature. Internally, some FFI
+    /// calls to `secp256k1` are performed and we might have undefined behavior in case the bytes
+    /// are not canonically encoded to a valid `secp256k1` signature.
+    pub unsafe fn from_slice_unchecked(bytes: &[u8]) -> Self {
+        Self(Bytes64::from_slice_unchecked(bytes))
+    }
+
+    /// Copy-free reference cast
+    ///
+    /// There is no guarantee the provided bytes will fit the field.
+    ///
+    /// # Safety
+    ///
+    /// Inputs smaller than `Self::LEN` will cause undefined behavior.
+    pub unsafe fn as_ref_unchecked(bytes: &[u8]) -> &Self {
+        // The interpreter will frequently make references to keys and values using
+        // logically checked slices.
+        //
+        // This function will avoid unnecessary copy to owned slices for the interpreter
+        // access
+        &*(bytes.as_ptr() as *const Self)
+    }
+}
+
+impl Deref for Signature {
+    type Target = [u8; Signature::LEN];
+
+    fn deref(&self) -> &[u8; Signature::LEN] {
+        self.0.deref()
+    }
+}
+
+impl AsRef<[u8]> for Signature {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl AsMut<[u8]> for Signature {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.0.as_mut()
+    }
+}
+
+impl From<Signature> for [u8; Signature::LEN] {
+    fn from(salt: Signature) -> [u8; Signature::LEN] {
+        salt.0.into()
+    }
+}
+
+impl fmt::LowerHex for Signature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl fmt::UpperHex for Signature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl fmt::Debug for Signature {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl fmt::Display for Signature {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl From<Bytes64> for Signature {
+    fn from(b: Bytes64) -> Self {
+        Self(b)
+    }
+}
+
+impl From<Signature> for Bytes64 {
+    fn from(s: Signature) -> Self {
+        s.0
+    }
+}
+
+impl str::FromStr for Signature {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Bytes64::from_str(s)
+            .map_err(|_| Error::InvalidSignature)
+            .map(|s| s.into())
+    }
+}
+
+#[cfg(feature = "std")]
+mod use_std {
+    use crate::{Error, Message, PublicKey, SecretKey, Signature};
+
+    use lazy_static::lazy_static;
+    use secp256k1::{
+        ecdsa::{RecoverableSignature as SecpRecoverableSignature, RecoveryId},
+        Secp256k1,
+    };
+
+    use std::borrow::Borrow;
+
+    lazy_static! {
+        static ref SIGNING_SECP: Secp256k1<secp256k1::SignOnly> = Secp256k1::signing_only();
+        static ref RECOVER_SECP: Secp256k1<secp256k1::All> = Secp256k1::new();
+    }
+
+    impl Signature {
+        // Internal API - this isn't meant to be made public because some assumptions and pre-checks
+        // are performed prior to this call
+        pub(crate) fn to_secp(&mut self) -> SecpRecoverableSignature {
+            let v = (self.as_mut()[32] >> 7) as i32;
+
+            self.truncate_recovery_id();
+
+            let v = RecoveryId::from_i32(v)
+                .unwrap_or_else(|_| RecoveryId::from_i32(0).expect("0 is infallible recovery ID"));
+
+            let signature = SecpRecoverableSignature::from_compact(self.as_ref(), v)
+                .unwrap_or_else(|_| {
+                    SecpRecoverableSignature::from_compact(&[0u8; 64], v)
+                        .expect("Zeroed signature is infallible")
+                });
+
+            signature
+        }
+
+        pub(crate) fn from_secp(signature: SecpRecoverableSignature) -> Self {
+            let (v, mut signature) = signature.serialize_compact();
+
+            let v = v.to_i32();
+
+            signature[32] |= (v << 7) as u8;
+
+            // Safety: the security of this call reflects the security of secp256k1 FFI
+            unsafe { Signature::from_bytes_unchecked(signature) }
+        }
+
+        /// Truncate the recovery id from the signature, producing a valid `secp256k1`
+        /// representation.
+        pub(crate) fn truncate_recovery_id(&mut self) {
+            self.as_mut()[32] &= 0x7f;
+        }
+
+        /// Sign a given message and compress the `v` to the signature
+        ///
+        /// The compression scheme is described in
+        /// <https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/cryptographic_primitives.md#public-key-cryptography>
+        pub fn sign(secret: &SecretKey, message: &Message) -> Self {
+            let secret = secret.borrow();
+            let message = message.to_secp();
+
+            let signature = SIGNING_SECP.sign_ecdsa_recoverable(&message, secret);
+
+            Signature::from_secp(signature)
+        }
+
+        /// Recover the public key from a signature performed with
+        /// [`Signature::sign`]
+        ///
+        /// It takes the signature as owned because this operation is not idempotent. The taken
+        /// signature will not be recoverable. Signatures are meant to be single use, so this
+        /// avoids unnecessary copy.
+        pub fn recover(mut self, message: &Message) -> Result<PublicKey, Error> {
+            let signature = self.to_secp();
+            let message = message.to_secp();
+
+            let pk = RECOVER_SECP
+                .recover_ecdsa(&message, &signature)
+                .map(|pk| PublicKey::from_secp(&pk))?;
+
+            Ok(pk)
+        }
+
+        /// Verify a signature produced by [`Signature::sign`]
+        ///
+        /// It takes the signature as owned because this operation is not idempotent. The taken
+        /// signature will not be recoverable. Signatures are meant to be single use, so this
+        /// avoids unnecessary copy.
+        pub fn verify(self, pk: &PublicKey, message: &Message) -> Result<(), Error> {
+            // TODO evaluate if its worthy to use native verify
+            //
+            // https://github.com/FuelLabs/fuel-crypto/issues/4
+
+            self.recover(message)
+                .and_then(|pk_p| (pk == &pk_p).then_some(()).ok_or(Error::InvalidSignature))
+        }
+    }
+}

--- a/fuel-crypto/src/signer.rs
+++ b/fuel-crypto/src/signer.rs
@@ -1,0 +1,69 @@
+use crate::{Error, Keystore, Message, PublicKey, SecretKey, Signature};
+
+use borrown::Borrown;
+
+/// Signature provider based on a keystore
+pub trait Signer {
+    /// Keystore error implementation
+    type Error: From<Error> + From<<Self::Keystore as Keystore>::Error>;
+
+    /// Concrete keystore implementation
+    type Keystore: Keystore;
+
+    /// Accessor to the keystore
+    ///
+    /// Might fail if the keystore is in a corrupt state, not initialized or locked by a
+    /// concurrent thread.
+    fn keystore(&self) -> Result<&Self::Keystore, Self::Error>;
+
+    /// Secret key indexed by `id`.
+    fn id_secret(
+        &self,
+        id: &<Self::Keystore as Keystore>::KeyId,
+    ) -> Result<Borrown<'_, SecretKey>, Self::Error> {
+        let keystore = self.keystore()?;
+        let secret = keystore.secret(id)?.ok_or(Error::KeyNotFound)?;
+
+        Ok(secret)
+    }
+
+    /// Public key indexed by `id`.
+    fn id_public(
+        &self,
+        id: &<Self::Keystore as Keystore>::KeyId,
+    ) -> Result<Borrown<'_, PublicKey>, Self::Error> {
+        let keystore = self.keystore()?;
+        let public = keystore.public(id)?.ok_or(Error::KeyNotFound)?;
+
+        Ok(public)
+    }
+
+    /// Sign a given message with the secret key identified by `id`
+    fn sign(
+        &self,
+        id: &<Self::Keystore as Keystore>::KeyId,
+        message: &Message,
+    ) -> Result<Signature, Self::Error> {
+        let secret = self.id_secret(id)?;
+
+        self.sign_with_key(secret.as_ref(), message)
+    }
+
+    /// Sign a given message with the provided key
+    #[cfg(not(feature = "std"))]
+    fn sign_with_key(
+        &self,
+        secret: &SecretKey,
+        message: &Message,
+    ) -> Result<Signature, Self::Error>;
+
+    /// Sign a given message with the provided key
+    #[cfg(feature = "std")]
+    fn sign_with_key(
+        &self,
+        secret: &SecretKey,
+        message: &Message,
+    ) -> Result<Signature, Self::Error> {
+        Ok(Signature::sign(secret, message))
+    }
+}

--- a/fuel-crypto/src/signer.rs
+++ b/fuel-crypto/src/signer.rs
@@ -17,10 +17,7 @@ pub trait Signer {
     fn keystore(&self) -> Result<&Self::Keystore, Self::Error>;
 
     /// Secret key indexed by `id`.
-    fn id_secret(
-        &self,
-        id: &<Self::Keystore as Keystore>::KeyId,
-    ) -> Result<Borrown<'_, SecretKey>, Self::Error> {
+    fn id_secret(&self, id: &<Self::Keystore as Keystore>::KeyId) -> Result<Borrown<'_, SecretKey>, Self::Error> {
         let keystore = self.keystore()?;
         let secret = keystore.secret(id)?.ok_or(Error::KeyNotFound)?;
 
@@ -28,10 +25,7 @@ pub trait Signer {
     }
 
     /// Public key indexed by `id`.
-    fn id_public(
-        &self,
-        id: &<Self::Keystore as Keystore>::KeyId,
-    ) -> Result<Borrown<'_, PublicKey>, Self::Error> {
+    fn id_public(&self, id: &<Self::Keystore as Keystore>::KeyId) -> Result<Borrown<'_, PublicKey>, Self::Error> {
         let keystore = self.keystore()?;
         let public = keystore.public(id)?.ok_or(Error::KeyNotFound)?;
 
@@ -39,11 +33,7 @@ pub trait Signer {
     }
 
     /// Sign a given message with the secret key identified by `id`
-    fn sign(
-        &self,
-        id: &<Self::Keystore as Keystore>::KeyId,
-        message: &Message,
-    ) -> Result<Signature, Self::Error> {
+    fn sign(&self, id: &<Self::Keystore as Keystore>::KeyId, message: &Message) -> Result<Signature, Self::Error> {
         let secret = self.id_secret(id)?;
 
         self.sign_with_key(secret.as_ref(), message)
@@ -51,19 +41,11 @@ pub trait Signer {
 
     /// Sign a given message with the provided key
     #[cfg(not(feature = "std"))]
-    fn sign_with_key(
-        &self,
-        secret: &SecretKey,
-        message: &Message,
-    ) -> Result<Signature, Self::Error>;
+    fn sign_with_key(&self, secret: &SecretKey, message: &Message) -> Result<Signature, Self::Error>;
 
     /// Sign a given message with the provided key
     #[cfg(feature = "std")]
-    fn sign_with_key(
-        &self,
-        secret: &SecretKey,
-        message: &Message,
-    ) -> Result<Signature, Self::Error> {
+    fn sign_with_key(&self, secret: &SecretKey, message: &Message) -> Result<Signature, Self::Error> {
         Ok(Signature::sign(secret, message))
     }
 }

--- a/fuel-crypto/tests/hasher.rs
+++ b/fuel-crypto/tests/hasher.rs
@@ -33,10 +33,7 @@ fn digest() {
 
     assert_eq!(digest, d);
 
-    let d = input
-        .iter()
-        .fold(Hasher::default(), |h, i| h.chain(i))
-        .finalize();
+    let d = input.iter().fold(Hasher::default(), |h, i| h.chain(i)).finalize();
 
     assert_eq!(digest, d);
 

--- a/fuel-crypto/tests/hasher.rs
+++ b/fuel-crypto/tests/hasher.rs
@@ -1,0 +1,50 @@
+use fuel_crypto::*;
+
+#[test]
+fn digest() {
+    let input: [&'static [u8]; 14] = [
+        b"I met a traveler from an antique land",
+        b"Who said: 'Two vast and trunkless legs of stone'",
+        b"Stand in the desert. Near them, on the sand,",
+        b"Half sunk, a shattered visage lies, whose frown,",
+        b"And wrinkled lip, and sneer of cold command,",
+        b"Tell that its sculptor well those passions read",
+        b"Which yet survive, stamped on these lifeless things,",
+        b"The hand that mocked them and the heart that fed:",
+        b"And on the pedestal these words appear:",
+        b"'My name is Ozymandias, king of kings;'",
+        b"Look on my works, ye Mighty, and despair!",
+        b"Nothing beside remains. Round the decay",
+        b"Of that colossal wreck, boundless and bare",
+        b"The lone and level sands stretch far away.",
+    ];
+
+    let mut h = Hasher::default();
+
+    input.iter().for_each(|i| h.input(i));
+
+    let digest = h.finalize();
+
+    let mut h = Hasher::default();
+
+    h.extend(input.iter());
+
+    let d = h.finalize();
+
+    assert_eq!(digest, d);
+
+    let d = input
+        .iter()
+        .fold(Hasher::default(), |h, i| h.chain(i))
+        .finalize();
+
+    assert_eq!(digest, d);
+
+    let d = Hasher::default().extend_chain(input.iter()).finalize();
+
+    assert_eq!(digest, d);
+
+    let d = input.iter().collect::<Hasher>().finalize();
+
+    assert_eq!(digest, d);
+}

--- a/fuel-crypto/tests/mnemonic.rs
+++ b/fuel-crypto/tests/mnemonic.rs
@@ -1,0 +1,50 @@
+use std::str::FromStr;
+
+use coins_bip32::path::DerivationPath;
+use coins_bip39::{English, Mnemonic};
+use fuel_crypto::{FuelMnemonic, SecretKey};
+
+type W = English;
+
+#[test]
+fn secret_key_from_mnemonic_phrase() {
+    let phrase = "oblige salon price punch saddle immune slogan rare snap desert retire surprise";
+
+    let expected_public_key = "30cc18506ed9d500fa348d1202bac14e9683b6d4cd7a02eb5357504d74ff2a19a8b672eb22c6509588424bab5c627515a9105b7ad25b7f948fcb5cd09448df5e";
+
+    let secret = SecretKey::new_from_mnemonic_phrase_with_path(phrase, "m/44'/60'/0'/0/0")
+        .expect("failed to create secret key from mnemonic phrase");
+
+    let public = secret.public_key();
+
+    assert_eq!(public.to_string(), expected_public_key);
+}
+
+#[test]
+fn secret_key_from_mnemonic() {
+    let phrase = "oblige salon price punch saddle immune slogan rare snap desert retire surprise";
+    let expected_public_key = "30cc18506ed9d500fa348d1202bac14e9683b6d4cd7a02eb5357504d74ff2a19a8b672eb22c6509588424bab5c627515a9105b7ad25b7f948fcb5cd09448df5e";
+
+    let m = Mnemonic::<W>::new_from_phrase(phrase).expect("failed to create mnemonic");
+
+    let d = DerivationPath::from_str("m/44'/60'/0'/0/0").expect("failed to create derivation path");
+    let secret =
+        SecretKey::new_from_mnemonic(d, m).expect("failed to create secret key from mnemonic");
+
+    let public = secret.public_key();
+    let public_key = public.to_string();
+
+    assert_eq!(public_key, expected_public_key);
+}
+
+#[test]
+fn random_mnemonic_phrase() {
+    // create rng
+    let mut rng = rand::thread_rng();
+
+    let phrase = FuelMnemonic::generate_mnemonic_phrase(&mut rng, 12)
+        .expect("failed to generate mnemonic phrase");
+
+    let _secret = SecretKey::new_from_mnemonic_phrase_with_path(&phrase, "m/44'/60'/0'/0/0")
+        .expect("failed to create secret key from mnemonic phrase");
+}

--- a/fuel-crypto/tests/mnemonic.rs
+++ b/fuel-crypto/tests/mnemonic.rs
@@ -28,8 +28,7 @@ fn secret_key_from_mnemonic() {
     let m = Mnemonic::<W>::new_from_phrase(phrase).expect("failed to create mnemonic");
 
     let d = DerivationPath::from_str("m/44'/60'/0'/0/0").expect("failed to create derivation path");
-    let secret =
-        SecretKey::new_from_mnemonic(d, m).expect("failed to create secret key from mnemonic");
+    let secret = SecretKey::new_from_mnemonic(d, m).expect("failed to create secret key from mnemonic");
 
     let public = secret.public_key();
     let public_key = public.to_string();
@@ -42,8 +41,7 @@ fn random_mnemonic_phrase() {
     // create rng
     let mut rng = rand::thread_rng();
 
-    let phrase = FuelMnemonic::generate_mnemonic_phrase(&mut rng, 12)
-        .expect("failed to generate mnemonic phrase");
+    let phrase = FuelMnemonic::generate_mnemonic_phrase(&mut rng, 12).expect("failed to generate mnemonic phrase");
 
     let _secret = SecretKey::new_from_mnemonic_phrase_with_path(&phrase, "m/44'/60'/0'/0/0")
         .expect("failed to create secret key from mnemonic phrase");

--- a/fuel-crypto/tests/serde.rs
+++ b/fuel-crypto/tests/serde.rs
@@ -1,0 +1,33 @@
+use fuel_crypto::{Message, SecretKey, Signature};
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+
+#[test]
+fn serde() {
+    let rng = &mut StdRng::seed_from_u64(8586);
+
+    let secret = SecretKey::random(rng);
+    let secret_p = bincode::serialize(&secret).expect("Failed to serialize secret");
+    let secret_p = bincode::deserialize(&secret_p).expect("Failed to deserialize secret");
+
+    assert_eq!(secret, secret_p);
+
+    let public = secret.public_key();
+    let public_p = bincode::serialize(&public).expect("Failed to serialize public");
+    let public_p = bincode::deserialize(&public_p).expect("Failed to deserialize public");
+
+    assert_eq!(public, public_p);
+
+    let message = b"Two souls live in me, alas, Irreconcilable with one another.";
+    let message = Message::new(message);
+    let message_p = bincode::serialize(&message).expect("Failed to serialize message");
+    let message_p = bincode::deserialize(&message_p).expect("Failed to deserialize message");
+
+    assert_eq!(message, message_p);
+
+    let signature = Signature::sign(&secret, &message);
+    let signature_p = bincode::serialize(&signature).expect("Failed to serialize signature");
+    let signature_p = bincode::deserialize(&signature_p).expect("Failed to deserialize signature");
+
+    assert_eq!(signature, signature_p);
+}

--- a/fuel-crypto/tests/signature.rs
+++ b/fuel-crypto/tests/signature.rs
@@ -6,8 +6,7 @@ use rand::SeedableRng;
 fn recover() {
     let rng = &mut StdRng::seed_from_u64(8586);
 
-    let message =
-        b"A beast can never be as cruel as a human being, so artistically, so picturesquely cruel.";
+    let message = b"A beast can never be as cruel as a human being, so artistically, so picturesquely cruel.";
 
     for _ in 0..100 {
         let message = Message::new(message);
@@ -26,8 +25,7 @@ fn recover() {
 fn verify() {
     let rng = &mut StdRng::seed_from_u64(8586);
 
-    let message =
-        b"Music expresses that which cannot be put into words and that which cannot remain silent.";
+    let message = b"Music expresses that which cannot be put into words and that which cannot remain silent.";
 
     for _ in 0..100 {
         let message = Message::new(message);
@@ -37,9 +35,7 @@ fn verify() {
 
         let signature = Signature::sign(&secret, &message);
 
-        signature
-            .verify(&public, &message)
-            .expect("Failed to verify signature");
+        signature.verify(&public, &message).expect("Failed to verify signature");
     }
 }
 

--- a/fuel-crypto/tests/signature.rs
+++ b/fuel-crypto/tests/signature.rs
@@ -1,0 +1,100 @@
+use fuel_crypto::{Error, Message, PublicKey, SecretKey, Signature};
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+
+#[test]
+fn recover() {
+    let rng = &mut StdRng::seed_from_u64(8586);
+
+    let message =
+        b"A beast can never be as cruel as a human being, so artistically, so picturesquely cruel.";
+
+    for _ in 0..100 {
+        let message = Message::new(message);
+
+        let secret = SecretKey::random(rng);
+        let public = secret.public_key();
+
+        let signature = Signature::sign(&secret, &message);
+        let recover = signature.recover(&message).expect("Failed to recover PK");
+
+        assert_eq!(public, recover);
+    }
+}
+
+#[test]
+fn verify() {
+    let rng = &mut StdRng::seed_from_u64(8586);
+
+    let message =
+        b"Music expresses that which cannot be put into words and that which cannot remain silent.";
+
+    for _ in 0..100 {
+        let message = Message::new(message);
+
+        let secret = SecretKey::random(rng);
+        let public = secret.public_key();
+
+        let signature = Signature::sign(&secret, &message);
+
+        signature
+            .verify(&public, &message)
+            .expect("Failed to verify signature");
+    }
+}
+
+#[test]
+fn corrupted_signature() {
+    let rng = &mut StdRng::seed_from_u64(8586);
+
+    let message = b"When life itself seems lunatic, who knows where madness lies?";
+    let message = Message::new(message);
+
+    let secret = SecretKey::random(rng);
+    let public = secret.public_key();
+
+    let signature = Signature::sign(&secret, &message);
+
+    // Tamper, bit by bit, the signature and public key.
+    //
+    // The recover and verify operations should fail in all cases.
+    (0..Signature::LEN).for_each(|i| {
+        (0..7).fold(1u8, |m, _| {
+            let mut s = signature;
+
+            s.as_mut()[i] ^= m;
+
+            match s.recover(&message) {
+                Ok(pk) => assert_ne!(public, pk),
+                Err(Error::InvalidSignature) => (),
+                Err(e) => panic!("Unexpected error: {}", e),
+            }
+
+            m << 1
+        });
+    });
+
+    (0..Signature::LEN).for_each(|i| {
+        (0..7).fold(1u8, |m, _| {
+            let mut s = signature;
+
+            s.as_mut()[i] ^= m;
+
+            assert!(s.verify(&public, &message).is_err());
+
+            m << 1
+        });
+    });
+
+    (0..PublicKey::LEN).for_each(|i| {
+        (0..7).fold(1u8, |m, _| {
+            let mut p = public;
+
+            p.as_mut()[i] ^= m;
+
+            assert!(signature.verify(&p, &message).is_err());
+
+            m << 1
+        });
+    });
+}

--- a/fuel-crypto/tests/signer.rs
+++ b/fuel-crypto/tests/signer.rs
@@ -1,0 +1,104 @@
+use fuel_crypto::borrown::Borrown;
+use fuel_crypto::{Keystore, Message, SecretKey, Signer};
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+
+use std::io;
+
+#[derive(Debug, Default, Clone)]
+struct TestKeystore {
+    keys: Vec<SecretKey>,
+}
+
+impl TestKeystore {
+    pub fn generate_key<R>(&mut self, rng: &mut R) -> usize
+    where
+        R: rand::Rng + ?Sized,
+    {
+        let n = self.keys.len();
+
+        let secret = SecretKey::random(rng);
+
+        self.keys.push(secret);
+
+        n
+    }
+}
+
+impl Keystore for TestKeystore {
+    type Error = io::Error;
+    type KeyId = usize;
+
+    fn secret(&self, id: &usize) -> Result<Option<Borrown<'_, SecretKey>>, io::Error> {
+        Ok(self.keys.get(*id).map(Borrown::from))
+    }
+}
+
+impl AsRef<TestKeystore> for TestKeystore {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
+impl Signer for TestKeystore {
+    type Error = io::Error;
+    type Keystore = Self;
+
+    fn keystore(&self) -> Result<&Self, Self::Error> {
+        Ok(self)
+    }
+}
+
+#[test]
+fn signer() {
+    let rng = &mut StdRng::seed_from_u64(8586);
+
+    let mut keystore = TestKeystore::default();
+
+    let message = b"It is amazing how complete is the delusion that beauty is goodness.";
+    let message = Message::new(message);
+
+    let key = keystore.generate_key(rng);
+    let key_p = keystore.generate_key(rng);
+
+    assert_ne!(key, key_p);
+
+    keystore
+        .public(&key)
+        .expect("Test keystore is infallible")
+        .expect("PK was inserted");
+
+    keystore
+        .public(&key_p)
+        .expect("Test keystore is infallible")
+        .expect("PK was inserted");
+
+    let signature = keystore.sign(&key, &message).expect("Failed to sign");
+    let signature_p = keystore.sign(&key_p, &message).expect("Failed to sign");
+
+    let public = keystore
+        .public(&key)
+        .expect("Failed to access keystore")
+        .expect("Key not found");
+
+    let public_p = keystore
+        .public(&key_p)
+        .expect("Failed to access keystore")
+        .expect("Key not found");
+
+    signature
+        .verify(public.as_ref(), &message)
+        .expect("Failed to verify signature");
+
+    signature_p
+        .verify(public_p.as_ref(), &message)
+        .expect("Failed to verify signature");
+
+    signature
+        .verify(public_p.as_ref(), &message)
+        .expect_err("Wrong key should fail verification");
+
+    signature_p
+        .verify(public.as_ref(), &message)
+        .expect_err("Wrong key should fail verification");
+}

--- a/fuel-tx/Cargo.toml
+++ b/fuel-tx/Cargo.toml
@@ -14,7 +14,7 @@ description = "FuelVM transaction."
 bitflags = "1"
 derivative = { version = "2.2.0", default-features = false, features = ["use_core"] }
 fuel-asm = { version = "0.10", path = "../fuel-asm", default-features = false }
-fuel-crypto = { version = "0.6", default-features = false }
+fuel-crypto = { version = "0.6", path = "../fuel-crypto", default-features = false }
 fuel-merkle = { version = "0.4", default-features = false }
 fuel-types = { version = "0.5", path = "../fuel-types", default-features = false }
 itertools = { version = "0.10", default-features = false }
@@ -25,7 +25,7 @@ serde_json = { version = "1.0", default-features = false, features = ["alloc"], 
 
 [dev-dependencies]
 bincode = { version = "1.3", default-features = false }
-fuel-crypto = { version = "0.6", default-features = false, features = ["random"] }
+fuel-crypto = { version = "0.6", path = "../fuel-crypto", default-features = false, features = ["random"] }
 fuel-tx = { path = ".", features = ["builder", "random"] }
 fuel-tx-test-helpers = { path = "test-helpers" }
 fuel-types = { version = "0.5", path = "../fuel-types", default-features = false, features = ["random"] }

--- a/fuel-tx/test-helpers/Cargo.toml
+++ b/fuel-tx/test-helpers/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 publish = false
 
 [dependencies]
-fuel-crypto = { version = "0.6", default-features = false, features = ["random"] }
+fuel-crypto = { version = "0.6", path = "../../fuel-crypto", default-features = false, features = ["random"] }
 fuel-tx = { path = "../../fuel-tx", default-features = false, features = ["builder", "random"] }
-fuel-types = { version = "0.5", default-features = false, features = ["random"] }
+fuel-types = { version = "0.5", path = "../../fuel-types", default-features = false, features = ["random"] }
 rand = { version = "0.8", default-features = false }
 
 [features]

--- a/fuel-vm/Cargo.toml
+++ b/fuel-vm/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = { version = "1.0", optional = true }
 backtrace = { version = "0.3", optional = true } # requires debug symbols to work
 dyn-clone = { version = "1.0", optional = true }
 fuel-asm = { version = "0.10", path = "../fuel-asm" }
-fuel-crypto = "0.6"
+fuel-crypto = { version = "0.6", path = "../fuel-crypto" }
 fuel-merkle = "0.4"
 fuel-storage = { version = "0.3", path = "../fuel-storage" }
 fuel-tx = { version = "0.23", path = "../fuel-tx" }


### PR DESCRIPTION
This PR is based on @ControlCplusControlV's WIP merge in #274.

This PR merges the `fuel-crypto` repository into this repo (in a history-preserving manner) to avoid introducing a dependency cycle between the `fuel-vm` and `fuel-crypto` repositories as highlighted [here](https://github.com/FuelLabs/fuel-vm/pull/274#issuecomment-1336388924).

**NOTE:** If/when we merge this into @ControlCplusControlV's branch, we should *not* use the "Squash" option and instead should add a new merge commit. Otherwise, I think we risk squashing the preserved history commits included within this PR into a single commit, which is probably not what we want.

cc @adlerjohn @sezna I think one of you might need to re-enable the option to merge without squashing temporarily until both this PR and #274 have landed?