### PR TITLE
chore: BMT clean up

### DIFF
--- a/fuel-merkle/src/binary/in_memory.rs
+++ b/fuel-merkle/src/binary/in_memory.rs
@@ -34,11 +34,11 @@ impl MerkleTree {
         let _ = self.tree.push(data);
     }
 
-    pub fn root(&mut self) -> Bytes32 {
+    pub fn root(&self) -> Bytes32 {
         self.tree.root()
     }
 
-    pub fn prove(&mut self, proof_index: u64) -> Option<(Bytes32, ProofSet)> {
+    pub fn prove(&self, proof_index: u64) -> Option<(Bytes32, ProofSet)> {
         self.tree.prove(proof_index).ok()
     }
 }
@@ -57,7 +57,7 @@ mod test {
 
     #[test]
     fn root_returns_the_empty_root_for_0_leaves() {
-        let mut tree = MerkleTree::new();
+        let tree = MerkleTree::new();
 
         let root = tree.root();
         assert_eq!(root, empty_sum().clone());
@@ -123,7 +123,7 @@ mod test {
 
     #[test]
     fn prove_returns_none_for_0_leaves() {
-        let mut tree = MerkleTree::new();
+        let tree = MerkleTree::new();
 
         let proof = tree.prove(0);
         assert!(proof.is_none());

--- a/fuel-merkle/src/binary/merkle_tree.rs
+++ b/fuel-merkle/src/binary/merkle_tree.rs
@@ -292,7 +292,7 @@ where
     TableType: Mappable<Key = u64, Value = Primitive, OwnedValue = Primitive>,
     StorageType: StorageMutate<TableType, Error = StorageError>,
 {
-    pub fn push(&mut self, data: &[u8]) -> Result<(), MerkleTreeError<StorageError>> {
+    pub fn push(&mut self, data: &[u8]) -> Result<(), StorageError> {
         let node = Node::create_leaf(self.leaves_count, data);
         self.storage.insert(&node.key(), &node.as_ref().into())?;
         let next = self.head.take();


### PR DESCRIPTION
Changes:
- Remove mut requirement from in memory BMT `root`
- Remove `MerkleTreeError` wrapper around BMT `push` StorageError in return type