### PR TITLE
Return the previous behavior of the data length GTF

### DIFF
--- a/fuel-tx/src/transaction/types/input.rs
+++ b/fuel-tx/src/transaction/types/input.rs
@@ -476,6 +476,15 @@ impl Input {
         }
     }
 
+    pub fn input_data_len(&self) -> Option<usize> {
+        match self {
+            Input::MessageDataSigned(MessageDataSigned { data, .. })
+            | Input::MessageDataPredicate(MessageDataPredicate { data, .. }) => Some(data.len()),
+            Input::MessageCoinSigned(_) | Input::MessageCoinPredicate(_) => Some(0),
+            _ => None,
+        }
+    }
+
     pub fn input_predicate(&self) -> Option<&[u8]> {
         match self {
             Input::CoinPredicate(CoinPredicate { predicate, .. })

--- a/fuel-vm/src/interpreter/metadata.rs
+++ b/fuel-vm/src/interpreter/metadata.rs
@@ -337,9 +337,8 @@ impl<Tx> GTFInput<'_, Tx> {
                 .inputs()
                 .get(b)
                 .filter(|i| i.is_message())
-                .and_then(Input::input_data)
-                .map(|d| d.len() as Word)
-                .ok_or(PanicReason::InputNotFound)?,
+                .and_then(Input::input_data_len)
+                .ok_or(PanicReason::InputNotFound)? as Word,
             GTFArgs::InputMessagePredicateLength => tx
                 .inputs()
                 .get(b)


### PR DESCRIPTION
This PR mirrors the [patch](https://github.com/FuelLabs/fuel-vm/pull/479) for the `0.31.2` to the `master`