### PR TITLE
Bump the version to the `0.32.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,13 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.31.1"
+version = "0.32.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.31.1", path = "./fuel-asm", default-features = false }
-fuel-crypto = { version = "0.31.1", path = "./fuel-crypto", default-features = false }
-fuel-merkle = { version = "0.31.1", path = "./fuel-merkle", default-features = false }
-fuel-storage = { version = "0.31.1", path = "./fuel-storage", default-features = false }
-fuel-tx = { version = "0.31.1", path = "./fuel-tx", default-features = false }
-fuel-types = { version = "0.31.1", path = "./fuel-types", default-features = false }
+fuel-asm = { version = "0.32.0", path = "./fuel-asm", default-features = false }
+fuel-crypto = { version = "0.32.0", path = "./fuel-crypto", default-features = false }
+fuel-merkle = { version = "0.32.0", path = "./fuel-merkle", default-features = false }
+fuel-storage = { version = "0.32.0", path = "./fuel-storage", default-features = false }
+fuel-tx = { version = "0.32.0", path = "./fuel-tx", default-features = false }
+fuel-types = { version = "0.32.0", path = "./fuel-types", default-features = false }
 bincode = { version = "1.3", default-features = false }


### PR DESCRIPTION
## What's Changed
* Add wide math operations by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/424
* Do not panic when shifting by more than u32::MAX bits by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/433
* Allow empty range in the checked memory by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/436
* Modify "with" functions for consensus parameters by @mitch-fuel in https://github.com/FuelLabs/fuel-vm/pull/446
* Fix to_bytes for numeric types by @Voxelot in https://github.com/FuelLabs/fuel-vm/pull/447
* Addressing minor issues by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/444


**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.31.0...v0.32.0