### PR TITLE
CALL instruction recursion limit

### DIFF
--- a/fuel-asm/src/panic_reason.rs
+++ b/fuel-asm/src/panic_reason.rs
@@ -79,8 +79,8 @@ pub enum PanicReason {
     ContractIdAlreadyDeployed = 0x22,
     /// The loaded contract mismatch expectations.
     ContractMismatch = 0x23,
-    /// RESERV24
-    RESERV24 = 0x24,
+    /// No more nested calls are allowed.
+    NestedCallLimitReached = 0x24,
     /// RESERV25
     RESERV25 = 0x25,
     /// RESERV26

--- a/fuel-vm/src/consts.rs
+++ b/fuel-vm/src/consts.rs
@@ -13,6 +13,11 @@ pub const VM_REGISTER_SYSTEM_COUNT: usize = 16;
 /// The number of writable registers.
 pub const VM_REGISTER_PROGRAM_COUNT: usize = VM_REGISTER_COUNT - VM_REGISTER_SYSTEM_COUNT;
 
+/// Max amount of nested call contexts.
+/// Used to protect against stack overflows, since the CALL
+/// instruction is currently implemented using recursion.
+pub const VM_MAX_NESTED_CALLS: usize = 64;
+
 /* MEMORY TYPES */
 
 /// Length of a word, in bytes

--- a/fuel-vm/src/interpreter/executors/instruction.rs
+++ b/fuel-vm/src/interpreter/executors/instruction.rs
@@ -462,6 +462,11 @@ where
 
             Instruction::CALL(call) => {
                 let (a, b, c, d) = call.unpack();
+
+                if self.frames.len() >= VM_MAX_NESTED_CALLS {
+                    return Err(PanicReason::NestedCallLimitReached.into());
+                }
+
                 let state = self.call(r!(a), r!(b), r!(c), r!(d))?;
                 // raise revert state to halt execution for the callee
                 if let ProgramState::Revert(ra) = state {

--- a/fuel-vm/tests/flow.rs
+++ b/fuel-vm/tests/flow.rs
@@ -492,7 +492,7 @@ fn nested_call_limit() {
         maturity,
         script,
         script_data,
-        vec![input.clone()],
+        vec![input],
         vec![output],
         vec![],
     )

--- a/fuel-vm/tests/flow.rs
+++ b/fuel-vm/tests/flow.rs
@@ -461,30 +461,13 @@ fn nested_call_limit() {
     let input = Input::contract(rng.gen(), rng.gen(), rng.gen(), rng.gen(), contract);
     let output = Output::contract(0, rng.gen(), rng.gen());
 
-    let mut script_ops = vec![
-        op::movi(0x10, 0),
+    let script: Vec<u8> = vec![
+        op::gtf_args(0x10, RegId::ZERO, GTFArgs::ScriptData),
         op::call(0x10, RegId::ZERO, 0x10, RegId::CGAS),
         op::ret(RegId::ONE),
-    ];
-
-    let script: Vec<u8> = script_ops.clone().into_iter().collect();
-    let tx = Transaction::script(
-        gas_price,
-        gas_limit,
-        maturity,
-        script,
-        vec![],
-        vec![input.clone()],
-        vec![output],
-        vec![],
-    )
-    .into_checked(height, &params, client.gas_costs())
-    .expect("failed to generate checked tx");
-
-    let script_data_offset = client.tx_offset() + tx.transaction().script_data_offset();
-    script_ops[0] = op::movi(0x10, script_data_offset as Immediate18);
-
-    let script: Vec<u8> = script_ops.clone().into_iter().collect();
+    ]
+    .into_iter()
+    .collect();
     let script_data = Call::new(contract, 0, 1000).to_bytes();
     let tx = Transaction::script(
         gas_price,


### PR DESCRIPTION
Since we currently implement CALL using recursion, it can overflow the process stack before exceeding the gas limit. Currently that occurs around 95 nested calls, so to be sure I've set the limit to 64 for now. It's hardcoded as a part of the interpreter, as changing that value in a config doesn't currently make much sense.

In the future it would be nice to reduce the stack allocations to a level where the limit of 256 could be reached. Even better would be to not use non-optimized recursion in the first place, and keep the state in a stack instead. I will be attempting a refactor for this in the future. When such refactor is complete, the recursion limit could controlled similarly to the gas limits.

This is a breaking change, although I'd assume that nobody is relying on the behavior this PR disallows.