### PR TITLE
feat: Separate SMT impls for mutable and immutable storage

### DIFF
--- a/fuel-merkle/src/binary/in_memory.rs
+++ b/fuel-merkle/src/binary/in_memory.rs
@@ -1,8 +1,8 @@
 use crate::{
     binary::{self, Primitive},
     common::{Bytes32, ProofSet, StorageMap},
+    storage::Mappable
 };
-use fuel_storage::Mappable;
 
 /// The table of the Binary Merkle Tree's nodes. [`MerkleTree`] works with it as
 /// a binary array, where the storage key of the node is the `u64` index and

--- a/fuel-merkle/src/binary/in_memory.rs
+++ b/fuel-merkle/src/binary/in_memory.rs
@@ -1,7 +1,7 @@
 use crate::{
     binary::{self, Primitive},
     common::{Bytes32, ProofSet, StorageMap},
-    storage::Mappable
+    storage::Mappable,
 };
 
 /// The table of the Binary Merkle Tree's nodes. [`MerkleTree`] works with it as

--- a/fuel-merkle/src/sparse/in_memory.rs
+++ b/fuel-merkle/src/sparse/in_memory.rs
@@ -1,8 +1,8 @@
 use crate::{
     common::{Bytes32, StorageMap},
     sparse::{self, Primitive},
+    storage::Mappable
 };
-use fuel_storage::Mappable;
 
 /// The table of the Sparse Merkle tree's nodes. [`MerkleTree`] works with it as a sparse merkle
 /// tree, where the storage key is `Bytes32` and the value is the [`Buffer`](crate::sparse::Buffer)

--- a/fuel-merkle/src/sparse/in_memory.rs
+++ b/fuel-merkle/src/sparse/in_memory.rs
@@ -1,7 +1,7 @@
 use crate::{
     common::{Bytes32, StorageMap},
     sparse::{self, Primitive},
-    storage::Mappable
+    storage::Mappable,
 };
 
 /// The table of the Sparse Merkle tree's nodes. [`MerkleTree`] works with it as a sparse merkle

--- a/fuel-merkle/src/sparse/merkle_tree.rs
+++ b/fuel-merkle/src/sparse/merkle_tree.rs
@@ -1,12 +1,11 @@
 use crate::{
     common::{error::DeserializeError, AsPathIterator, Bytes32, ChildError},
     sparse::{primitive::Primitive, zero_sum, Node, StorageNode, StorageNodeError},
-    storage::{Mappable, StorageMutate},
+    storage::{Mappable, StorageInspect, StorageMutate},
 };
 
 use alloc::{string::String, vec::Vec};
 use core::{cmp, iter, marker::PhantomData};
-use fuel_storage::StorageInspect;
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "std", derive(thiserror::Error))]

--- a/fuel-merkle/src/sparse/node.rs
+++ b/fuel-merkle/src/sparse/node.rs
@@ -284,7 +284,6 @@ impl<TableType, StorageType> ParentNodeTrait for StorageNode<'_, TableType, Stor
 where
     StorageType: StorageInspect<TableType>,
     TableType: Mappable<Key = Bytes32, Value = Primitive, OwnedValue = Primitive>,
-    StorageType::Error: fmt::Debug,
 {
     type Error = StorageNodeError<StorageType::Error>;
 
@@ -333,7 +332,6 @@ impl<TableType, StorageType> fmt::Debug for StorageNode<'_, TableType, StorageTy
 where
     StorageType: StorageInspect<TableType>,
     TableType: Mappable<Key = Bytes32, Value = Primitive, OwnedValue = Primitive>,
-    StorageType::Error: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.is_node() {


### PR DESCRIPTION
Similar to https://github.com/FuelLabs/fuel-merkle/pull/141, this PR separates the SMT implementation blocks across mutable and immutable storage. In some cases, we need to be able to call methods, such as `root` when the tree only has immutable storage access. When a method does not need mutable storage access, these methods can now be called. 