### PR TITLE
enable merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  merge_group:
   release:
     types: [published]
 


### PR DESCRIPTION
Attempt to address some of the squashed updates / rebasing headaches by using a merge train instead of requiring all branches to be up-to-date with master before merging.