### PR TITLE
Bump the version to `0.31.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,13 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.30.0"
+version = "0.31.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.30.0", path = "./fuel-asm", default-features = false }
-fuel-crypto = { version = "0.30.0", path = "./fuel-crypto", default-features = false }
-fuel-merkle = { version = "0.30.0", path = "./fuel-merkle", default-features = false }
-fuel-storage = { version = "0.30.0", path = "./fuel-storage", default-features = false }
-fuel-tx = { version = "0.30.0", path = "./fuel-tx", default-features = false }
-fuel-types = { version = "0.30.0", path = "./fuel-types", default-features = false }
+fuel-asm = { version = "0.31.0", path = "./fuel-asm", default-features = false }
+fuel-crypto = { version = "0.31.0", path = "./fuel-crypto", default-features = false }
+fuel-merkle = { version = "0.31.0", path = "./fuel-merkle", default-features = false }
+fuel-storage = { version = "0.31.0", path = "./fuel-storage", default-features = false }
+fuel-tx = { version = "0.31.0", path = "./fuel-tx", default-features = false }
+fuel-types = { version = "0.31.0", path = "./fuel-types", default-features = false }
 bincode = { version = "1.3", default-features = false }


### PR DESCRIPTION
## What's Changed
* Serialize BlockHeight as integer again by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/422
* Duplicate patch from `0.26.3` by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/428
* Adding more unit tests by @freesig in https://github.com/FuelLabs/fuel-vm/pull/390
* Update deps and audit by @freesig in https://github.com/FuelLabs/fuel-vm/pull/429

