### PR TITLE
Add convenience API for getting transaction ID without ConsensusParameters

### DIFF
--- a/fuel-tx/src/transaction/id.rs
+++ b/fuel-tx/src/transaction/id.rs
@@ -8,6 +8,10 @@ use fuel_types::Bytes32;
 pub trait UniqueIdentifier {
     /// The unique identifier of the transaction is based on its content.
     fn id(&self, params: &ConsensusParameters) -> Bytes32;
+
+    /// The cached unique identifier of the transaction.
+    /// Returns None if transaction was not precomputed.
+    fn cached_id(&self) -> Option<Bytes32>;
 }
 
 impl UniqueIdentifier for Transaction {
@@ -16,6 +20,14 @@ impl UniqueIdentifier for Transaction {
             Transaction::Script(script) => script.id(params),
             Transaction::Create(create) => create.id(params),
             Self::Mint(mint) => mint.id(params),
+        }
+    }
+
+    fn cached_id(&self) -> Option<Bytes32> {
+        match self {
+            Transaction::Script(script) => script.cached_id(),
+            Transaction::Create(create) => create.cached_id(),
+            Self::Mint(mint) => mint.cached_id(),
         }
     }
 }

--- a/fuel-tx/src/transaction/types/create.rs
+++ b/fuel-tx/src/transaction/types/create.rs
@@ -7,7 +7,7 @@ use crate::transaction::{
     metadata::CommonMetadata,
     validity::{check_common_part, FormatValidityChecks},
 };
-use crate::{Chargeable, CheckError, ConsensusParameters, Contract, Input, Output, StorageSlot, Witness};
+use crate::{Chargeable, CheckError, ConsensusParameters, Contract, Input, Output, StorageSlot, TxId, Witness};
 use derivative::Derivative;
 use fuel_types::{bytes, AssetId, BlockHeight, Salt, Word};
 use fuel_types::{
@@ -60,8 +60,8 @@ mem_layout!(
 
 #[cfg(feature = "std")]
 impl crate::UniqueIdentifier for Create {
-    fn id(&self, params: &ConsensusParameters) -> fuel_types::Bytes32 {
-        if let Some(CommonMetadata { id, .. }) = self.metadata {
+    fn id(&self, params: &ConsensusParameters) -> TxId {
+        if let Some(id) = self.cached_id() {
             return id;
         }
 
@@ -73,6 +73,10 @@ impl crate::UniqueIdentifier for Create {
         clone.witnesses_mut().clear();
 
         compute_transaction_id(params, &mut clone)
+    }
+
+    fn cached_id(&self) -> Option<TxId> {
+        self.metadata.as_ref().map(|m| m.id)
     }
 }
 

--- a/fuel-tx/src/transaction/types/mint.rs
+++ b/fuel-tx/src/transaction/types/mint.rs
@@ -90,12 +90,16 @@ mem_layout!(
 #[cfg(feature = "std")]
 impl crate::UniqueIdentifier for Mint {
     fn id(&self, params: &ConsensusParameters) -> Bytes32 {
-        if let Some(MintMetadata { id, .. }) = self.metadata {
+        if let Some(id) = self.cached_id() {
             return id;
         }
 
         let mut clone = self.clone();
         compute_transaction_id(params, &mut clone)
+    }
+
+    fn cached_id(&self) -> Option<Bytes32> {
+        self.metadata.as_ref().map(|m| m.id)
     }
 }
 

--- a/fuel-tx/src/transaction/types/script.rs
+++ b/fuel-tx/src/transaction/types/script.rs
@@ -86,11 +86,7 @@ impl Default for Script {
 #[cfg(feature = "std")]
 impl crate::UniqueIdentifier for Script {
     fn id(&self, params: &ConsensusParameters) -> Bytes32 {
-        if let Some(ScriptMetadata {
-            common: CommonMetadata { id, .. },
-            ..
-        }) = self.metadata
-        {
+        if let Some(id) = self.cached_id() {
             return id;
         }
 
@@ -103,6 +99,10 @@ impl crate::UniqueIdentifier for Script {
         clone.witnesses_mut().clear();
 
         compute_transaction_id(params, &mut clone)
+    }
+
+    fn cached_id(&self) -> Option<Bytes32> {
+        self.metadata.as_ref().map(|m| m.common.id)
     }
 }
 

--- a/fuel-vm/src/checked_transaction.rs
+++ b/fuel-vm/src/checked_transaction.rs
@@ -100,6 +100,15 @@ impl<Tx: IntoChecked> Checked<Tx> {
     }
 }
 
+impl<Tx: IntoChecked + UniqueIdentifier> Checked<Tx> {
+    /// Returns the transaction ID from the computed metadata
+    pub fn id(&self) -> TxId {
+        self.transaction
+            .cached_id()
+            .expect("Transaction metadata should be computed for checked transactions")
+    }
+}
+
 #[cfg(feature = "test-helpers")]
 impl<Tx: IntoChecked + Default> Default for Checked<Tx>
 where


### PR DESCRIPTION
Since checked transactions are guaranteed to have computed all relevant metadata, this PR adds an infallible API to enable fetching the cached transaction ID for Checked\<Tx\> types.

This cleans up a lot of places in https://github.com/FuelLabs/fuel-core/pull/1107 where the consensus parameters would have to be routed even though the transaction id is already known (mainly executor and txpool since they use checked transactions).