### PR TITLE
Bump the version to `0.27.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.26.1"
+version = "0.27.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.26.1", path = "./fuel-asm", default-features = false }
-fuel-crypto = { version = "0.26.1", path = "./fuel-crypto", default-features = false }
-fuel-merkle = { version = "0.26.1", path = "./fuel-merkle", default-features = false }
-fuel-storage = { version = "0.26.1", path = "./fuel-storage", default-features = false }
-fuel-tx = { version = "0.26.1", path = "./fuel-tx", default-features = false }
-fuel-types = { version = "0.26.1", path = "./fuel-types", default-features = false }
+fuel-asm = { version = "0.27.0", path = "./fuel-asm", default-features = false }
+fuel-crypto = { version = "0.27.0", path = "./fuel-crypto", default-features = false }
+fuel-merkle = { version = "0.27.0", path = "./fuel-merkle", default-features = false }
+fuel-storage = { version = "0.27.0", path = "./fuel-storage", default-features = false }
+fuel-tx = { version = "0.27.0", path = "./fuel-tx", default-features = false }
+fuel-types = { version = "0.27.0", path = "./fuel-types", default-features = false }


### PR DESCRIPTION
The new release brings better test coverage, fixes some issues found during testing, improves performance, and adds new breaking changes.

## Improvements

* fix: Encode SMT error keys by @bvrooman in https://github.com/FuelLabs/fuel-vm/pull/356
* Spec compliance testing, round 1 by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/345
* Iterate through instruction encondings using codegen by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/340

## Breaking

* Refactor of `fuel-crypto` for clarity around safety by @mitchmindtree in https://github.com/FuelLabs/fuel-vm/pull/346 - It removes some public functions from `fuel-crypto` primitives that may cause compilation errors.
* Read contract directly into memory by @freesig in https://github.com/FuelLabs/fuel-vm/pull/342 - Adds new traits `StorageSize`, `StorageRead`, `StorageWrite` into `fuel-storage`. The `fuel-vm` requires `InterpreterStorage` to implement those traits now, which can cause compilation errors.

## Fixes
* Fix panics in fuel-vm for exponent or bitshift larger than u32::MAX by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/344
* Do not allow setting reserved flags by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/363


**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.26.1...v0.27.0