### PR TITLE
Disallow setting $sp < $ssp using CFS and CFSI instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Description of the upcoming release here.
 
+### Breaking
+
+- [#386](https://github.com/FuelLabs/fuel-vm/pull/473): CFS and CFSI were not validating
+    that the new `$sp` value isn't below `$ssp`, allowing write access to non-owned
+    memory. This is now fixed, and attempting to set an incorrect `$sp` value panics.
+
 ## [Version 0.33.0]
 
 The release contains a lot of breaking changes. 

--- a/fuel-vm/src/interpreter/memory/allocation_tests.rs
+++ b/fuel-vm/src/interpreter/memory/allocation_tests.rs
@@ -109,18 +109,19 @@ fn test_memeq(b: Word, c: Word, d: Word) -> Result<(), RuntimeError> {
     Ok(())
 }
 
-#[test_case(true, 20, 40, 10 => Ok(()); "Can move sp up")]
-#[test_case(false, 20, 40, 10 => Ok(()); "Can move sp down")]
-#[test_case(true, u64::MAX - 10, u64::MAX, 20 => Err(RuntimeError::Recoverable(PanicReason::MemoryOverflow)); "Panics on overflowing addition")]
-#[test_case(false, 10, 11, 20 => Err(RuntimeError::Recoverable(PanicReason::MemoryOverflow)); "Panics on underflowing subtraction")]
-#[test_case(true, u64::MAX, u64::MAX, 0 => Err(RuntimeError::Recoverable(PanicReason::MemoryOverflow)); "Panics on equality check for overflowing addition")]
-#[test_case(false, 0, u64::MAX, 1 => Err(RuntimeError::Recoverable(PanicReason::MemoryOverflow)); "Panics on zero check for underflowing subtraction")]
-fn test_stack_pointer_overflow(add: bool, mut sp: Word, hp: Word, v: Word) -> Result<(), RuntimeError> {
+#[test_case(true, 20, 0, 40, 10 => Ok(()); "Can move sp up")]
+#[test_case(false, 20, 0, 40, 10 => Ok(()); "Can move sp down")]
+#[test_case(true, u64::MAX - 10, 0, u64::MAX, 20 => Err(RuntimeError::Recoverable(PanicReason::MemoryOverflow)); "Panics on overflowing addition")]
+#[test_case(false, 10, 0, 11, 20 => Err(RuntimeError::Recoverable(PanicReason::MemoryOverflow)); "Panics on underflowing subtraction")]
+#[test_case(true, u64::MAX, 0, u64::MAX, 0 => Err(RuntimeError::Recoverable(PanicReason::MemoryOverflow)); "Panics on equality check for overflowing addition")]
+#[test_case(false, 0, 0, u64::MAX, 1 => Err(RuntimeError::Recoverable(PanicReason::MemoryOverflow)); "Panics on zero check for underflowing subtraction")]
+fn test_stack_pointer_overflow(add: bool, mut sp: Word, ssp: Word, hp: Word, v: Word) -> Result<(), RuntimeError> {
     let mut pc = 4;
     let old_sp = sp;
 
     stack_pointer_overflow(
         RegMut::new(&mut sp),
+        Reg::new(&ssp),
         Reg::new(&hp),
         RegMut::new(&mut pc),
         if add {

--- a/fuel-vm/src/interpreter/memory/allocation_tests.rs
+++ b/fuel-vm/src/interpreter/memory/allocation_tests.rs
@@ -115,6 +115,7 @@ fn test_memeq(b: Word, c: Word, d: Word) -> Result<(), RuntimeError> {
 #[test_case(false, 10, 0, 11, 20 => Err(RuntimeError::Recoverable(PanicReason::MemoryOverflow)); "Panics on underflowing subtraction")]
 #[test_case(true, u64::MAX, 0, u64::MAX, 0 => Err(RuntimeError::Recoverable(PanicReason::MemoryOverflow)); "Panics on equality check for overflowing addition")]
 #[test_case(false, 0, 0, u64::MAX, 1 => Err(RuntimeError::Recoverable(PanicReason::MemoryOverflow)); "Panics on zero check for underflowing subtraction")]
+#[test_case(false, 8, 8, u64::MAX, 1 => Err(RuntimeError::Recoverable(PanicReason::MemoryOverflow)); "Panics on sp < ssp")]
 fn test_stack_pointer_overflow(add: bool, mut sp: Word, ssp: Word, hp: Word, v: Word) -> Result<(), RuntimeError> {
     let mut pc = 4;
     let old_sp = sp;


### PR DESCRIPTION
This is a critical security bug that allows bypassing memory ownership protection completely.

Exploiting this bug is trivial. Using the following code would make the whole VM memory writable using e.g. SB and SW instructions. This in turn allows for instance performing contract operations using different contracts id.

```
cfs $sp           // Use the bug to set $sp = 0
slli $a, $one, 26 // Set $a to VM_MAX_RAM
aloc $a           // Set $hp = 0, so that the whole memory is in owned heap range
```