### PR TITLE
Moved the check of the `contract_id` and `state_root` from `fuel-vm` to `fuel-tx`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,6 @@ Description of the upcoming release here.
 
 #### Breaking
 
-- [#462](https://github.com/FuelLabs/fuel-vm/pull/462): Adds a `cache` parameter to `Input::check` and `Input::check_signature`.
-    This is used to avoid redundant signature recovery when multiple inputs share the same witness index.
-
 - [#386](https://github.com/FuelLabs/fuel-vm/pull/386): The coin and message inputs 
     got a new field - `predicate_gas_used`. So it breaks the constructor API 
     of these inputs.
@@ -53,21 +50,30 @@ It is a wrapper around the `u64`, so any `u64` can be converted into this type v
 - [#459](https://github.com/FuelLabs/fuel-vm/pull/459) Require witness index to be specified when adding an unsigned coin to a transaction.
 This allows for better reuse of witness data when using the transaction builder and helper methods to make transactions compact.
 
+- [#462](https://github.com/FuelLabs/fuel-vm/pull/462): Adds a `cache` parameter to `Input::check` and `Input::check_signature`.
+  This is used to avoid redundant signature recovery when multiple inputs share the same witness index.
+
 ### Changed
 
 - [#458](https://github.com/FuelLabs/fuel-vm/pull/458): Automatically sort storage slots for creation transactions.
 
 #### Breaking
 
+- [#386](https://github.com/FuelLabs/fuel-vm/pull/386): Several methods of the `TransactionFee` are renamed `total` -> `max_fee`
+  and `bytes` -> `min_fee`. The `TransactionFee::min_fee` take into account the gas used by predicates.
+
+- [#450](https://github.com/FuelLabs/fuel-vm/pull/450): The Merkle root of a contract's code is now calculated by partitioning the code into chunks of 16 KiB, instead of 8 bytes. If the last leaf is does not a full 16 KiB, it is padded with `0` up to the nearest multiple of 8 bytes. This affects the `ContractId` and `PredicateId` calculations, breaking all code that used hardcoded values.
+
 - [#456](https://github.com/FuelLabs/fuel-vm/pull/456): The basic methods `UniqueIdentifier::id`, `Signable::sign_inputs`, 
 and `Input::predicate_owner` use `ChainId` instead of the `ConsensusParameters`. 
 It is a less strict requirement than before because you can get `ChainId` 
 from `ConsensusParameters.chain_id`, and it makes the API cleaner. 
 It affects all downstream functions that use listed methods.
-- [#450](https://github.com/FuelLabs/fuel-vm/pull/450): The Merkle root of a contract's code is now calculated by partitioning the code into chunks of 16 KiB, instead of 8 bytes. If the last leaf is does not a full 16 KiB, it is padded with `0` up to the nearest multiple of 8 bytes. This affects the `ContractId` and `PredicateId` calculations, breaking all code that used hardcoded values.
 
-- [#386](https://github.com/FuelLabs/fuel-vm/pull/386): Several methods of the `TransactionFee` are renamed `total` -> `max_fee` 
-    and `bytes` -> `min_fee`. The `TransactionFee::min_fee` take into account the gas used by predicates.
+- [#463](https://github.com/FuelLabs/fuel-vm/pull/463): Moves verification that the `Output::ContractCreated` 
+output contains valid `contract_id` and `state_root`(the values from the `Output` match with calculated 
+values from the bytecode, storage slots, and salt) from `fuel-vm` to `fuel-tx`. 
+It means the end-user will receive this error earlier on the SDK side before `dry_run` instead of after.
 
 ### Fixed
 

--- a/fuel-tx/src/builder.rs
+++ b/fuel-tx/src/builder.rs
@@ -331,7 +331,8 @@ impl<Tx: Buildable> TransactionBuilder<Tx> {
             .iter()
             .for_each(|(k, _)| tx.sign_inputs(k, &self.parameters.chain_id));
 
-        tx.precompute(&self.parameters.chain_id);
+        tx.precompute(&self.parameters.chain_id)
+            .expect("Should be able to calculate cache");
 
         tx
     }
@@ -342,7 +343,8 @@ impl<Tx: Buildable> TransactionBuilder<Tx> {
 
         let mut tx = core::mem::take(&mut self.tx);
 
-        tx.precompute(&self.parameters.chain_id);
+        tx.precompute(&self.parameters.chain_id)
+            .expect("Should be able to calculate cache");
 
         tx
     }
@@ -365,7 +367,8 @@ pub trait Finalizable<Tx> {
 impl Finalizable<Mint> for TransactionBuilder<Mint> {
     fn finalize(&mut self) -> Mint {
         let mut tx = core::mem::take(&mut self.tx);
-        tx.precompute(&self.parameters.chain_id);
+        tx.precompute(&self.parameters.chain_id)
+            .expect("Should be able to calculate cache");
         tx
     }
 

--- a/fuel-tx/src/tests/bytes.rs
+++ b/fuel-tx/src/tests/bytes.rs
@@ -719,8 +719,7 @@ fn create_input_data_offset() {
                         witnesses.clone(),
                     );
 
-                    let mut tx_p = tx.clone();
-                    tx_p.precompute(&ConsensusParameters::DEFAULT.chain_id);
+                    let tx_p = tx.clone();
 
                     buffer.iter_mut().for_each(|b| *b = 0x00);
                     let _ = tx.read(buffer.as_mut_slice()).expect("Failed to serialize input");
@@ -828,7 +827,8 @@ fn script_input_coin_data_offset() {
                         );
 
                         let mut tx_p = tx.clone();
-                        tx_p.precompute(&ConsensusParameters::DEFAULT.chain_id);
+                        tx_p.precompute(&ConsensusParameters::DEFAULT.chain_id)
+                            .expect("Should be able to calculate cache");
 
                         buffer.iter_mut().for_each(|b| *b = 0x00);
 

--- a/fuel-tx/src/tests/offset.rs
+++ b/fuel-tx/src/tests/offset.rs
@@ -391,7 +391,8 @@ fn iow_offset() {
             let bytes = tx.to_bytes();
 
             let mut tx_p = tx.clone();
-            tx_p.precompute(&ConsensusParameters::DEFAULT.chain_id);
+            tx_p.precompute(&ConsensusParameters::DEFAULT.chain_id)
+                .expect("Should be able to calculate cache");
 
             tx.inputs().iter().enumerate().for_each(|(x, i)| {
                 let offset = tx.inputs_offset_at(x).unwrap();

--- a/fuel-tx/src/transaction/id.rs
+++ b/fuel-tx/src/transaction/id.rs
@@ -161,8 +161,7 @@ mod tests {
     {
         let mut tx_p = tx.clone();
 
-        let mut tx_q = tx.clone();
-        tx_q.precompute(&ConsensusParameters::DEFAULT.chain_id);
+        let tx_q = tx.clone();
 
         f(&mut tx_p);
 
@@ -184,8 +183,7 @@ mod tests {
 
         f(&mut tx_p);
 
-        let mut tx_q = tx_p.clone();
-        tx_q.precompute(&ConsensusParameters::DEFAULT.chain_id);
+        let tx_q = tx_p.clone();
 
         assert_ne!(
             tx.id(&ConsensusParameters::DEFAULT.chain_id),

--- a/fuel-tx/src/transaction/metadata.rs
+++ b/fuel-tx/src/transaction/metadata.rs
@@ -1,6 +1,7 @@
 use alloc::vec::Vec;
 use fuel_types::{Bytes32, ChainId};
 
+use crate::CheckError;
 #[cfg(feature = "std")]
 use crate::{field, UniqueIdentifier};
 
@@ -12,7 +13,7 @@ pub trait Cacheable {
     fn is_computed(&self) -> bool;
 
     /// Computes the cache for the entity.
-    fn precompute(&mut self, chain_id: &ChainId);
+    fn precompute(&mut self, chain_id: &ChainId) -> Result<(), CheckError>;
 }
 
 #[cfg(feature = "std")]
@@ -25,7 +26,7 @@ impl Cacheable for super::Transaction {
         }
     }
 
-    fn precompute(&mut self, chain_id: &ChainId) {
+    fn precompute(&mut self, chain_id: &ChainId) -> Result<(), CheckError> {
         match self {
             Self::Script(script) => script.precompute(chain_id),
             Self::Create(create) => create.precompute(chain_id),

--- a/fuel-tx/src/transaction/types/mint.rs
+++ b/fuel-tx/src/transaction/types/mint.rs
@@ -144,9 +144,10 @@ impl crate::Cacheable for Mint {
         self.metadata.is_some()
     }
 
-    fn precompute(&mut self, chain_id: &ChainId) {
+    fn precompute(&mut self, chain_id: &ChainId) -> Result<(), CheckError> {
         self.metadata = None;
         self.metadata = Some(MintMetadata::compute(self, chain_id));
+        Ok(())
     }
 }
 

--- a/fuel-tx/src/transaction/types/script.rs
+++ b/fuel-tx/src/transaction/types/script.rs
@@ -185,12 +185,13 @@ impl crate::Cacheable for Script {
         self.metadata.is_some()
     }
 
-    fn precompute(&mut self, chain_id: &ChainId) {
+    fn precompute(&mut self, chain_id: &ChainId) -> Result<(), CheckError> {
         self.metadata = None;
         self.metadata = Some(ScriptMetadata {
             common: CommonMetadata::compute(self, chain_id),
             script_data_offset: self.script_data_offset(),
         });
+        Ok(())
     }
 }
 

--- a/fuel-tx/src/transaction/validity/error.rs
+++ b/fuel-tx/src/transaction/validity/error.rs
@@ -63,6 +63,9 @@ pub enum CheckError {
     TransactionCreateOutputChangeNotBaseAsset {
         index: usize,
     },
+    TransactionCreateOutputContractCreatedDoesntMatch {
+        index: usize,
+    },
     TransactionCreateOutputContractCreatedMultiple {
         index: usize,
     },

--- a/fuel-vm/src/checked_transaction/types.rs
+++ b/fuel-vm/src/checked_transaction/types.rs
@@ -77,7 +77,7 @@ pub mod create {
             block_height: BlockHeight,
             params: &ConsensusParameters,
         ) -> Result<Checked<Self>, CheckError> {
-            self.precompute(&params.chain_id);
+            self.precompute(&params.chain_id)?;
             self.check_without_signatures(block_height, params)?;
 
             // validate fees and compute free balances
@@ -117,7 +117,7 @@ pub mod mint {
             block_height: BlockHeight,
             params: &ConsensusParameters,
         ) -> Result<Checked<Self>, CheckError> {
-            self.precompute(&params.chain_id);
+            self.precompute(&params.chain_id)?;
             self.check_without_signatures(block_height, params)?;
 
             Ok(Checked::basic(self, ()))
@@ -159,7 +159,7 @@ pub mod script {
             block_height: BlockHeight,
             params: &ConsensusParameters,
         ) -> Result<Checked<Self>, CheckError> {
-            self.precompute(&params.chain_id);
+            self.precompute(&params.chain_id)?;
             self.check_without_signatures(block_height, params)?;
 
             // validate fees and compute free balances


### PR DESCRIPTION
It fixes several TODO.

The change moves the check of the `contract_id` and `state_root` from VM to the check rules. The change also caches the `contract_root`, `state_root`, and `contract_id` in the metadata.