### PR TITLE
MemoryRange rework

### DIFF
--- a/fuel-vm/src/constraints.rs
+++ b/fuel-vm/src/constraints.rs
@@ -2,40 +2,32 @@
 use std::ops::Deref;
 use std::ops::DerefMut;
 
-use fuel_asm::PanicReason;
 use fuel_asm::Word;
 use fuel_types::ContractId;
 
 use crate::consts::MEM_SIZE;
-use crate::consts::VM_MAX_RAM;
-use crate::prelude::Bug;
-use crate::prelude::BugId;
-use crate::prelude::BugVariant;
+use crate::prelude::MemoryRange;
 use crate::prelude::RuntimeError;
 
 pub mod reg_key;
 
 /// A range of memory that has been checked that it fits into the VM memory.
 #[derive(Clone)]
-pub struct CheckedMemRange(core::ops::Range<usize>);
-
-/// A range of memory that has been checked that it fits into the VM memory.
-#[derive(Clone)]
 // TODO: Replace `LEN` constant with a generic object that implements some trait that knows
 //  the static size of the generic.
-pub struct CheckedMemConstLen<const LEN: usize>(CheckedMemRange);
+pub struct CheckedMemConstLen<const LEN: usize>(MemoryRange);
 
 /// A range of memory that has been checked that it fits into the VM memory.
 /// This range can be used to read a value of type `T` from memory.
 #[derive(Clone)]
 // TODO: Merge this type with `CheckedMemConstLen`.
