### PR TITLE
bump 0.25.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.25.2"
+version = "0.25.3"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.25.2", path = "./fuel-asm", default-features = false }
-fuel-crypto = { version = "0.25.2", path = "./fuel-crypto", default-features = false }
-fuel-merkle = { version = "0.25.2", path = "./fuel-merkle", default-features = false }
-fuel-storage = { version = "0.25.2", path = "./fuel-storage", default-features = false }
-fuel-tx = { version = "0.25.2", path = "./fuel-tx", default-features = false }
-fuel-types = { version = "0.25.2", path = "./fuel-types", default-features = false }
+fuel-asm = { version = "0.25.3", path = "./fuel-asm", default-features = false }
+fuel-crypto = { version = "0.25.3", path = "./fuel-crypto", default-features = false }
+fuel-merkle = { version = "0.25.3", path = "./fuel-merkle", default-features = false }
+fuel-storage = { version = "0.25.3", path = "./fuel-storage", default-features = false }
+fuel-tx = { version = "0.25.3", path = "./fuel-tx", default-features = false }
+fuel-types = { version = "0.25.3", path = "./fuel-types", default-features = false }


### PR DESCRIPTION
## What's Changed
* Use the recently stabilized checked_ilog by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/332
* Added additional methods for storage for the cases when the developer need to work with `StorageAsRef` and `StorageAsMut` by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/331
* Implement `fmt::Display` for `TxPointer` by @mitchmindtree in https://github.com/FuelLabs/fuel-vm/pull/334
* Updated `publish-crates` by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/333
* Remove `Clone` constraint from `PathIterator` by @bvrooman in https://github.com/FuelLabs/fuel-vm/pull/336


**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.25.2...v0.25.3