### PR TITLE
Remove `Clone` constraint from `PathIterator`

### DIFF
--- a/fuel-merkle/src/common/path_iterator.rs
+++ b/fuel-merkle/src/common/path_iterator.rs
@@ -145,14 +145,13 @@ impl<T> Iterator for PathIter<T>
 where
     T: ParentNode + Clone,
     T::Key: Path + Clone,
-    T::Error: Clone,
 {
     type Item = (ChildResult<T>, ChildResult<T>);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let value = self.current.clone();
+        let value = self.current.take();
 
-        if let Some((ref path_node, _)) = self.current {
+        if let Some((ref path_node, _)) = value {
             match path_node {
                 Ok(path_node) if path_node.is_node() => {
                     let path = self.leaf.leaf_key();

--- a/fuel-merkle/src/common/path_iterator.rs
+++ b/fuel-merkle/src/common/path_iterator.rs
@@ -143,8 +143,8 @@ where
 
 impl<T> Iterator for PathIter<T>
 where
-    T: ParentNode + Clone,
-    T::Key: Path + Clone,
+    T: ParentNode,
+    T::Key: Path,
 {
     type Item = (ChildResult<T>, ChildResult<T>);
 

--- a/fuel-merkle/src/sparse/merkle_tree.rs
+++ b/fuel-merkle/src/sparse/merkle_tree.rs
@@ -64,7 +64,6 @@ impl<TableType, StorageType, StorageError> MerkleTree<TableType, StorageType>
 where
     TableType: Mappable<Key = Bytes32, Value = Primitive, OwnedValue = Primitive>,
     StorageType: StorageInspect<TableType, Error = StorageError>,
-    StorageType::Error: Clone,
 {
     pub fn new(storage: StorageType) -> Self {
         Self {
@@ -117,7 +116,6 @@ impl<TableType, StorageType, StorageError> MerkleTree<TableType, StorageType>
 where
     TableType: Mappable<Key = Bytes32, Value = Primitive, OwnedValue = Primitive>,
     StorageType: StorageMutate<TableType, Error = StorageError>,
-    StorageType::Error: Clone,
 {
     pub fn update(&mut self, key: &Bytes32, data: &[u8]) -> Result<(), MerkleTreeError<StorageError>> {
         if data.is_empty() {

--- a/fuel-merkle/src/sum/merkle_tree.rs
+++ b/fuel-merkle/src/sum/merkle_tree.rs
@@ -6,7 +6,7 @@ use crate::{
 use fuel_storage::{Mappable, StorageMutate};
 
 use alloc::boxed::Box;
-use core::{fmt, marker::PhantomData};
+use core::marker::PhantomData;
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "std", derive(thiserror::Error))]

--- a/fuel-merkle/src/sum/merkle_tree.rs
+++ b/fuel-merkle/src/sum/merkle_tree.rs
@@ -54,7 +54,6 @@ impl<TableType, StorageType, StorageError> MerkleTree<TableType, StorageType>
 where
     TableType: Mappable<Key = Bytes32, Value = Node, OwnedValue = Node>,
     StorageType: StorageMutate<TableType, Error = StorageError>,
-    StorageError: fmt::Debug + Clone + 'static,
 {
     pub fn new(storage: StorageType) -> Self {
         Self {


### PR DESCRIPTION
Related issues:
- https://github.com/FuelLabs/fuel-core/issues/527

Removes `Clone` constraint from `PathIterator` by using `take` instead of `clone`. Requiring `Clone` is too cumbersome because it requires that the `ParentNode::Error` (e.g., `StorageError` in the case of `fuel-core`) also implement `Clone`, which cannot be guaranteed.  