### PR TITLE
Some improvements of API after integration of previous release into `fuel-core`

### DIFF
--- a/fuel-merkle/src/binary/merkle_tree.rs
+++ b/fuel-merkle/src/binary/merkle_tree.rs
@@ -38,11 +38,15 @@ pub struct MerkleTree<TableType, StorageType> {
 }
 
 impl<TableType, StorageType> MerkleTree<TableType, StorageType> {
+    pub const fn empty_root() -> Bytes32 {
+        *empty_sum()
+    }
+
     pub fn root(&self) -> Bytes32 {
         let mut scratch_storage = StorageMap::<NodesTable>::new();
         let root_node = self.root_node(&mut scratch_storage);
         match root_node {
-            None => *empty_sum(),
+            None => Self::empty_root(),
             Some(ref node) => *node.hash(),
         }
     }
@@ -461,7 +465,7 @@ mod test {
     fn load_returns_empty_tree_for_0_leaves() {
         const LEAVES_COUNT: u64 = 0;
 
-        let expected_root = *empty_sum();
+        let expected_root = MerkleTree::<(), ()>::empty_root();
 
         let root = {
             let mut storage_map = StorageMap::<TestTable>::new();

--- a/fuel-merkle/src/sparse/hash.rs
+++ b/fuel-merkle/src/sparse/hash.rs
@@ -5,7 +5,7 @@ use sha2::Sha256;
 
 pub(crate) type Hash = Sha256;
 
-pub fn zero_sum() -> &'static Bytes32 {
+pub const fn zero_sum() -> &'static Bytes32 {
     const ZERO_SUM: Bytes32 = [0; 32];
 
     &ZERO_SUM

--- a/fuel-merkle/src/sparse/merkle_tree.rs
+++ b/fuel-merkle/src/sparse/merkle_tree.rs
@@ -40,6 +40,10 @@ pub struct MerkleTree<TableType, StorageType> {
 }
 
 impl<TableType, StorageType> MerkleTree<TableType, StorageType> {
+    pub const fn empty_root() -> Bytes32 {
+        *zero_sum()
+    }
+
     pub fn root(&self) -> Bytes32 {
         self.root_node().hash()
     }
@@ -138,7 +142,7 @@ where
     }
 
     pub fn delete(&mut self, key: &Bytes32) -> Result<(), MerkleTreeError<StorageError>> {
-        if self.root() == *zero_sum() {
+        if self.root() == Self::empty_root() {
             // The zero root signifies that all leaves are empty, including the
             // given key.
             return Ok(());

--- a/fuel-merkle/src/sum/merkle_tree.rs
+++ b/fuel-merkle/src/sum/merkle_tree.rs
@@ -44,6 +44,12 @@ pub struct MerkleTree<TableType, StorageType> {
     phantom_table: PhantomData<TableType>,
 }
 
+impl<TableType, StorageType> MerkleTree<TableType, StorageType> {
+    pub const fn empty_root() -> (u64, Bytes32) {
+        (0, *empty_sum())
+    }
+}
+
 impl<TableType, StorageType, StorageError> MerkleTree<TableType, StorageType>
 where
     TableType: Mappable<Key = Bytes32, Value = Node, OwnedValue = Node>,
@@ -61,7 +67,7 @@ where
     pub fn root(&mut self) -> Result<(u64, Bytes32), StorageError> {
         let root_node = self.root_node()?;
         let root_pair = match root_node {
-            None => (0, *empty_sum()),
+            None => Self::empty_root(),
             Some(ref node) => (node.fee(), *node.hash()),
         };
 
@@ -145,7 +151,7 @@ where
 mod test {
     use crate::{
         common::{Bytes32, StorageMap},
-        sum::{empty_sum, leaf_sum, node_sum, MerkleTree, Node},
+        sum::{leaf_sum, node_sum, MerkleTree, Node},
     };
     use fuel_merkle_test_helpers::TEST_DATA;
     use fuel_storage::Mappable;
@@ -167,7 +173,7 @@ mod test {
         let mut tree = MerkleTree::new(&mut storage_map);
 
         let root = tree.root().unwrap();
-        assert_eq!(root, (0, *empty_sum()));
+        assert_eq!(root, MerkleTree::<(), ()>::empty_root());
     }
 
     #[test]

--- a/fuel-vm/src/storage.rs
+++ b/fuel-vm/src/storage.rs
@@ -81,12 +81,25 @@ macro_rules! double_key {
         }
 
         impl $i {
+            /// The length of the underlying array.
+            pub const LEN: usize = $first::LEN + $second::LEN;
+
             /// Create a new instance of the double storage key from references.
             pub fn new(first: &$first, second: &$second) -> Self {
                 let mut default = Self::default();
                 default.0[0..Self::first_end()].copy_from_slice(first.as_ref());
                 default.0[Self::first_end()..Self::second_end()].copy_from_slice(second.as_ref());
                 default
+            }
+
+            /// Creates a new instance of double storage key from the array.
+            pub fn from_array(array: [u8; { $first::LEN + $second::LEN }]) -> Self {
+                Self(array)
+            }
+
+            /// Creates a new instance of double storage key from the slice.
+            pub fn from_slice(slice: &[u8]) -> Result<Self, core::array::TryFromSliceError> {
+                Ok(Self(slice.try_into()?))
             }
 
             /// Returns the reference to the first sub-key.
@@ -127,6 +140,12 @@ macro_rules! double_key {
                 let first = first.try_into().unwrap();
                 let second = second.try_into().unwrap();
                 (first, second)
+            }
+        }
+
+        impl From<$i> for [u8; { $first::LEN + $second::LEN }] {
+            fn from(key: $i) -> [u8; { $first::LEN + $second::LEN }] {
+                key.0
             }
         }
     };


### PR DESCRIPTION
After https://github.com/FuelLabs/fuel-core/pull/917 I realized that it would be nice to have some additional methods.

- Added static `empty_root` method to all Merkle trees.
- Added new constructors for double storage key.