### PR TITLE
Do not allow setting reserved flags

### DIFF
--- a/fuel-asm/Cargo.toml
+++ b/fuel-asm/Cargo.toml
@@ -12,6 +12,7 @@ description = "Atomic types of the FuelVM."
 
 [dependencies]
 arbitrary = { version = "1.1", features = ["derive"], optional = true }
+bitflags = "1.3"
 fuel-types = { workspace = true, default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 strum = { version = "0.24", default-features = false, features = ["derive"] }

--- a/fuel-asm/src/lib.rs
+++ b/fuel-asm/src/lib.rs
@@ -47,6 +47,19 @@ pub type RawInstruction = u32;
 #[derive(Debug, Eq, PartialEq)]
 pub struct InvalidOpcode;
 
+bitflags::bitflags! {
+    /// Possible values for the FLAG instruction.
+    /// See https://github.com/FuelLabs/fuel-specs/blob/master/src/vm/index.md#flags
+    pub struct Flags: Word {
+        /// If set, arithmetic errors result in setting $err instead of panicking.
+        /// This includes cases where result of a computation is undefined, like
+        /// division by zero. Arithmetic overflows still cause a panic, but that be
+        /// controlled with [`Flags::WRAPPING`].
+        const UNSAFEMATH = 0x01;
+        /// If set, arithmetic overflows result in setting $of instead of panicking.
+        const WRAPPING = 0x02;
+    }
+}
 /// Type is convertible to a [`RegId`]
 pub trait CheckRegId {
     /// Convert to a [`RegId`], or panic

--- a/fuel-vm/src/interpreter.rs
+++ b/fuel-vm/src/interpreter.rs
@@ -5,7 +5,7 @@ use crate::consts::*;
 use crate::context::Context;
 use crate::gas::GasCosts;
 use crate::state::Debugger;
-use fuel_asm::{PanicReason, RegId};
+use fuel_asm::{Flags, PanicReason, RegId};
 use std::collections::BTreeMap;
 use std::io::Read;
 use std::ops::Index;
@@ -111,12 +111,17 @@ impl<S, Tx> Interpreter<S, Tx> {
         &self.debugger
     }
 
+    /// Contents of the flag register
+    pub(crate) fn flags(&self) -> Flags {
+        Flags::from_bits_truncate(self.registers[RegId::FLAG])
+    }
+
     pub(crate) fn is_unsafe_math(&self) -> bool {
-        self.registers[RegId::FLAG] & 0x01 == 0x01
+        self.flags().contains(Flags::UNSAFEMATH)
     }
 
     pub(crate) fn is_wrapping(&self) -> bool {
-        self.registers[RegId::FLAG] & 0x02 == 0x02
+        self.flags().contains(Flags::WRAPPING)
     }
 
     /// The current transaction.

--- a/fuel-vm/src/interpreter/internal.rs
+++ b/fuel-vm/src/interpreter/internal.rs
@@ -4,7 +4,7 @@ use crate::context::Context;
 use crate::crypto;
 use crate::error::RuntimeError;
 
-use fuel_asm::{Instruction, PanicReason, RegId};
+use fuel_asm::{Flags, Instruction, PanicReason, RegId};
 use fuel_tx::field::ReceiptsRoot;
 use fuel_tx::{Output, Receipt};
 use fuel_types::bytes::SerializableVec;
@@ -93,7 +93,11 @@ impl<S, Tx> Interpreter<S, Tx> {
     }
 
     pub(crate) fn set_flag(&mut self, a: Word) -> Result<(), RuntimeError> {
-        self.registers[RegId::FLAG] = a;
+        let Some(flags) = Flags::from_bits(a) else {
+            return Err(PanicReason::ErrorFlag.into());
+        };
+
+        self.registers[RegId::FLAG] = flags.bits();
 
         self.inc_pc()
     }

--- a/fuel-vm/tests/spec.rs
+++ b/fuel-vm/tests/spec.rs
@@ -358,7 +358,7 @@ fn spec_can_write_allowed_flag_combinations(#[values(0b00, 0b01, 0b10, 0b11)] fl
 #[rstest]
 fn spec_cannot_write_reserved_flags(#[values(0b100, 0b111)] flags: Immediate18) {
     let mut script = common_setup();
-    script.push(op::movi(0x20, 0b111));
+    script.push(op::movi(0x20, flags));
     script.push(op::flag(0x20));
     script.push(op::ret(RegId::ONE));
 

--- a/fuel-vm/tests/spec.rs
+++ b/fuel-vm/tests/spec.rs
@@ -1,8 +1,20 @@
 use fuel_asm::*;
 use fuel_tx::{ConsensusParameters, Receipt, ScriptExecutionResult, Transaction};
+use fuel_types::Immediate18;
 use fuel_vm::prelude::{IntoChecked, MemoryClient};
 
 use rstest::rstest;
+
+/// Assert that transaction didn't panic
+fn assert_success(receipts: &[Receipt]) {
+    if let Receipt::ScriptResult { result, .. } = receipts.last().unwrap() {
+        if *result != ScriptExecutionResult::Success {
+            panic!("Expected vm success, got {result:?} instead");
+        }
+    } else {
+        unreachable!("No script result");
+    }
+}
 
 /// Assert that transaction receipts end in a panic with the given reason
 fn assert_panics(receipts: &[Receipt], reason: PanicReason) {
@@ -330,4 +342,26 @@ fn spec_incr_pc_by_four(
     } else {
         panic!("No log data");
     }
+}
+
+#[rstest]
+fn spec_can_write_allowed_flag_combinations(#[values(0b00, 0b01, 0b10, 0b11)] flags: Immediate18) {
+    let mut script = common_setup();
+    script.push(op::movi(0x20, flags));
+    script.push(op::flag(0x20));
+    script.push(op::ret(RegId::ONE));
+
+    let receipts = run_script(script.into_iter().collect());
+    assert_success(&receipts);
+}
+
+#[rstest]
+fn spec_cannot_write_reserved_flags(#[values(0b100, 0b111)] flags: Immediate18) {
+    let mut script = common_setup();
+    script.push(op::movi(0x20, 0b111));
+    script.push(op::flag(0x20));
+    script.push(op::ret(RegId::ONE));
+
+    let receipts = run_script(script.into_iter().collect());
+    assert_panics(&receipts, PanicReason::ErrorFlag);
 }


### PR DESCRIPTION
Implementation of https://github.com/FuelLabs/fuel-specs/pull/457

This is technically a breaking change, but it's unlikely that anyone was relying on this behavior.