### PR TITLE
Upgrade criterion to 0.4

### DIFF
--- a/fuel-crypto/Cargo.toml
+++ b/fuel-crypto/Cargo.toml
@@ -24,7 +24,7 @@ zeroize = { version = "1.5", features = ["derive"] }
 
 [dev-dependencies]
 bincode = { workspace = true }
-criterion = "0.3"
+criterion = "0.4"
 fuel-crypto = { path = ".", default-features = false, features = ["random"] }
 k256 = { version = "0.11", features = [ "ecdsa" ] }
 sha2 = "0.10"


### PR DESCRIPTION
Fixes #294 by removing transitive dependency to `serde_cbor`