### PR TITLE
Use the recently stabilized checked_ilog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.66.0
+  RUST_VERSION: 1.67.0
 
 jobs:
   cargo:

--- a/fuel-asm/src/panic_reason.rs
+++ b/fuel-asm/src/panic_reason.rs
@@ -527,7 +527,7 @@ pub enum PanicReason {
 
 impl fmt::Display for PanicReason {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/fuel-asm/tests/encoding.rs
+++ b/fuel-asm/tests/encoding.rs
@@ -184,7 +184,7 @@ fn opcode() {
     assert_eq!(data, data_p);
     assert_eq!(data, data_q);
 
-    let pairs = bytes.chunks(8).into_iter().map(|chunk| {
+    let pairs = bytes.chunks(8).map(|chunk| {
         let mut arr = [0; core::mem::size_of::<Word>()];
         arr.copy_from_slice(chunk);
         Instruction::parse_word(Word::from_be_bytes(arr))

--- a/fuel-crypto/src/error.rs
+++ b/fuel-crypto/src/error.rs
@@ -83,7 +83,7 @@ mod use_std {
 
     impl fmt::Display for Error {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(f, "{:?}", self)
+            write!(f, "{self:?}")
         }
     }
 

--- a/fuel-crypto/tests/signature.rs
+++ b/fuel-crypto/tests/signature.rs
@@ -63,7 +63,7 @@ fn corrupted_signature() {
             match s.recover(&message) {
                 Ok(pk) => assert_ne!(public, pk),
                 Err(Error::InvalidSignature) => (),
-                Err(e) => panic!("Unexpected error: {}", e),
+                Err(e) => panic!("Unexpected error: {e}"),
             }
 
             m << 1

--- a/fuel-merkle/src/common/prefix.rs
+++ b/fuel-merkle/src/common/prefix.rs
@@ -1,17 +1,12 @@
 const NODE: u8 = 0x01;
 const LEAF: u8 = 0x00;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 #[repr(u8)]
 pub enum Prefix {
     Node = NODE,
+    #[default]
     Leaf = LEAF,
-}
-
-impl Default for Prefix {
-    fn default() -> Self {
-        Prefix::Leaf
-    }
 }
 
 impl From<Prefix> for u8 {

--- a/fuel-tx/src/contract.rs
+++ b/fuel-tx/src/contract.rs
@@ -153,7 +153,7 @@ mod tests {
 
         // take root snapshot
         insta::with_settings!(
-            {snapshot_suffix => format!("instructions-{}", instructions)},
+            {snapshot_suffix => format!("instructions-{instructions}")},
             {
                 insta::assert_debug_snapshot!(root);
             }

--- a/fuel-tx/src/transaction.rs
+++ b/fuel-tx/src/transaction.rs
@@ -130,7 +130,7 @@ impl Transaction {
     /// If an error happens, a JSON string with the error description will be returned
     #[cfg(all(feature = "serde", feature = "alloc"))]
     pub fn to_json(&self) -> alloc::string::String {
-        serde_json::to_string(self).unwrap_or_else(|e| alloc::format!(r#"{{"error": "{}"}}"#, e))
+        serde_json::to_string(self).unwrap_or_else(|e| alloc::format!(r#"{{"error": "{e}"}}"#))
     }
 
     /// Attempt to deserialize a transaction from a JSON string, returning `None` if it fails

--- a/fuel-tx/src/transaction/types/input/repr.rs
+++ b/fuel-tx/src/transaction/types/input/repr.rs
@@ -127,7 +127,7 @@ impl TryFrom<Word> for InputRepr {
             0x02 => Ok(Self::Message),
             id => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("The provided input identifier ({}) is invalid!", id),
+                format!("The provided input identifier ({id}) is invalid!"),
             )),
         }
     }

--- a/fuel-tx/src/transaction/types/output/repr.rs
+++ b/fuel-tx/src/transaction/types/output/repr.rs
@@ -93,7 +93,7 @@ impl TryFrom<Word> for OutputRepr {
             0x05 => Ok(Self::ContractCreated),
             i => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("The provided output identifier ({}) is invalid!", i),
+                format!("The provided output identifier ({i}) is invalid!"),
             )),
         }
     }

--- a/fuel-tx/src/transaction/types/utxo_id.rs
+++ b/fuel-tx/src/transaction/types/utxo_id.rs
@@ -155,11 +155,11 @@ mod tests {
             output_index: 26,
         };
         assert_eq!(
-            format!("{:#x}", utxo_id),
+            format!("{utxo_id:#x}"),
             "0x0c0000000000000000000000000000000000000000000000000000000000000b1a"
         );
         assert_eq!(
-            format!("{:x}", utxo_id),
+            format!("{utxo_id:x}"),
             "0c0000000000000000000000000000000000000000000000000000000000000b1a"
         );
     }

--- a/fuel-tx/src/transaction/validity/error.rs
+++ b/fuel-tx/src/transaction/validity/error.rs
@@ -115,7 +115,7 @@ pub enum CheckError {
 impl fmt::Display for CheckError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // TODO better describe the error variants
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/fuel-tx/src/tx_pointer.rs
+++ b/fuel-tx/src/tx_pointer.rs
@@ -128,11 +128,11 @@ fn fmt_encode_decode() {
     for (block_height, tx_index) in cases {
         let tx_pointer = TxPointer::new(block_height, tx_index);
 
-        let lower = format!("{:x}", tx_pointer);
-        let upper = format!("{:X}", tx_pointer);
+        let lower = format!("{tx_pointer:x}");
+        let upper = format!("{tx_pointer:X}");
 
-        assert_eq!(lower, format!("{:08x}{:04x}", block_height, tx_index));
-        assert_eq!(upper, format!("{:08X}{:04X}", block_height, tx_index));
+        assert_eq!(lower, format!("{block_height:08x}{tx_index:04x}"));
+        assert_eq!(upper, format!("{block_height:08X}{tx_index:04X}"));
 
         let x = TxPointer::from_str(&lower).expect("failed to decode from str");
         assert_eq!(tx_pointer, x);

--- a/fuel-types/tests/types.rs
+++ b/fuel-types/tests/types.rs
@@ -73,14 +73,14 @@ fn hex_encoding() {
         T: fmt::LowerHex + fmt::UpperHex + str::FromStr + Eq + fmt::Debug + AsRef<[u8]>,
         <T as str::FromStr>::Err: fmt::Debug,
     {
-        let lower = format!("{:x}", t);
-        let lower_w0 = format!("{:0x}", t);
-        let lower_alternate = format!("{:#x}", t);
-        let lower_alternate_w0 = format!("{:#0x}", t);
-        let upper = format!("{:X}", t);
-        let upper_w0 = format!("{:0X}", t);
-        let upper_alternate = format!("{:#X}", t);
-        let upper_alternate_w0 = format!("{:#X}", t);
+        let lower = format!("{t:x}");
+        let lower_w0 = format!("{t:0x}");
+        let lower_alternate = format!("{t:#x}");
+        let lower_alternate_w0 = format!("{t:#0x}");
+        let upper = format!("{t:X}");
+        let upper_w0 = format!("{t:0X}");
+        let upper_alternate = format!("{t:#X}");
+        let upper_alternate_w0 = format!("{t:#X}");
 
         assert_ne!(lower, lower_alternate);
         assert_ne!(lower, upper);
@@ -107,13 +107,13 @@ fn hex_encoding() {
         let reduced = t.as_ref().iter().fold(0u8, |acc, x| acc ^ x);
 
         let x = hex::encode([reduced]);
-        let y = format!("{:2x}", t);
+        let y = format!("{t:2x}");
 
         assert_eq!(x, y);
 
-        let x = format!("{:0x}", t).len();
-        let y = format!("{:2x}", t).len();
-        let z = format!("{:4x}", t).len();
+        let x = format!("{t:0x}").len();
+        let y = format!("{t:2x}").len();
+        let z = format!("{t:4x}").len();
 
         assert_eq!(t.as_ref().len() * 2, x);
         assert_eq!(2, y);
@@ -197,42 +197,42 @@ fn test_key_types_hex_serialization() {
 
     let adr: Address = rng.gen();
     let adr_to_string = serde_json::to_string(&adr).expect("serde_json::to_string failed on Address");
-    assert_eq!(format!("\"{}\"", adr), adr_to_string);
+    assert_eq!(format!("\"{adr}\""), adr_to_string);
 
     let ast_id: AssetId = rng.gen();
     let ast_id_to_string = serde_json::to_string(&ast_id).expect("serde_json::to_string failed on AssetId");
-    assert_eq!(format!("\"{}\"", ast_id), ast_id_to_string);
+    assert_eq!(format!("\"{ast_id}\""), ast_id_to_string);
 
     let contract_id: ContractId = rng.gen();
     let contract_id_to_string =
         serde_json::to_string(&contract_id).expect("serde_json::to_string failed on ContractId");
-    assert_eq!(format!("\"{}\"", contract_id), contract_id_to_string);
+    assert_eq!(format!("\"{contract_id}\""), contract_id_to_string);
 
     let bytes4: Bytes4 = rng.gen();
     let bytes4_to_string = serde_json::to_string(&bytes4).expect("serde_json::to_string failed on Bytes4");
-    assert_eq!(format!("\"{}\"", bytes4), bytes4_to_string);
+    assert_eq!(format!("\"{bytes4}\""), bytes4_to_string);
 
     let bytes8: Bytes8 = rng.gen();
     let bytes8_to_string = serde_json::to_string(&bytes8).expect("serde_json::to_string failed on Bytes8");
-    assert_eq!(format!("\"{}\"", bytes8), bytes8_to_string);
+    assert_eq!(format!("\"{bytes8}\""), bytes8_to_string);
 
     let bytes20: Bytes20 = rng.gen();
     let bytes20_to_string = serde_json::to_string(&bytes20).expect("serde_json::to_string failed on Bytes20");
-    assert_eq!(format!("\"{}\"", bytes20), bytes20_to_string);
+    assert_eq!(format!("\"{bytes20}\""), bytes20_to_string);
 
     let bytes32: Bytes32 = rng.gen();
     let bytes32_to_string = serde_json::to_string(&bytes32).expect("serde_json::to_string failed on Bytes32");
-    assert_eq!(format!("\"{}\"", bytes32), bytes32_to_string);
+    assert_eq!(format!("\"{bytes32}\""), bytes32_to_string);
 
     let message_id: MessageId = rng.gen();
     let message_id_to_string = serde_json::to_string(&message_id).expect("serde_json::to_string failed on MessageId");
-    assert_eq!(format!("\"{}\"", message_id), message_id_to_string);
+    assert_eq!(format!("\"{message_id}\""), message_id_to_string);
 
     let salt: Salt = rng.gen();
     let salt_to_string = serde_json::to_string(&salt).expect("serde_json::to_string failed on Salt");
-    assert_eq!(format!("\"{}\"", salt), salt_to_string);
+    assert_eq!(format!("\"{salt}\""), salt_to_string);
 
     let bytes64: Bytes64 = rng.gen();
     let bytes64_to_string = serde_json::to_string(&bytes64).expect("Failed to serialize Bytes64");
-    assert_eq!(format!("\"{}\"", bytes64), bytes64_to_string);
+    assert_eq!(format!("\"{bytes64}\""), bytes64_to_string);
 }

--- a/fuel-vm/src/checked_transaction.rs
+++ b/fuel-vm/src/checked_transaction.rs
@@ -592,7 +592,7 @@ mod tests {
 
         let provided = match err {
             CheckError::InsufficientFeeAmount { provided, .. } => provided,
-            _ => panic!("expected insufficient fee amount; found {:?}", err),
+            _ => panic!("expected insufficient fee amount; found {err:?}"),
         };
 
         assert_eq!(provided, input_amount);
@@ -617,7 +617,7 @@ mod tests {
 
         let provided = match err {
             CheckError::InsufficientFeeAmount { provided, .. } => provided,
-            _ => panic!("expected insufficient fee amount; found {:?}", err),
+            _ => panic!("expected insufficient fee amount; found {err:?}"),
         };
 
         assert_eq!(provided, input_amount);

--- a/fuel-vm/src/interpreter/executors/instruction.rs
+++ b/fuel-vm/src/interpreter/executors/instruction.rs
@@ -132,7 +132,7 @@ where
                 self.gas_charge(self.gas_costs.mlog)?;
                 self.alu_error(
                     ra,
-                    |b, c| checked_ilog(b, c).expect("checked_ilog returned None for valid values") as Word,
+                    |b, c| b.checked_ilog(c).expect("checked_ilog returned None for valid values") as Word,
                     b,
                     c,
                     b == 0 || c <= 1,
@@ -544,49 +544,6 @@ fn checked_nth_root(target: u64, nth_root: u64) -> Option<u64> {
 
     // Check if the guess was correct
     Some(guess + 1)
-}
-
-/// Computes logarithm for given exponent and base.
-/// Diverges when exp == 0 or base <= 1.
-///
-/// This code is originally from [rust corelib][rust-corelib-impl],
-/// but with all additional clutter removed.
-///
-/// [rust-corelib-impl]: https://github.com/rust-lang/rust/blob/415d8fcc3e17f8c1324a81cf2aa7127b4fcfa32e/library/core/src/num/uint_macros.rs#L774
-#[inline(always)] // Force copy of each invocation for optimization, see comments below
-const fn _unchecked_ilog_inner(exp: Word, base: Word) -> u32 {
-    let mut n = 0;
-    let mut r = exp;
-    while r >= base {
-        r /= base;
-        n += 1;
-    }
-
-    n
-}
-
-/// Logarithm for given exponent and an arbitrary base, rounded
-/// rounded down to nearest integer value.
-///
-/// Returns `None` if the exponent == 0, or if the base <= 1.
-///
-/// TODO: when <https://github.com/rust-lang/rust/issues/70887> is stabilized,
-/// consider using that instead.
-const fn checked_ilog(exp: Word, base: Word) -> Option<u32> {
-    if exp == 0 || base <= 1 {
-        return None;
-    }
-
-    // Generate separately optimized paths for some common and/or expensive bases.
-    // See <https://github.com/FuelLabs/fuel-vm/issues/150#issuecomment-1288797787> for benchmark.
-    Some(match base {
-        2 => _unchecked_ilog_inner(exp, 2),
-        3 => _unchecked_ilog_inner(exp, 3),
-        4 => _unchecked_ilog_inner(exp, 4),
-        5 => _unchecked_ilog_inner(exp, 5),
-        10 => _unchecked_ilog_inner(exp, 10),
-        n => _unchecked_ilog_inner(exp, n),
-    })
 }
 
 #[cfg(test)]

--- a/fuel-vm/src/interpreter/executors/instruction/tests/math_operations.rs
+++ b/fuel-vm/src/interpreter/executors/instruction/tests/math_operations.rs
@@ -1,14 +1,14 @@
 use num_integer::Roots;
 use rayon::prelude::*;
 
-use super::{checked_ilog, checked_nth_root};
+use super::checked_nth_root;
 
 /// Check for https://github.com/FuelLabs/fuel-vm/issues/150
 #[test]
 fn mlog_rounding_issues() {
-    assert_eq!(checked_ilog(999, 10), Some(2));
-    assert_eq!(checked_ilog(1000, 10), Some(3));
-    assert_eq!(checked_ilog(1001, 10), Some(3));
+    assert_eq!(999u32.checked_ilog(10), Some(2));
+    assert_eq!(1000u32.checked_ilog(10), Some(3));
+    assert_eq!(1001u32.checked_ilog(10), Some(3));
 }
 
 /// Verify some subsets of possible inputs against a known-good implementation.

--- a/fuel-vm/src/interpreter/memory.rs
+++ b/fuel-vm/src/interpreter/memory.rs
@@ -7,7 +7,7 @@ use fuel_types::{RegisterId, Word};
 
 use std::{ops, ptr};
 
-#[allow(clippy::derived_hash_with_manual_eq)]
+#[allow(clippy::derive_hash_xor_eq)]
 #[derive(Debug, Clone, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Memory range representation for the VM.

--- a/fuel-vm/src/interpreter/memory.rs
+++ b/fuel-vm/src/interpreter/memory.rs
@@ -7,7 +7,7 @@ use fuel_types::{RegisterId, Word};
 
 use std::{ops, ptr};
 
-#[allow(clippy::derive_hash_xor_eq)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 #[derive(Debug, Clone, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Memory range representation for the VM.

--- a/fuel-vm/src/interpreter/post_execution.rs
+++ b/fuel-vm/src/interpreter/post_execution.rs
@@ -34,7 +34,7 @@ where
         tx.update_outputs(params, revert, remaining_gas, initial_balances, balances)
             .map_err(|e| io::Error::new(
                 io::ErrorKind::Other,
-                format!("a valid VM execution shouldn't result in a state where it can't compute its refund. This is a bug! {}", e)
+                format!("a valid VM execution shouldn't result in a state where it can't compute its refund. This is a bug! {e}")
             ))?;
 
         Ok(())

--- a/fuel-vm/src/profiler.rs
+++ b/fuel-vm/src/profiler.rs
@@ -98,7 +98,7 @@ impl fmt::Display for InstructionLocation {
             self.context
                 .map(|contract_id| format!(
                     "contract_id={}",
-                    contract_id.iter().map(|b| format!("{:02x?}", b)).collect::<String>()
+                    contract_id.iter().map(|b| format!("{b:02x?}")).collect::<String>()
                 ),)
                 .unwrap_or_else(|| "script".to_string()),
             self.offset
@@ -152,7 +152,7 @@ pub struct StderrReceiver;
 
 impl ProfileReceiver for StderrReceiver {
     fn on_transaction(&mut self, state: &Result<ProgramState, InterpreterError>, data: &ProfilingData) {
-        eprintln!("PROFILER: {:?} {:?}", state, data);
+        eprintln!("PROFILER: {state:?} {data:?}");
     }
 }
 
@@ -268,7 +268,7 @@ impl fmt::Display for CoverageProfilingData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut items: Vec<_> = self.iter().collect();
         items.sort();
-        writeln!(f, "{:?}", items)
+        writeln!(f, "{items:?}")
     }
 }
 
@@ -312,7 +312,7 @@ impl fmt::Display for GasProfilingData {
         let mut items: Vec<(_, _)> = self.iter().collect();
         items.sort();
         for (addr, count) in items {
-            writeln!(f, "{}: {}", addr, count)?;
+            writeln!(f, "{addr}: {count}")?;
         }
         Ok(())
     }

--- a/fuel-vm/tests/outputs.rs
+++ b/fuel-vm/tests/outputs.rs
@@ -367,7 +367,7 @@ fn variable_output_not_set_by_external_transfer_out_on_revert() {
     let outputs = result.tx().outputs();
     let receipts = result.receipts();
 
-    println!("{:?}", receipts);
+    println!("{receipts:?}");
 
     assert!(matches!(
         outputs[0], Output::Variable { amount, .. } if amount == 0

--- a/fuel-vm/tests/profile_gas.rs
+++ b/fuel-vm/tests/profile_gas.rs
@@ -58,8 +58,7 @@ fn profile_gas() {
                     .expect("Expected a panic reason.");
                 assert!(
                     matches!(panic_reason, PanicReason::OutOfGas),
-                    "Expected out-of-gas error, got {:?}",
-                    panic_reason
+                    "Expected out-of-gas error, got {panic_reason:?}"
                 );
             } else {
                 matches!(result, &ScriptExecutionResult::Success);


### PR DESCRIPTION
Replaces our custom (although stdlib-inspired) solution with a call to the now-stable function in the stdlib.

This PR also upgrades CI Rust version to 1.67 which stabilized this function. This in turn requires some minor changes to appease clippy.