### PR TITLE
Release version bump 0.28.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,13 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.27.0"
+version = "0.28.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.27.0", path = "./fuel-asm", default-features = false }
-fuel-crypto = { version = "0.27.0", path = "./fuel-crypto", default-features = false }
-fuel-merkle = { version = "0.27.0", path = "./fuel-merkle", default-features = false }
-fuel-storage = { version = "0.27.0", path = "./fuel-storage", default-features = false }
-fuel-tx = { version = "0.27.0", path = "./fuel-tx", default-features = false }
-fuel-types = { version = "0.27.0", path = "./fuel-types", default-features = false }
+fuel-asm = { version = "0.28.0", path = "./fuel-asm", default-features = false }
+fuel-crypto = { version = "0.28.0", path = "./fuel-crypto", default-features = false }
+fuel-merkle = { version = "0.28.0", path = "./fuel-merkle", default-features = false }
+fuel-storage = { version = "0.28.0", path = "./fuel-storage", default-features = false }
+fuel-tx = { version = "0.28.0", path = "./fuel-tx", default-features = false }
+fuel-types = { version = "0.28.0", path = "./fuel-types", default-features = false }
 bincode = { version = "1.3", default-features = false }


### PR DESCRIPTION
More releases to come, this is mainly to avoid needing to deal with all the breaking changes in one big fuel-core PR.