### PR TITLE
Fix bug in `LOGD` which throws `MemoryOverflow` for buffers at the very top of RAM

### DIFF
--- a/src/interpreter/log.rs
+++ b/src/interpreter/log.rs
@@ -28,7 +28,7 @@ where
     }
 
     pub(crate) fn log_data(&mut self, a: Word, b: Word, c: Word, d: Word) -> Result<(), RuntimeError> {
-        if d > MEM_MAX_ACCESS_SIZE || c >= VM_MAX_RAM - d {
+        if d > MEM_MAX_ACCESS_SIZE || c > VM_MAX_RAM - d {
             return Err(PanicReason::MemoryOverflow.into());
         }
 

--- a/tests/flow.rs
+++ b/tests/flow.rs
@@ -810,3 +810,39 @@ fn retd_from_top_of_heap() {
     assert_eq!(receipts.len(), 2);
     assert!(matches!(receipts[0], Receipt::ReturnData { .. }));
 }
+
+#[test]
+fn logd_from_top_of_heap() {
+    let mut client = MemoryClient::default();
+
+    let gas_price = 0;
+    let gas_limit = 1_000_000;
+    let maturity = 0;
+    let height = 0;
+    let params = ConsensusParameters::DEFAULT;
+
+    const REG_SIZE: usize = REG_WRITABLE;
+    const REG_PTR: usize = REG_WRITABLE + 1;
+
+    #[rustfmt::skip]
+    let script = vec![
+        Opcode::MOVI(REG_SIZE, 32),                           // Allocate 32 bytes.
+        Opcode::ALOC(REG_SIZE),                               // $hp -= 32.
+        Opcode::ADDI(REG_PTR, REG_HP, 1),                     // Pointer is $hp + 1, first byte in allocated buffer.
+        Opcode::LOGD(REG_ZERO, REG_ZERO, REG_PTR, REG_SIZE),  // Log the whole buffer
+        Opcode::RET(REG_ONE),                                 // Return 
+    ].into_iter()
+    .collect::<Vec<u8>>();
+
+    let tx = Transaction::script(gas_price, gas_limit, maturity, script, vec![], vec![], vec![], vec![])
+        .into_checked(height, &params)
+        .expect("failed to generate a checked tx");
+
+    client.transact(tx);
+
+    let receipts = client.receipts().expect("Expected receipts");
+
+    // Expect the correct receipt
+    assert_eq!(receipts.len(), 3);
+    assert!(matches!(receipts[0], Receipt::LogData { .. }));
+}


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuel-vm/issues/282

This is quite similar to https://github.com/FuelLabs/fuel-vm/pull/229