-pub struct CheckedMemValue<T>(CheckedMemRange, core::marker::PhantomData<T>);
+pub struct CheckedMemValue<T>(MemoryRange, core::marker::PhantomData<T>);
 
 impl<T> CheckedMemValue<T> {
     /// Create a new const sized memory range.
     pub fn new<const SIZE: usize>(address: Word) -> Result<Self, RuntimeError> {
         Ok(Self(
-            CheckedMemRange::new_const::<SIZE>(address)?,
+            MemoryRange::new_const::<_, SIZE>(address)?,
             core::marker::PhantomData,
         ))
     }
@@ -46,69 +38,7 @@ impl<T> CheckedMemValue<T> {
         T: for<'a> TryFrom<&'a [u8]>,
         RuntimeError: for<'a> From<<T as TryFrom<&'a [u8]>>::Error>,
     {
-        Ok(T::try_from(&memory[self.0 .0])?)
-    }
-
-    /// The start of the range.
-    pub fn start(&self) -> usize {
-        self.0.start()
-    }
-
-    /// The end of the range.
-    pub fn end(&self) -> usize {
-        self.0.end()
-    }
-
-    #[cfg(test)]
-    /// Inspect a value of type `T` from memory.
-    pub fn inspect(self, memory: &[u8; MEM_SIZE]) -> T
-    where
-        T: std::io::Write + Default,
-    {
-        let mut t = T::default();
-        t.write_all(&memory[self.0 .0]).unwrap();
-        t
-    }
-}
-
-impl CheckedMemRange {
-    const DEFAULT_CONSTRAINT: core::ops::Range<Word> = 0..VM_MAX_RAM;
-
-    /// Create a new const sized memory range.
-    pub fn new_const<const SIZE: usize>(address: Word) -> Result<Self, RuntimeError> {
-        Self::new(address, SIZE)
-    }
-
-    /// Create a new memory range.
-    pub fn new(address: Word, size: usize) -> Result<Self, RuntimeError> {
-        Self::new_inner(address as usize, size, Self::DEFAULT_CONSTRAINT)
-    }
-
-    /// Create a new memory range with a custom constraint.
-    /// The min of the constraints end and `VM_MAX_RAM` will be used.
-    pub fn new_with_constraint(
-        address: Word,
-        size: usize,
-        constraint: core::ops::Range<Word>,
-    ) -> Result<Self, RuntimeError> {
-        if constraint.end > VM_MAX_RAM {
-            return Err(Bug::new(BugId::ID009, BugVariant::InvalidMemoryConstraint).into());
-        }
-        Self::new_inner(address as usize, size, constraint)
-    }
-
-    /// Create a new memory range, checks that the range fits into the constraint.
-    fn new_inner(address: usize, size: usize, constraint: core::ops::Range<Word>) -> Result<Self, RuntimeError> {
-        let (end, of) = address.overflowing_add(size);
-        let range = address..end;
-
-        if of
-            || !constraint.contains(&(range.start as Word))
-            || size != 0 && !constraint.contains(&((range.end - 1) as Word))
-        {
-            return Err(PanicReason::MemoryOverflow.into());
-        }
-        Ok(Self(range))
+        Ok(T::try_from(&memory[self.0.usizes()])?)
     }
 
     /// The start of the range.
@@ -121,52 +51,34 @@ impl CheckedMemRange {
         self.0.end
     }
 
-    /// This function is safe because it is only used to shrink the range
-    /// and worst case the range will be empty.
-    pub fn shrink_end(&mut self, by: usize) {
-        self.0 = self.0.start..self.0.end.saturating_sub(by);
-    }
-
-    /// This function is safe because it is only used to grow the range
-    /// and worst case the range will be empty.
-    pub fn grow_start(&mut self, by: usize) {
-        self.0 = self.0.start.saturating_add(by)..self.0.end;
-    }
-
-    /// Get the memory slice for this range.
-    pub fn read(self, memory: &[u8; MEM_SIZE]) -> &[u8] {
-        &memory[self.0]
-    }
-
-    /// Get the mutable memory slice for this range.
-    pub fn write(self, memory: &mut [u8; MEM_SIZE]) -> &mut [u8] {
-        &mut memory[self.0]
+    #[cfg(test)]
+    /// Inspect a value of type `T` from memory.
+    pub fn inspect(self, memory: &[u8; MEM_SIZE]) -> T
+    where
+        T: std::io::Write + Default,
+    {
+        let mut t = T::default();
+        t.write_all(&memory[self.0.usizes()]).unwrap();
+        t
     }
 }
 
 impl<const LEN: usize> CheckedMemConstLen<LEN> {
     /// Create a new const sized memory range.
     pub fn new(address: Word) -> Result<Self, RuntimeError> {
-        Ok(Self(CheckedMemRange::new_const::<LEN>(address)?))
-    }
-
-    /// Create a new memory range with a custom constraint.
-    /// Panics if constraints end > `VM_MAX_RAM`.
-    pub fn new_with_constraint(address: Word, constraint: core::ops::Range<Word>) -> Result<Self, RuntimeError> {
-        assert!(constraint.end <= VM_MAX_RAM, "Constraint end must be <= VM_MAX_RAM.");
-        Ok(Self(CheckedMemRange::new_inner(address as usize, LEN, constraint)?))
+        Ok(Self(MemoryRange::new_const::<_, LEN>(address)?))
     }
 
     /// Get the memory slice for this range.
     pub fn read(self, memory: &[u8; MEM_SIZE]) -> &[u8; LEN] {
-        (&memory[self.0 .0])
+        (&memory[self.0.usizes()])
             .try_into()
             .expect("This is always correct as the address and LEN are checked on construction.")
     }
 
     /// Get the mutable memory slice for this range.
     pub fn write(self, memory: &mut [u8; MEM_SIZE]) -> &mut [u8; LEN] {
-        (&mut memory[self.0 .0])
+        (&mut memory[self.0.usizes()])
             .try_into()
             .expect("This is always correct as the address and LEN are checked on construction.")
     }
@@ -182,7 +94,7 @@ pub struct InstructionLocation {
 }
 
 impl<const LEN: usize> Deref for CheckedMemConstLen<LEN> {
-    type Target = CheckedMemRange;
+    type Target = MemoryRange;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/fuel-vm/src/error.rs
+++ b/fuel-vm/src/error.rs
@@ -275,15 +275,17 @@ impl From<InterpreterError> for PredicateVerificationFailed {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "strum", derive(strum::EnumVariantNames))]
 pub enum BugId {
+    // Not used
     ID001,
     ID002,
     ID003,
     ID004,
+    // Not used
     ID005,
+    // Not used
     ID006,
     ID007,
     ID008,
-    ID009,
 }
 
 /// Traceable bug variants
@@ -303,9 +305,6 @@ pub enum BugVariant {
 
     /// The global gas is less than the context gas.
     GlobalGasLessThanContext,
-
-    /// Constraint larger then memory bounds
-    InvalidMemoryConstraint,
 }
 
 impl fmt::Display for BugVariant {
@@ -344,13 +343,6 @@ impl fmt::Display for BugVariant {
                 r#"The global gas cannot ever be less than the context gas. 
 
                 This means the registers are corrupted."#
-            ),
-
-            Self::InvalidMemoryConstraint => write!(
-                f,
-                r#"The memory constraint cannot exceed the memory size.
-
-                This is a bug in the vm."#
             ),
         }
     }

--- a/fuel-vm/src/interpreter/balances.rs
+++ b/fuel-vm/src/interpreter/balances.rs
@@ -97,7 +97,7 @@ impl RuntimeBalances {
         let offset = balance.offset();
 
         let offset = offset + AssetId::LEN;
-        let range = MemoryRange::new_const::<_, WORD_SIZE>(offset as Word)?;
+        let range = MemoryRange::new_const::<_, WORD_SIZE>(offset)?;
 
         range.write(memory).copy_from_slice(&value.to_be_bytes());
 

--- a/fuel-vm/src/interpreter/balances.rs
+++ b/fuel-vm/src/interpreter/balances.rs
@@ -1,4 +1,3 @@
-use crate::constraints::CheckedMemRange;
 use crate::consts::*;
 use crate::interpreter::{ExecutableTransaction, InitialBalances, Interpreter};
 use crate::prelude::RuntimeError;
@@ -10,6 +9,8 @@ use itertools::Itertools;
 
 use std::collections::{BTreeMap, HashMap};
 use std::ops::Index;
+
+use super::MemoryRange;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct Balance {
@@ -96,7 +97,7 @@ impl RuntimeBalances {
         let offset = balance.offset();
 
         let offset = offset + AssetId::LEN;
-        let range = CheckedMemRange::new_const::<WORD_SIZE>(offset as Word)?;
+        let range = MemoryRange::new_const::<_, WORD_SIZE>(offset as Word)?;
 
         range.write(memory).copy_from_slice(&value.to_be_bytes());
 

--- a/fuel-vm/src/interpreter/blockchain.rs
+++ b/fuel-vm/src/interpreter/blockchain.rs
@@ -8,7 +8,7 @@ use super::memory::{try_mem_write, try_zeroize, OwnershipRegisters};
 use super::{ExecutableTransaction, Interpreter, MemoryRange, RuntimeBalances};
 use crate::arith::{add_usize, checked_add_usize, checked_add_word, checked_sub_word};
 use crate::call::CallFrame;
-use crate::constraints::{reg_key::*, CheckedMemConstLen, CheckedMemRange, CheckedMemValue};
+use crate::constraints::{reg_key::*, CheckedMemConstLen, CheckedMemValue};
 use crate::context::Context;
 use crate::error::{Bug, BugId, BugVariant, RuntimeError};
 use crate::gas::DependentCost;
@@ -713,7 +713,7 @@ where
             return Err(RuntimeError::Recoverable(PanicReason::MessageDataTooLong));
         }
 
-        let msg_data_range = CheckedMemRange::new(self.msg_data_ptr, self.msg_data_len as usize)?;
+        let msg_data_range = MemoryRange::new(self.msg_data_ptr, self.msg_data_len as usize)?;
 
         let recipient = recipient_address.try_from(self.memory)?;
 
@@ -779,7 +779,7 @@ impl StateReadQWord {
         let mem_range = MemoryRange::new(
             destination_memory_address,
             (Bytes32::LEN as Word).saturating_mul(num_slots),
-        );
+        )?;
         if !ownership_registers.has_ownership_range(&mem_range) {
             return Err(PanicReason::MemoryOwnership.into());
         }

--- a/fuel-vm/src/interpreter/blockchain.rs
+++ b/fuel-vm/src/interpreter/blockchain.rs
@@ -713,7 +713,7 @@ where
             return Err(RuntimeError::Recoverable(PanicReason::MessageDataTooLong));
         }
 
-        let msg_data_range = MemoryRange::new(self.msg_data_ptr, self.msg_data_len as usize)?;
+        let msg_data_range = MemoryRange::new(self.msg_data_ptr, self.msg_data_len)?;
 
         let recipient = recipient_address.try_from(self.memory)?;
 

--- a/fuel-vm/src/interpreter/contract.rs
+++ b/fuel-vm/src/interpreter/contract.rs
@@ -104,10 +104,8 @@ impl<'vm, S, I> ContractBalanceCtx<'vm, S, I> {
         S: ContractsAssetsStorage,
         <S as StorageInspect<ContractsAssets>>::Error: Into<std::io::Error>,
     {
-        //if above usize::MAX then it cannot be safely cast to usize,
-        // check the tighter bound between VM_MAX_RAM and usize::MAX
-        let asset_id = CheckedMemConstLen::<{ AssetId::LEN }>::new_with_constraint(b, 0..MIN_VM_MAX_RAM_USIZE_MAX)?;
-        let contract = CheckedMemConstLen::<{ ContractId::LEN }>::new_with_constraint(c, 0..MIN_VM_MAX_RAM_USIZE_MAX)?;
+        let asset_id = CheckedMemConstLen::<{ AssetId::LEN }>::new(b)?;
+        let contract = CheckedMemConstLen::<{ ContractId::LEN }>::new(c)?;
 
         let asset_id = AssetId::from_bytes_ref(asset_id.read(self.memory));
         let contract = ContractId::from_bytes_ref(contract.read(self.memory));

--- a/fuel-vm/src/interpreter/executors/predicate.rs
+++ b/fuel-vm/src/interpreter/executors/predicate.rs
@@ -10,17 +10,18 @@ where
     Tx: ExecutableTransaction,
 {
     pub(crate) fn verify_predicate(&mut self) -> Result<ProgramState, InterpreterError> {
-        let (start, end) = self
+        let range = self
             .context
             .predicate()
-            .map(|p| p.program().boundaries(&self.ownership_registers()))
-            .ok_or(InterpreterError::PredicateFailure)?;
+            .ok_or(InterpreterError::PredicateFailure)?
+            .program()
+            .words();
 
-        self.registers[RegId::PC] = start;
-        self.registers[RegId::IS] = start;
+        self.registers[RegId::PC] = range.start;
+        self.registers[RegId::IS] = range.start;
 
         loop {
-            if end <= self.registers[RegId::PC] {
+            if range.end <= self.registers[RegId::PC] {
                 return Err(InterpreterError::Panic(PanicReason::MemoryOverflow));
             }
 

--- a/fuel-vm/src/interpreter/flow.rs
+++ b/fuel-vm/src/interpreter/flow.rs
@@ -4,7 +4,7 @@ use super::internal::{
     append_receipt, current_contract, external_asset_id_balance_sub, inc_pc, internal_contract_or_default,
     set_frame_pointer, AppendReceipt,
 };
-use super::{ExecutableTransaction, Interpreter, RuntimeBalances};
+use super::{ExecutableTransaction, Interpreter, MemoryRange, RuntimeBalances};
 use crate::arith;
 use crate::call::{Call, CallFrame};
 use crate::constraints::reg_key::*;
@@ -491,7 +491,7 @@ impl<'vm, S> PrepareCallCtx<'vm, S> {
         *self.registers.system_registers.sp = arith::checked_add_word(*self.registers.system_registers.sp, len)?;
         *self.registers.system_registers.ssp = *self.registers.system_registers.sp;
 
-        let code_frame_mem_range = CheckedMemRange::new(*self.registers.system_registers.fp, len as usize)?;
+        let code_frame_mem_range = MemoryRange::new(*self.registers.system_registers.fp, len as usize)?;
         let frame_end = write_call_to_memory(
             &frame,
             frame_bytes,
@@ -535,7 +535,7 @@ impl<'vm, S> PrepareCallCtx<'vm, S> {
 fn write_call_to_memory<S>(
     frame: &CallFrame,
     frame_bytes: Vec<u8>,
-    code_mem_range: CheckedMemRange,
+    code_mem_range: MemoryRange,
     memory: &mut [u8; MEM_SIZE],
     storage: &S,
 ) -> Result<Word, RuntimeError>
@@ -565,7 +565,7 @@ where
         padding_range.grow_start(CallFrame::serialized_size() + frame.code_size() as usize);
         padding_range.write(memory).fill(0);
     }
-    Ok(code_frame_range.end() as Word)
+    Ok(code_frame_range.end as Word)
 }
 
 fn call_frame<S>(

--- a/fuel-vm/src/interpreter/flow.rs
+++ b/fuel-vm/src/interpreter/flow.rs
@@ -491,7 +491,7 @@ impl<'vm, S> PrepareCallCtx<'vm, S> {
         *self.registers.system_registers.sp = arith::checked_add_word(*self.registers.system_registers.sp, len)?;
         *self.registers.system_registers.ssp = *self.registers.system_registers.sp;
 
-        let code_frame_mem_range = MemoryRange::new(*self.registers.system_registers.fp, len as usize)?;
+        let code_frame_mem_range = MemoryRange::new(*self.registers.system_registers.fp, len)?;
         let frame_end = write_call_to_memory(
             &frame,
             frame_bytes,

--- a/fuel-vm/src/interpreter/flow/tests.rs
+++ b/fuel-vm/src/interpreter/flow/tests.rs
@@ -394,10 +394,10 @@ fn check_output(expected: Result<Output, RuntimeError>) -> impl FnOnce(Result<Ou
         4,
         5,
     ),
-    CheckedMemRange::new(0, 640).unwrap()
+    MemoryRange::new(0, 640).unwrap()
     => Ok(600); "call"
 )]
-fn test_write_call_to_memory(mut call_frame: CallFrame, code_mem_range: CheckedMemRange) -> Result<Word, RuntimeError> {
+fn test_write_call_to_memory(mut call_frame: CallFrame, code_mem_range: MemoryRange) -> Result<Word, RuntimeError> {
     let frame_bytes = call_frame.to_bytes();
     let mut storage = MemoryStorage::new(Default::default(), Default::default());
     let code = vec![6u8; call_frame.code_size() as usize];

--- a/fuel-vm/src/interpreter/internal.rs
+++ b/fuel-vm/src/interpreter/internal.rs
@@ -66,7 +66,7 @@ pub(crate) fn absolute_output_mem_range<Tx: Outputs>(
     absolute_output_offset(tx, tx_offset, idx)
         .and_then(|offset| tx.outputs().get(idx).map(|output| (offset, output.serialized_size())))
         .map_or(Ok(None), |(offset, output_size)| {
-            Ok(Some(MemoryRange::new(offset as u64, output_size)?))
+            Ok(Some(MemoryRange::new(offset, output_size)?))
         })
 }
 

--- a/fuel-vm/src/interpreter/memory.rs
+++ b/fuel-vm/src/interpreter/memory.rs
@@ -43,6 +43,7 @@ impl ToAddr for Word {
     }
 }
 
+#[cfg(feature = "test-helpers")]
 /// Implemented for `i32` to allow integer literals. Panics on negative values.
 impl ToAddr for i32 {
     fn to_addr(self) -> Result<usize, RuntimeError> {

--- a/fuel-vm/src/interpreter/memory.rs
+++ b/fuel-vm/src/interpreter/memory.rs
@@ -17,186 +17,132 @@ mod tests;
 
 #[cfg(test)]
 mod allocation_tests;
-#[allow(clippy::derive_hash_xor_eq)]
-#[derive(Debug, Clone, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// Memory range representation for the VM.
-///
-/// `start` is inclusive, and `end` is exclusive.
-pub struct MemoryRange {
-    start: ops::Bound<Word>,
-    end: ops::Bound<Word>,
-    len: Word,
+
+/// Used to handle `Word` to `usize` conversions for memory addresses,
+/// as well as checking that the resulting value is withing the VM ram boundaries.
+pub trait ToAddr {
+    /// Converts a value to `usize` used for memory addresses.
+    /// Returns `Err` with `MemoryOverflow` if the resulting value does't fit in the VM memory.
+    /// This can be used for both addresses and offsets.
+    fn to_addr(self) -> Result<usize, RuntimeError>;
 }
+
+impl ToAddr for usize {
+    fn to_addr(self) -> Result<usize, RuntimeError> {
+        if self >= MEM_SIZE {
+            return Err(PanicReason::MemoryOverflow.into());
+        }
+        Ok(self)
+    }
+}
+
+impl ToAddr for Word {
+    fn to_addr(self) -> Result<usize, RuntimeError> {
+        let value = usize::try_from(self).map_err(|_| PanicReason::MemoryOverflow)?;
+        value.to_addr()
+    }
+}
+
+/// Implemented for `i32` to allow integer literals. Panics on negative values.
+impl ToAddr for i32 {
+    fn to_addr(self) -> Result<usize, RuntimeError> {
+        if self < 0 {
+            panic!("Negative memory address");
+        }
+        let value = usize::try_from(self).map_err(|_| PanicReason::MemoryOverflow)?;
+        value.to_addr()
+    }
+}
+
+/// Memory range representation for the VM, checked to be in-bounds on construction.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct MemoryRange(ops::Range<usize>);
 
 impl Default for MemoryRange {
     fn default() -> Self {
-        Self {
-            start: ops::Bound::Included(0),
-            end: ops::Bound::Excluded(0),
-            len: 0,
-        }
+        Self(0..0)
+    }
+}
+
+impl ops::Deref for MemoryRange {
+    type Target = ops::Range<usize>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
 impl MemoryRange {
     /// Create a new memory range represented as `[address, address + size[`.
-    pub const fn new(address: Word, size: Word) -> Self {
-        let start = ops::Bound::Included(address);
-        let end = ops::Bound::Excluded(address.saturating_add(size));
-        let len = size;
+    pub fn new<A: ToAddr, B: ToAddr>(address: A, size: B) -> Result<Self, RuntimeError> {
+        let start = address.to_addr()?;
+        let size = size.to_addr()?;
+        let end = start.checked_add(size).ok_or(PanicReason::MemoryOverflow)?;
 
-        Self { start, end, len }
-    }
-
-    /// Beginning of the memory range.
-    pub const fn start(&self) -> Word {
-        use ops::Bound::*;
-
-        match self.start {
-            Included(start) => start,
-            Excluded(start) => start.saturating_add(1),
-            Unbounded => 0,
+        if end > MEM_SIZE {
+            return Err(PanicReason::MemoryOverflow.into());
         }
+
+        Ok(Self(start..end))
     }
 
-    /// End of the memory range.
-    pub const fn end(&self) -> Word {
-        use ops::Bound::*;
-
-        match self.end {
-            Included(end) => end.saturating_add(1),
-            Excluded(end) => end,
-            Unbounded => VM_MAX_RAM,
-        }
-    }
-
-    /// Bytes count of this memory range.
-    pub const fn len(&self) -> Word {
-        self.len
+    /// Create a new const sized memory range.
+    pub fn new_const<A: ToAddr, const SIZE: usize>(address: A) -> Result<Self, RuntimeError> {
+        Self::new(address, SIZE)
     }
 
     /// Return `true` if the length is `0`.
-    pub const fn is_empty(&self) -> bool {
-        self.len == 0
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
-    /// Return the boundaries of the slice with exclusive end `[a, b[`
-    ///
-    /// Remap the unbound boundaries to stack or heap when applicable.
-    pub fn boundaries(&self, registers: &OwnershipRegisters) -> (Word, Word) {
-        use ops::Bound::*;
+    /// Convert to a raw `usize` range.
+    pub fn usizes(&self) -> ops::Range<usize> {
+        self.start..self.end
+    }
 
-        let stack = registers.sp;
-        let heap = registers.hp.saturating_add(1);
-        match (self.start, self.end) {
-            (Included(start), Included(end)) => (start, end.saturating_add(1)),
-            (Included(start), Excluded(end)) => (start, end),
-            (Excluded(start), Included(end)) => (start.saturating_add(1), end.saturating_add(1)),
-            (Excluded(start), Excluded(end)) => (start.saturating_add(1), end),
-            (Unbounded, Unbounded) => (0, VM_MAX_RAM),
-
-            (Included(start), Unbounded) if is_stack_address(&registers.sp, start) => (start, stack),
-            (Included(start), Unbounded) => (start, VM_MAX_RAM),
-
-            (Excluded(start), Unbounded) if is_stack_address(&registers.sp, start) => (start.saturating_add(1), stack),
-            (Excluded(start), Unbounded) => (start.saturating_add(1), VM_MAX_RAM),
-
-            (Unbounded, Included(end)) if is_stack_address(&registers.sp, end) => (0, end.saturating_add(1)),
-            (Unbounded, Included(end)) => (heap, end),
-
-            (Unbounded, Excluded(end)) if is_stack_address(&registers.sp, end) => (0, end),
-            (Unbounded, Excluded(end)) => (heap, end),
-        }
+    /// Convert to a raw `Word` range.
+    pub fn words(&self) -> ops::Range<Word> {
+        self.start as Word..self.end as Word
     }
 
     /// Return an owned memory slice with a relative address to the heap space
-    /// defined in `r[$hp]`
-    pub fn to_heap<S, Tx>(mut self, vm: &Interpreter<S, Tx>) -> Self
+    /// defined in `r[$hp]`. Panics if the range is not within the heap space.
+    #[cfg(test)]
+    pub fn to_heap<S, Tx>(self, vm: &Interpreter<S, Tx>) -> Self
     where
         Tx: ExecutableTransaction,
     {
-        use ops::Bound::*;
-
-        let heap = vm.registers()[RegId::HP];
-
-        self.start = match self.start {
-            Included(start) => Included(heap.saturating_add(start)),
-            Excluded(start) => Included(heap.saturating_add(start).saturating_add(1)),
-            Unbounded => Included(heap),
-        };
-
-        self.end = match self.end {
-            Included(end) => Excluded(heap.saturating_add(end).saturating_add(1)),
-            Excluded(end) => Excluded(heap.saturating_add(end)),
-            Unbounded => Excluded(VM_MAX_RAM),
-        };
-
-        let (start, end) = self.boundaries(&OwnershipRegisters::new(vm));
-        self.len = end.saturating_sub(start);
-
-        self
+        let hp = vm.registers()[RegId::HP] as usize;
+        let start = self.start.checked_add(hp).expect("Overflow");
+        let end = self.end.checked_add(hp).expect("Overflow");
+        if end > MEM_SIZE {
+            panic!("Invalid heap range");
+        }
+        Self(start..end)
     }
-}
 
-impl<R> From<R> for MemoryRange
-where
-    R: ops::RangeBounds<Word>,
-{
-    fn from(range: R) -> MemoryRange {
-        use ops::Bound::*;
-        // Owned bounds are unstable
-        // https://github.com/rust-lang/rust/issues/61356
-
-        let (start, s) = match range.start_bound() {
-            Included(start) => (Included(*start), *start),
-            Excluded(start) => (Included(start.saturating_add(1)), start.saturating_add(1)),
-            Unbounded => (Unbounded, 0),
-        };
-
-        let (end, e) = match range.end_bound() {
-            Included(end) => (Excluded(end.saturating_add(1)), end.saturating_add(1)),
-            Excluded(end) => (Excluded(*end), *end),
-            Unbounded => (Unbounded, VM_MAX_RAM),
-        };
-
-        let len = e.saturating_sub(s);
-
-        Self { start, end, len }
+    /// This function is safe because it is only used to shrink the range
+    /// and worst case the range will be empty.
+    pub fn shrink_end(&mut self, by: usize) {
+        self.0 = self.0.start..self.0.end.saturating_sub(by);
     }
-}
 
-// Memory bounds must be manually checked and cannot follow general PartialEq
-// rules
-impl PartialEq for MemoryRange {
-    fn eq(&self, other: &MemoryRange) -> bool {
-        use ops::Bound::*;
+    /// This function is safe because it is only used to grow the range
+    /// and worst case the range will be empty.
+    pub fn grow_start(&mut self, by: usize) {
+        self.0 = self.0.start.saturating_add(by)..self.0.end;
+    }
 
-        let start = match (self.start, other.start) {
-            (Included(a), Included(b)) => a == b,
-            (Included(a), Excluded(b)) => a == b.saturating_add(1),
-            (Included(a), Unbounded) => a == 0,
-            (Excluded(a), Included(b)) => a.saturating_add(1) == b,
-            (Excluded(a), Excluded(b)) => a == b,
-            (Excluded(a), Unbounded) => a == 0,
-            (Unbounded, Included(b)) => b == 0,
-            (Unbounded, Excluded(b)) => b == 0,
-            (Unbounded, Unbounded) => true,
-        };
+    /// Get the memory slice for this range.
+    pub fn read(self, memory: &[u8; MEM_SIZE]) -> &[u8] {
+        &memory[self.0]
+    }
 
-        let end = match (self.end, other.end) {
-            (Included(a), Included(b)) => a == b,
-            (Included(a), Excluded(b)) => a == b.saturating_sub(1),
-            (Included(a), Unbounded) => a == VM_MAX_RAM - 1,
-            (Excluded(a), Included(b)) => a.saturating_sub(1) == b,
-            (Excluded(a), Excluded(b)) => a == b,
-            (Excluded(a), Unbounded) => a == VM_MAX_RAM,
-            (Unbounded, Included(b)) => b == VM_MAX_RAM - 1,
-            (Unbounded, Excluded(b)) => b == VM_MAX_RAM,
-            (Unbounded, Unbounded) => true,
-        };
-
-        start && end
+    /// Get the mutable memory slice for this range.
+    pub fn write(self, memory: &mut [u8; MEM_SIZE]) -> &mut [u8] {
+        &mut memory[self.0]
     }
 }
 
@@ -366,17 +312,11 @@ pub(crate) fn memclear(
     a: Word,
     b: Word,
 ) -> Result<(), RuntimeError> {
-    let (ab, overflow) = a.overflowing_add(b);
-
-    let range = MemoryRange::new(a, b);
-    if overflow || ab > VM_MAX_RAM || b > MEM_MAX_ACCESS_SIZE || !owner.has_ownership_range(&range) {
+    let range = MemoryRange::new(a, b)?;
+    if b > MEM_MAX_ACCESS_SIZE || !owner.has_ownership_range(&range) {
         Err(PanicReason::MemoryOverflow.into())
     } else {
-        // trivial compiler optimization for memset
-        for i in &mut memory[a as usize..ab as usize] {
-            *i = 0
-        }
-
+        memory[range.usizes()].fill(0);
         inc_pc(pc)
     }
 }
@@ -389,33 +329,35 @@ pub(crate) fn memcopy(
     b: Word,
     c: Word,
 ) -> Result<(), RuntimeError> {
-    let (ac, overflow) = a.overflowing_add(c);
-    let (bc, of) = b.overflowing_add(c);
-    let overflow = overflow || of;
+    let dst_range = MemoryRange::new(a, c)?;
+    let src_range = MemoryRange::new(b, c)?;
 
-    let range = MemoryRange::new(a, c);
-    if overflow
-        || ac > VM_MAX_RAM
-        || bc > VM_MAX_RAM
-        || c > MEM_MAX_ACCESS_SIZE
-        || a <= b && b < ac
-        || b <= a && a < bc
-        || a < bc && bc <= ac
-        || b < ac && ac <= bc
-        || !owner.has_ownership_range(&range)
-    {
-        Err(PanicReason::MemoryOverflow.into())
-    } else {
-        if a <= b {
-            let (dst, src) = memory.split_at_mut(b as usize);
-            dst[a as usize..ac as usize].copy_from_slice(&src[..c as usize]);
-        } else {
-            let (src, dst) = memory.split_at_mut(a as usize);
-            dst[..c as usize].copy_from_slice(&src[b as usize..bc as usize]);
-        }
-
-        inc_pc(pc)
+    if c > MEM_MAX_ACCESS_SIZE {
+        return Err(PanicReason::MemoryOverflow.into());
     }
+
+    if !owner.has_ownership_range(&dst_range) {
+        return Err(PanicReason::MemoryOwnership.into());
+    }
+
+    if dst_range.start <= src_range.start && src_range.start < dst_range.end
+        || src_range.start <= dst_range.start && dst_range.start < src_range.end
+        || dst_range.start < src_range.end && src_range.end <= dst_range.end
+        || src_range.start < dst_range.end && dst_range.end <= src_range.end
+    {
+        return Err(PanicReason::MemoryWriteOverlap.into());
+    }
+
+    let len = src_range.len();
+    if a <= b {
+        let (dst, src) = memory.split_at_mut(src_range.start);
+        dst[dst_range.usizes()].copy_from_slice(&src[..len]);
+    } else {
+        let (src, dst) = memory.split_at_mut(dst_range.start);
+        dst[..len].copy_from_slice(&src[src_range.usizes()]);
+    }
+
+    inc_pc(pc)
 }
 
 pub(crate) fn memeq(
@@ -439,10 +381,7 @@ pub(crate) fn memeq(
     }
 }
 
-pub(crate) const fn is_stack_address(sp: &u64, a: Word) -> bool {
-    a < *sp
-}
-
+#[derive(Debug)]
 pub struct OwnershipRegisters {
     pub(crate) sp: u64,
     pub(crate) ssp: u64,
@@ -462,8 +401,7 @@ impl OwnershipRegisters {
         }
     }
     pub(crate) fn has_ownership_range(&self, range: &MemoryRange) -> bool {
-        let (start_incl, end_excl) = range.boundaries(self);
-        let range = start_incl..end_excl;
+        let range = range.words();
         self.has_ownership_stack(&range) || self.has_ownership_heap(&range)
     }
 
@@ -511,20 +449,14 @@ pub(crate) fn try_mem_write(
     registers: OwnershipRegisters,
     memory: &mut [u8; MEM_SIZE],
 ) -> Result<(), RuntimeError> {
-    let ax = addr.checked_add(data.len()).ok_or(PanicReason::ArithmeticOverflow)?;
+    let range = MemoryRange::new(addr, data.len())?;
 
-    let range = (ax <= VM_MAX_RAM as usize)
-        .then(|| MemoryRange::new(addr as Word, data.len() as Word))
-        .ok_or(PanicReason::MemoryOverflow)?;
+    if !registers.has_ownership_range(&range) {
+        return Err(PanicReason::MemoryOwnership.into());
+    }
 
-    registers
-        .has_ownership_range(&range)
-        .then(|| {
-            memory.get_mut(addr..ax)?.copy_from_slice(data);
-            Some(())
-        })
-        .flatten()
-        .ok_or_else(|| PanicReason::MemoryOwnership.into())
+    memory[range.usizes()].copy_from_slice(data);
+    Ok(())
 }
 
 pub(crate) fn try_zeroize(
@@ -533,18 +465,14 @@ pub(crate) fn try_zeroize(
     registers: OwnershipRegisters,
     memory: &mut [u8; MEM_SIZE],
 ) -> Result<(), RuntimeError> {
-    let ax = addr.checked_add(len).ok_or(PanicReason::ArithmeticOverflow)?;
+    let range = MemoryRange::new(addr, len)?;
 
-    let range = (ax <= VM_MAX_RAM as usize)
-        .then(|| MemoryRange::new(addr as Word, len as Word))
-        .ok_or(PanicReason::MemoryOverflow)?;
+    if !registers.has_ownership_range(&range) {
+        return Err(PanicReason::MemoryOwnership.into());
+    }
 
-    registers
-        .has_ownership_range(&range)
-        .then(|| {
-            memory[addr..].iter_mut().take(len).for_each(|m| *m = 0);
-        })
-        .ok_or_else(|| PanicReason::MemoryOwnership.into())
+    memory[range.usizes()].fill(0);
+    Ok(())
 }
 
 /// Reads a constant-sized byte array from memory, performing overflow and memory range checks.
@@ -566,14 +494,11 @@ pub(crate) fn write_bytes<const COUNT: usize>(
     addr: Word,
     bytes: [u8; COUNT],
 ) -> Result<(), RuntimeError> {
-    let range = MemoryRange::new(addr, COUNT as Word);
-    let addr = addr as usize;
-    let (end, overflow) = addr.overflowing_add(COUNT);
-
-    if overflow || (end as Word) > VM_MAX_RAM || !owner.has_ownership_range(&range) {
+    let range = MemoryRange::new_const::<_, COUNT>(addr)?;
+    if !owner.has_ownership_range(&range) {
         return Err(PanicReason::MemoryOverflow.into());
     }
 
-    memory[addr..end].copy_from_slice(&bytes);
+    memory[range.usizes()].copy_from_slice(&bytes);
     Ok(())
 }

--- a/fuel-vm/src/interpreter/memory/allocation_tests.rs
+++ b/fuel-vm/src/interpreter/memory/allocation_tests.rs
@@ -53,10 +53,10 @@ fn test_memclear(has_ownership: bool, a: Word, b: Word) -> Result<(), RuntimeErr
 #[test_case(true, 1, 20, 0 => Ok(()); "Can copy zero bytes")]
 #[test_case(true, 1, 20, 10 => Ok(()); "Can copy some bytes")]
 #[test_case(true, 10, 20, 10 => Ok(()); "Can copy some bytes in close range")]
-#[test_case(true, 21, 20, 10 => Err(PanicReason::MemoryOverflow.into()); "b <= a < bc")]
-#[test_case(true, 14, 20, 10 => Err(PanicReason::MemoryOverflow.into()); "b < ac <= bc")]
-#[test_case(true, 21, 22, 10 => Err(PanicReason::MemoryOverflow.into()); "a <= b < ac")]
-#[test_case(true, 21, 20, 10 => Err(PanicReason::MemoryOverflow.into()); "a < bc <= ac")]
+#[test_case(true, 21, 20, 10 => Err(PanicReason::MemoryWriteOverlap.into()); "b <= a < bc")]
+#[test_case(true, 14, 20, 10 => Err(PanicReason::MemoryWriteOverlap.into()); "b < ac <= bc")]
+#[test_case(true, 21, 22, 10 => Err(PanicReason::MemoryWriteOverlap.into()); "a <= b < ac")]
+#[test_case(true, 21, 20, 10 => Err(PanicReason::MemoryWriteOverlap.into()); "a < bc <= ac")]
 fn test_memcopy(has_ownership: bool, a: Word, b: Word, c: Word) -> Result<(), RuntimeError> {
     let mut memory: Memory<MEM_SIZE> = vec![1u8; MEM_SIZE].try_into().unwrap();
     memory[b as usize..b as usize + c as usize].copy_from_slice(&vec![2u8; c as usize]);

--- a/fuel-vm/src/tests/blockchain.rs
+++ b/fuel-vm/src/tests/blockchain.rs
@@ -13,7 +13,7 @@ use crate::script_with_data_offset;
 use fuel_asm::PanicReason::ErrorFlag;
 use fuel_asm::{
     op, Instruction,
-    PanicReason::{ArithmeticOverflow, ContractNotInInputs, ExpectedUnallocatedStack, MemoryOverflow, MemoryOwnership},
+    PanicReason::{ArithmeticOverflow, ContractNotInInputs, ExpectedUnallocatedStack, MemoryOverflow},
 };
 use fuel_tx::field::Script as ScriptField;
 use fuel_vm::util::test_helpers::check_expected_reason_for_instructions;
@@ -958,7 +958,7 @@ fn state_r_qword_a_plus_32_over() {
         op::srwq(reg_a, SET_STATUS_REG, RegId::ZERO, RegId::ONE),
     ];
 
-    check_expected_reason_for_instructions(state_read_qword, MemoryOwnership);
+    check_expected_reason_for_instructions(state_read_qword, MemoryOverflow);
 }
 
 #[test]
@@ -993,7 +993,7 @@ fn state_r_qword_a_over_max_ram() {
         op::srwq(reg_a, SET_STATUS_REG, RegId::ZERO, RegId::ONE),
     ];
 
-    check_expected_reason_for_instructions(state_read_qword, MemoryOwnership);
+    check_expected_reason_for_instructions(state_read_qword, MemoryOverflow);
 }
 
 #[test]


### PR DESCRIPTION
Removed `CheckedMemRange` and uses `MemoryRange` instead. `MemoryRange` is now always checked, validates and type-converts it's arguments safely.

This is a minimal set of changes required for merging the types. The improvements around memory handling will be used for follow-up PRs which will clean up the memory handling code even more.

Works towards https://github.com/FuelLabs/fuel-vm/issues/474. Partially extracted from https://github.com/FuelLabs/fuel-vm/pull/461.