### PR TITLE
Allow empty range in the checked memory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,13 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.31.0"
+version = "0.31.1"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.31.0", path = "./fuel-asm", default-features = false }
-fuel-crypto = { version = "0.31.0", path = "./fuel-crypto", default-features = false }
-fuel-merkle = { version = "0.31.0", path = "./fuel-merkle", default-features = false }
-fuel-storage = { version = "0.31.0", path = "./fuel-storage", default-features = false }
-fuel-tx = { version = "0.31.0", path = "./fuel-tx", default-features = false }
-fuel-types = { version = "0.31.0", path = "./fuel-types", default-features = false }
+fuel-asm = { version = "0.31.1", path = "./fuel-asm", default-features = false }
+fuel-crypto = { version = "0.31.1", path = "./fuel-crypto", default-features = false }
+fuel-merkle = { version = "0.31.1", path = "./fuel-merkle", default-features = false }
+fuel-storage = { version = "0.31.1", path = "./fuel-storage", default-features = false }
+fuel-tx = { version = "0.31.1", path = "./fuel-tx", default-features = false }
+fuel-types = { version = "0.31.1", path = "./fuel-types", default-features = false }
 bincode = { version = "1.3", default-features = false }

--- a/fuel-vm/src/constraints.rs
+++ b/fuel-vm/src/constraints.rs
@@ -97,8 +97,7 @@ impl CheckedMemRange {
         Self::new_inner(address as usize, size, constraint)
     }
 
-    /// Create a new memory range, checks that the range is not empty
-    /// and that it fits into the constraint.
+    /// Create a new memory range, checks that the range fits into the constraint.
     fn new_inner(address: usize, size: usize, constraint: core::ops::Range<Word>) -> Result<Self, RuntimeError> {
         if size == 0 {
             return Ok(Self(address..address));

--- a/fuel-vm/src/constraints.rs
+++ b/fuel-vm/src/constraints.rs
@@ -104,8 +104,8 @@ impl CheckedMemRange {
             return Ok(Self(address..address));
         }
 
-        let (end, of) = (address as usize).overflowing_add(size);
-        let range = address as usize..end;
+        let (end, of) = address.overflowing_add(size);
+        let range = address..end;
         if of || !constraint.contains(&((range.end - 1) as Word)) {
             return Err(PanicReason::MemoryOverflow.into());
         }

--- a/fuel-vm/src/constraints.rs
+++ b/fuel-vm/src/constraints.rs
@@ -81,7 +81,7 @@ impl CheckedMemRange {
 
     /// Create a new memory range.
     pub fn new(address: Word, size: usize) -> Result<Self, RuntimeError> {
-        Self::new_inner(address, size, Self::DEFAULT_CONSTRAINT)
+        Self::new_inner(address as usize, size, Self::DEFAULT_CONSTRAINT)
     }
 
     /// Create a new memory range with a custom constraint.
@@ -94,15 +94,19 @@ impl CheckedMemRange {
         if constraint.end > VM_MAX_RAM {
             return Err(Bug::new(BugId::ID009, BugVariant::InvalidMemoryConstraint).into());
         }
-        Self::new_inner(address, size, constraint)
+        Self::new_inner(address as usize, size, constraint)
     }
 
     /// Create a new memory range, checks that the range is not empty
     /// and that it fits into the constraint.
-    fn new_inner(address: Word, size: usize, constraint: core::ops::Range<Word>) -> Result<Self, RuntimeError> {
+    fn new_inner(address: usize, size: usize, constraint: core::ops::Range<Word>) -> Result<Self, RuntimeError> {
+        if size == 0 {
+            return Ok(Self(address..address));
+        }
+
         let (end, of) = (address as usize).overflowing_add(size);
         let range = address as usize..end;
-        if of || range.is_empty() || !constraint.contains(&((range.end - 1) as Word)) {
+        if of || !constraint.contains(&((range.end - 1) as Word)) {
             return Err(PanicReason::MemoryOverflow.into());
         }
         Ok(Self(range))
@@ -151,7 +155,7 @@ impl<const LEN: usize> CheckedMemConstLen<LEN> {
     /// Panics if constraints end > `VM_MAX_RAM`.
     pub fn new_with_constraint(address: Word, constraint: core::ops::Range<Word>) -> Result<Self, RuntimeError> {
         assert!(constraint.end <= VM_MAX_RAM, "Constraint end must be <= VM_MAX_RAM.");
-        Ok(Self(CheckedMemRange::new_inner(address, LEN, constraint)?))
+        Ok(Self(CheckedMemRange::new_inner(address as usize, LEN, constraint)?))
     }
 
     /// Get the memory slice for this range.

--- a/fuel-vm/src/interpreter/blockchain/smo_tests.rs
+++ b/fuel-vm/src/interpreter/blockchain/smo_tests.rs
@@ -74,7 +74,7 @@ impl Default for Input {
         msg_data_len: 0,
         amount_coins_to_send: 0,
         ..Default::default()
-    } => Err(RuntimeError::Recoverable(PanicReason::MemoryOverflow))
+    } => matches Ok(Output { .. })
     ; "Call abi can't be zero"
 )]
 #[test_case(

--- a/fuel-vm/src/interpreter/blockchain/smo_tests.rs
+++ b/fuel-vm/src/interpreter/blockchain/smo_tests.rs
@@ -75,7 +75,7 @@ impl Default for Input {
         amount_coins_to_send: 0,
         ..Default::default()
     } => matches Ok(Output { .. })
-    ; "Call abi can't be zero"
+    ; "message data can be zero-length"
 )]
 #[test_case(
     Input {

--- a/fuel-vm/src/tests/blockchain.rs
+++ b/fuel-vm/src/tests/blockchain.rs
@@ -8,6 +8,7 @@ use rand::{Rng, SeedableRng};
 use fuel_vm::consts::*;
 use fuel_vm::prelude::*;
 
+use fuel_asm::PanicReason::ErrorFlag;
 use fuel_asm::{
     op, Instruction,
     PanicReason::{ArithmeticOverflow, ContractNotInInputs, ExpectedUnallocatedStack, MemoryOverflow, MemoryOwnership},
@@ -1262,7 +1263,7 @@ fn message_output_b_gt_msg_len() {
         op::smo(RegId::ZERO, reg_a, RegId::ZERO, RegId::ZERO),
     ];
 
-    check_expected_reason_for_instructions(message_output, MemoryOverflow);
+    check_expected_reason_for_instructions(message_output, ErrorFlag);
 }
 
 #[test]


### PR DESCRIPTION
The `SMO` opcode may pass empty array with zero size.