### PR TITLE
Add bulk SMT creation

### DIFF
--- a/fuel-merkle/benches/smt.rs
+++ b/fuel-merkle/benches/smt.rs
@@ -223,23 +223,23 @@ fn sparse_merkle_tree(c: &mut Criterion) {
     let gen = || Some((random_bytes32(rng), random_bytes32(rng)));
     let data = std::iter::from_fn(gen).take(64000).collect::<Vec<_>>();
 
-    let l0 = Bytes32::default(); // left, left, left, left left, ...
-
-    let mut l1 = Bytes32::default();
-    l1[0..1].copy_from_slice(&[0b01000000]); // left, right, left, left, left, ...
-
-    let mut l3 = Bytes32::default();
-    l3[0..1].copy_from_slice(&[0b01001000]); // left, right, left, left, right, ...
-
-    let mut l2 = Bytes32::default();
-    l2[0..1].copy_from_slice(&[0b01100000]); // left, right, right, ...
-
-    let data = [
-        (l0, random_bytes32(rng)),
-        (l1, random_bytes32(rng)),
-        (l2, random_bytes32(rng)),
-        (l3, random_bytes32(rng)),
-    ];
+    // let l0 = Bytes32::default(); // left, left, left, left left, ...
+    //
+    // let mut l1 = Bytes32::default();
+    // l1[0..1].copy_from_slice(&[0b01000000]); // left, right, left, left, left, ...
+    //
+    // let mut l3 = Bytes32::default();
+    // l3[0..1].copy_from_slice(&[0b01001000]); // left, right, left, left, right, ...
+    //
+    // let mut l2 = Bytes32::default();
+    // l2[0..1].copy_from_slice(&[0b01100000]); // left, right, right, ...
+    //
+    // let data = [
+    //     (l0, random_bytes32(rng)),
+    //     (l1, random_bytes32(rng)),
+    //     (l2, random_bytes32(rng)),
+    //     (l3, random_bytes32(rng)),
+    // ];
 
     let input: BTreeMap<Bytes32, Bytes32> = BTreeMap::from_iter(data.into_iter());
 

--- a/fuel-merkle/benches/smt.rs
+++ b/fuel-merkle/benches/smt.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use fuel_merkle::common::{Bytes32, StorageMap};
-use fuel_merkle::sparse::{MerkleTree, MerkleTreeError, Primitive};
+use fuel_merkle::sparse::{MerkleTree, Node, Primitive};
 use fuel_storage::{Mappable, StorageMutate};
 use rand::Rng;
 use std::collections::BTreeMap;
@@ -26,23 +26,167 @@ impl Mappable for NodesTable {
 
 type Storage = StorageMap<NodesTable>;
 
+trait Prefix {
+    fn common_prefix(&self, other: &Self) -> usize;
+}
+
+impl Prefix for Bytes32 {
+    fn common_prefix(&self, other: &Self) -> usize {
+        use fuel_merkle::common::msb::Msb;
+        self.common_prefix_count(other)
+    }
+}
+
+struct Branch {
+    bits: Bytes32,
+    node: Node,
+}
+
 // Naive update set: Updates the Merkle tree sequentially.
 // This is the baseline. Performance improvements to the Sparse Merkle Tree's
 // update_set must demonstrate an increase in speed relative to this baseline.
-pub fn update_set_baseline<'a, I, Storage>(
-    tree: &mut MerkleTree<NodesTable, Storage>,
-    set: I,
-) -> Result<(), MerkleTreeError<MerkleTreeError<Storage::Error>>>
+pub fn update_set_baseline<'a, I, Storage>(storage: &mut Storage, set: I) -> Result<Bytes32, Storage::Error>
 where
     I: IntoIterator<Item = (&'a Bytes32, &'a Bytes32)>,
     Storage: StorageMutate<NodesTable>,
 {
-    let iter = set.into_iter();
-    for (key, data) in iter {
-        tree.update(key, data.as_ref())?;
+    let mut stack: Vec<Branch> = vec![];
+    let mut upcoming = set
+        .into_iter()
+        .map(|(key, data)| {
+            let leaf_node = Node::create_leaf(key, data);
+            storage.insert(&leaf_node.hash(), &leaf_node.as_ref().into())?;
+            storage.insert(leaf_node.leaf_key(), &leaf_node.as_ref().into())?;
+
+            Ok(Branch {
+                bits: *leaf_node.leaf_key(),
+                node: leaf_node,
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    while !upcoming.is_empty() {
+        let current = upcoming.pop().expect("We checked that above");
+
+        match (upcoming.pop(), stack.pop()) {
+            (Some(left), Some(right)) => {
+                let left_cur = left.bits.common_prefix(&current.bits);
+                let cur_right = current.bits.common_prefix(&right.bits);
+
+                if left_cur < cur_right {
+                    let branch = merge_branches(storage, current, right)?;
+                    upcoming.push(left);
+                    upcoming.push(branch);
+                } else {
+                    upcoming.push(left);
+                    stack.push(right);
+                    stack.push(current);
+                }
+            }
+            (Some(left), None) => {
+                stack.push(current);
+                upcoming.push(left);
+            }
+            (None, Some(right)) => {
+                let branch = merge_branches(storage, current, right)?;
+                upcoming.push(branch);
+            }
+            (None, None) => {
+                stack.push(current);
+            }
+        }
     }
 
-    Ok(())
+    assert_eq!(stack.len(), 1);
+
+    Ok(stack[0].node.hash())
+}
+
+fn merge_branches<Storage>(
+    storage: &mut Storage,
+    mut left_branch: Branch,
+    mut right_branch: Branch,
+) -> Result<Branch, Storage::Error>
+where
+    Storage: StorageMutate<NodesTable>,
+{
+    use fuel_merkle::common::msb::Bit;
+    use fuel_merkle::common::msb::Msb;
+
+    let branch = if left_branch.node.is_leaf() && right_branch.node.is_leaf() {
+        let parent_depth = left_branch.bits.common_prefix(&right_branch.bits);
+        let parent_height = (Node::max_height() - parent_depth) as u32;
+        let node = Node::create_node(&left_branch.node, &right_branch.node, parent_height);
+        Branch {
+            bits: left_branch.bits,
+            node,
+        }
+    } else {
+        let parent_depth = left_branch.bits.common_prefix(&right_branch.bits);
+        let parent_height = (Node::max_height() - parent_depth) as u32;
+
+        if right_branch.node.is_node() {
+            let start_height = right_branch.node.height() + 1;
+            for height in start_height..parent_height {
+                let byte_index = Node::max_height() - height as usize;
+
+                match right_branch.bits.get_bit_at_index_from_msb(byte_index).unwrap() {
+                    Bit::_0 => {
+                        let node = Node::create_node(&right_branch.node, &Node::create_placeholder(), height);
+
+                        right_branch = Branch {
+                            bits: right_branch.bits,
+                            node,
+                        };
+                    }
+                    Bit::_1 => {
+                        let node = Node::create_node(&Node::create_placeholder(), &right_branch.node, height);
+
+                        right_branch = Branch {
+                            bits: right_branch.bits,
+                            node,
+                        };
+                    }
+                }
+                storage.insert(&right_branch.node.hash(), &right_branch.node.as_ref().into())?;
+            }
+        }
+
+        if left_branch.node.is_node() {
+            let start_height = left_branch.node.height() + 1;
+            for height in start_height..parent_height {
+                let byte_index = Node::max_height() - height as usize;
+
+                match left_branch.bits.get_bit_at_index_from_msb(byte_index).unwrap() {
+                    Bit::_0 => {
+                        let node = Node::create_node(&left_branch.node, &Node::create_placeholder(), height);
+
+                        left_branch = Branch {
+                            bits: left_branch.bits,
+                            node,
+                        };
+                    }
+                    Bit::_1 => {
+                        let node = Node::create_node(&Node::create_placeholder(), &left_branch.node, height);
+
+                        left_branch = Branch {
+                            bits: left_branch.bits,
+                            node,
+                        };
+                    }
+                }
+                storage.insert(&left_branch.node.hash(), &left_branch.node.as_ref().into())?;
+            }
+        }
+
+        let node = Node::create_node(&left_branch.node, &right_branch.node, parent_height);
+        Branch {
+            bits: left_branch.bits,
+            node,
+        }
+    };
+
+    storage.insert(&branch.node.hash(), &branch.node.as_ref().into())?;
+    Ok(branch)
 }
 
 fn sparse_merkle_tree(c: &mut Criterion) {
@@ -51,15 +195,22 @@ fn sparse_merkle_tree(c: &mut Criterion) {
 
     let rng = &mut StdRng::seed_from_u64(8586);
     let gen = || Some((random_bytes32(rng), random_bytes32(rng)));
-    let data = std::iter::from_fn(gen).take(10000).collect::<Vec<_>>();
+    let data = std::iter::from_fn(gen).take(64000).collect::<Vec<_>>();
     let input: BTreeMap<Bytes32, Bytes32> = BTreeMap::from_iter(data.into_iter());
+
+    let storage = Storage::new();
+    let mut tree = MerkleTree::<NodesTable, Storage>::new(storage);
+    tree.update_set(black_box(&input)).unwrap();
+    let mut storage = Storage::new();
+    let baseline_root = update_set_baseline(black_box(&mut storage), black_box(&input)).unwrap();
+
+    assert_eq!(tree.root(), baseline_root);
 
     let mut group_update = c.benchmark_group("update");
 
     group_update.bench_with_input("update-set-baseline", &input, |b, input| {
-        let storage = Storage::new();
-        let mut tree = MerkleTree::<NodesTable, Storage>::new(storage);
-        b.iter(|| update_set_baseline(black_box(&mut tree), black_box(input)));
+        let mut storage = Storage::new();
+        b.iter(|| update_set_baseline(black_box(&mut storage), black_box(input)));
     });
 
     group_update.bench_with_input("update-set", &input, |b, input| {

--- a/fuel-merkle/benches/smt.rs
+++ b/fuel-merkle/benches/smt.rs
@@ -32,8 +32,21 @@ trait Prefix {
 
 impl Prefix for Bytes32 {
     fn common_prefix(&self, other: &Self) -> usize {
-        use fuel_merkle::common::msb::Msb;
-        self.common_prefix_count(other)
+        for i in 0..self.len() {
+            if self[i] == other[i] {
+                continue;
+            } else {
+                for k in 0..8 {
+                    let bit = 1 << (7 - k);
+                    if self[i] & bit == other[i] & bit {
+                        continue;
+                    } else {
+                        return 8 * i + k;
+                    }
+                }
+            }
+        }
+        core::mem::size_of::<Self>()
     }
 }
 
@@ -50,7 +63,6 @@ where
     I: IntoIterator<Item = (&'a Bytes32, &'a Bytes32)>,
     Storage: StorageMutate<NodesTable>,
 {
-    let mut stack: Vec<Branch> = vec![];
     let mut upcoming = set
         .into_iter()
         .map(|(key, data)| {
@@ -64,6 +76,8 @@ where
             })
         })
         .collect::<Result<Vec<_>, _>>()?;
+    let mut stack: Vec<Branch> = Vec::with_capacity(upcoming.len());
+
     while !upcoming.is_empty() {
         let current = upcoming.pop().expect("We checked that above");
 

--- a/fuel-merkle/src/common.rs
+++ b/fuel-merkle/src/common.rs
@@ -1,4 +1,4 @@
-mod msb;
+pub mod msb;
 mod path_iterator;
 mod position;
 mod position_path;

--- a/fuel-merkle/src/sparse.rs
+++ b/fuel-merkle/src/sparse.rs
@@ -4,9 +4,10 @@ mod node;
 mod primitive;
 
 pub(crate) use hash::zero_sum;
-pub(crate) use node::{Node, StorageNode, StorageNodeError};
+pub(crate) use node::{StorageNode, StorageNodeError};
 
 pub use merkle_tree::{MerkleTree, MerkleTreeError};
+pub use node::Node;
 pub use primitive::Primitive;
 pub mod in_memory;
 

--- a/fuel-merkle/src/sparse/hash.rs
+++ b/fuel-merkle/src/sparse/hash.rs
@@ -19,15 +19,3 @@ where
     hash.update(data);
     hash.finalize().try_into().unwrap()
 }
-
-pub fn sum_all<I>(data: I) -> Bytes32
-where
-    I: IntoIterator,
-    I::Item: AsRef<[u8]>,
-{
-    let mut hash = Hash::new();
-    for datum in data.into_iter() {
-        hash.update(datum)
-    }
-    hash.finalize().try_into().unwrap()
-}

--- a/fuel-merkle/src/sparse/node.rs
+++ b/fuel-merkle/src/sparse/node.rs
@@ -15,7 +15,7 @@ use crate::{
 use core::{cmp, fmt, marker::PhantomData};
 
 #[derive(Clone)]
-pub(crate) struct Node {
+pub struct Node {
     height: u32,
     prefix: Prefix,
     bytes_lo: Bytes32,

--- a/fuel-merkle/src/sparse/node.rs
+++ b/fuel-merkle/src/sparse/node.rs
@@ -5,41 +5,41 @@ use crate::{
         path::{ComparablePath, Instruction, Path},
         Bytes32, Prefix,
     },
-    sparse::{
-        hash::{sum, sum_all},
-        zero_sum, Primitive,
-    },
+    sparse::{hash::sum, zero_sum, Primitive},
     storage::{Mappable, StorageInspect},
 };
 
 use core::{cmp, fmt, marker::PhantomData};
 
-#[derive(Clone)]
-pub struct Node {
-    height: u32,
-    prefix: Prefix,
-    bytes_lo: Bytes32,
-    bytes_hi: Bytes32,
-}
-
-impl Default for Node {
-    fn default() -> Self {
-        Self {
-            height: Default::default(),
-            prefix: Default::default(),
-            bytes_lo: *zero_sum(),
-            bytes_hi: *zero_sum(),
-        }
-    }
+#[derive(Clone, PartialEq, Eq)]
+pub enum Node {
+    Node {
+        hash: Bytes32,
+        height: u32,
+        prefix: Prefix,
+        bytes_lo: Bytes32,
+        bytes_hi: Bytes32,
+    },
+    Placeholder,
 }
 
 impl Node {
+    fn calculate_hash(prefix: &Prefix, bytes_lo: &Bytes32, bytes_hi: &Bytes32) -> Bytes32 {
+        use digest::Digest;
+        let mut hash = sha2::Sha256::new();
+        hash.update(prefix);
+        hash.update(bytes_lo);
+        hash.update(bytes_hi);
+        hash.finalize().try_into().unwrap()
+    }
+
     pub fn max_height() -> usize {
         Node::key_size_in_bits()
     }
 
     pub fn new(height: u32, prefix: Prefix, bytes_lo: Bytes32, bytes_hi: Bytes32) -> Self {
-        Self {
+        Self::Node {
+            hash: Self::calculate_hash(&prefix, &bytes_lo, &bytes_hi),
             height,
             prefix,
             bytes_lo,
@@ -48,20 +48,25 @@ impl Node {
     }
 
     pub fn create_leaf(key: &Bytes32, data: &[u8]) -> Self {
-        Self {
+        let bytes_hi = sum(data);
+        Self::Node {
+            hash: Self::calculate_hash(&Prefix::Leaf, key, &bytes_hi),
             height: 0u32,
             prefix: Prefix::Leaf,
             bytes_lo: *key,
-            bytes_hi: sum(data),
+            bytes_hi,
         }
     }
 
     pub fn create_node(left_child: &Node, right_child: &Node, height: u32) -> Self {
-        Self {
+        let bytes_lo = left_child.hash();
+        let bytes_hi = right_child.hash();
+        Self::Node {
+            hash: Self::calculate_hash(&Prefix::Node, &bytes_lo, &bytes_hi),
             height,
             prefix: Prefix::Node,
-            bytes_lo: left_child.hash(),
-            bytes_hi: right_child.hash(),
+            bytes_lo,
+            bytes_hi,
         }
     }
 
@@ -93,7 +98,7 @@ impl Node {
     }
 
     pub fn create_placeholder() -> Self {
-        Default::default()
+        Self::Placeholder
     }
 
     pub fn common_path_length(&self, other: &Node) -> usize {
@@ -112,19 +117,31 @@ impl Node {
     }
 
     pub fn height(&self) -> u32 {
-        self.height
+        match self {
+            Node::Node { height, .. } => *height,
+            Node::Placeholder => 0,
+        }
     }
 
     pub fn prefix(&self) -> Prefix {
-        self.prefix
+        match self {
+            Node::Node { prefix, .. } => *prefix,
+            Node::Placeholder => Prefix::Leaf,
+        }
     }
 
     pub fn bytes_lo(&self) -> &Bytes32 {
-        &self.bytes_lo
+        match self {
+            Node::Node { bytes_lo, .. } => bytes_lo,
+            Node::Placeholder => zero_sum(),
+        }
     }
 
     pub fn bytes_hi(&self) -> &Bytes32 {
-        &self.bytes_hi
+        match self {
+            Node::Node { bytes_hi, .. } => bytes_hi,
+            Node::Placeholder => zero_sum(),
+        }
     }
 
     pub fn is_leaf(&self) -> bool {
@@ -156,15 +173,13 @@ impl Node {
     }
 
     pub fn is_placeholder(&self) -> bool {
-        *self.bytes_lo() == *zero_sum() && *self.bytes_hi() == *zero_sum()
+        &Self::Placeholder == self
     }
 
     pub fn hash(&self) -> Bytes32 {
-        if self.is_placeholder() {
-            *zero_sum()
-        } else {
-            let data = [self.prefix.as_ref(), self.bytes_lo.as_ref(), self.bytes_hi.as_ref()];
-            sum_all(data)
+        match self {
+            Node::Node { hash, .. } => *hash,
+            Node::Placeholder => *zero_sum(),
         }
     }
 }


### PR DESCRIPTION
I came up with the idea of the algorithm. It creates a tree for 180ms instead of 1.4s (~8x faster) for 64k entries. So already is better than before=D

<img width="1136" alt="image" src="https://github.com/FuelLabs/fuel-vm/assets/18346821/a3c11aa8-c23f-48ab-819d-cd229b622355">
