### PR TITLE
Bump version to `0.33.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased] - yyyy-mm-dd
+## [Unreleased]
 
 Description of the upcoming release here.
+
+## [Version 0.33.0]
+
+The release contains a lot of breaking changes. 
+Most of them are audit blockers and affect the protocol itself.
+Starting this release we plan to maintain the changelog file and describe all minor and major changes that make sense.
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,13 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.32.0"
+version = "0.33.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.32.0", path = "./fuel-asm", default-features = false }
-fuel-crypto = { version = "0.32.0", path = "./fuel-crypto", default-features = false }
-fuel-merkle = { version = "0.32.0", path = "./fuel-merkle", default-features = false }
-fuel-storage = { version = "0.32.0", path = "./fuel-storage", default-features = false }
-fuel-tx = { version = "0.32.0", path = "./fuel-tx", default-features = false }
-fuel-types = { version = "0.32.0", path = "./fuel-types", default-features = false }
+fuel-asm = { version = "0.33.0", path = "./fuel-asm", default-features = false }
+fuel-crypto = { version = "0.33.0", path = "./fuel-crypto", default-features = false }
+fuel-merkle = { version = "0.33.0", path = "./fuel-merkle", default-features = false }
+fuel-storage = { version = "0.33.0", path = "./fuel-storage", default-features = false }
+fuel-tx = { version = "0.33.0", path = "./fuel-tx", default-features = false }
+fuel-types = { version = "0.33.0", path = "./fuel-types", default-features = false }
 bincode = { version = "1.3", default-features = false }


### PR DESCRIPTION
[Rendered release notes](https://github.com/FuelLabs/fuel-vm/blob/release/0.33.0/CHANGELOG.md#version-0330)