### PR TITLE
Return `None` for zeroed `ContractId` in `Receipt`

### DIFF
--- a/fuel-vm/tests/flow.rs
+++ b/fuel-vm/tests/flow.rs
@@ -239,10 +239,7 @@ fn call() {
         .expect("Failed to execute script")
         .to_owned();
 
-    assert_eq!(
-        receipts[0].id().expect("Receipt value failed").to_owned(),
-        ContractId::default()
-    );
+    assert_eq!(receipts[0].id(), None);
     assert_eq!(receipts[0].to().expect("Receipt value failed").to_owned(), contract);
     assert_eq!(receipts[1].ra().expect("Receipt value failed"), 0x11);
     assert_eq!(receipts[1].rb().expect("Receipt value failed"), 0x2a);


### PR DESCRIPTION
# Problem

We have optional methods for fetching contract id's from receipts, however the VM returns all zeros instead of None. This caused unexpected failures since downstream we expect these methods to only return Some if there is a real contract id.

# Solution

If contract id is zeroed, convert to an Option::None when fetching receipt fields.