### PR TITLE
Return the previous behavior of the data length GTF

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,13 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.31.1"
+version = "0.31.2"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.31.1", path = "./fuel-asm", default-features = false }
-fuel-crypto = { version = "0.31.1", path = "./fuel-crypto", default-features = false }
-fuel-merkle = { version = "0.31.1", path = "./fuel-merkle", default-features = false }
-fuel-storage = { version = "0.31.1", path = "./fuel-storage", default-features = false }
-fuel-tx = { version = "0.31.1", path = "./fuel-tx", default-features = false }
-fuel-types = { version = "0.31.1", path = "./fuel-types", default-features = false }
+fuel-asm = { version = "0.31.2", path = "./fuel-asm", default-features = false }
+fuel-crypto = { version = "0.31.2", path = "./fuel-crypto", default-features = false }
+fuel-merkle = { version = "0.31.2", path = "./fuel-merkle", default-features = false }
+fuel-storage = { version = "0.31.2", path = "./fuel-storage", default-features = false }
+fuel-tx = { version = "0.31.2", path = "./fuel-tx", default-features = false }
+fuel-types = { version = "0.31.2", path = "./fuel-types", default-features = false }
 bincode = { version = "1.3", default-features = false }

--- a/fuel-tx/src/transaction/types/input.rs
+++ b/fuel-tx/src/transaction/types/input.rs
@@ -439,6 +439,15 @@ impl Input {
         }
     }
 
+    pub fn input_data_len(&self) -> Option<usize> {
+        match self {
+            Input::MessageDataSigned(MessageDataSigned { data, .. })
+            | Input::MessageDataPredicate(MessageDataPredicate { data, .. }) => Some(data.len()),
+            Input::MessageCoinSigned(_) | Input::MessageCoinPredicate(_) => Some(0),
+            _ => None,
+        }
+    }
+
     pub fn input_predicate(&self) -> Option<&[u8]> {
         match self {
             Input::CoinPredicate(CoinPredicate { predicate, .. })

--- a/fuel-vm/src/interpreter/metadata.rs
+++ b/fuel-vm/src/interpreter/metadata.rs
@@ -331,9 +331,8 @@ impl<Tx> GTFInput<'_, Tx> {
                 .inputs()
                 .get(b)
                 .filter(|i| i.is_message())
-                .and_then(Input::input_data)
-                .map(|d| d.len() as Word)
-                .ok_or(PanicReason::InputNotFound)?,
+                .and_then(Input::input_data_len)
+                .ok_or(PanicReason::InputNotFound)? as Word,
             GTFArgs::InputMessagePredicateLength => tx
                 .inputs()
                 .get(b)


### PR DESCRIPTION
After https://github.com/FuelLabs/fuel-vm/pull/373 the GTF for data length is not working for `MessageCoinSigned` and `MessageCoinPredicate`