### PR TITLE
dev-deps on local crate must use path

### DIFF
--- a/fuel-asm/Cargo.toml
+++ b/fuel-asm/Cargo.toml
@@ -19,7 +19,7 @@ strum = { version = "0.24", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 bincode = { workspace = true }
-fuel-asm = { workspace = true, features = ["serde"] }
+fuel-asm = { path = ".", features = ["serde"] }
 rstest = "0.16"
 
 [features]

--- a/fuel-crypto/Cargo.toml
+++ b/fuel-crypto/Cargo.toml
@@ -25,7 +25,7 @@ zeroize = { version = "1.5", features = ["derive"] }
 [dev-dependencies]
 bincode = { workspace = true }
 criterion = "0.4"
-fuel-crypto = { workspace = true, default-features = false, features = ["random"] }
+fuel-crypto = { path = ".", default-features = false, features = ["random"] }
 k256 = { version = "0.11", features = [ "ecdsa" ] }
 sha2 = "0.10"
 

--- a/fuel-tx/Cargo.toml
+++ b/fuel-tx/Cargo.toml
@@ -27,7 +27,7 @@ strum_macros = "0.24"
 [dev-dependencies]
 bincode = { workspace = true }
 fuel-crypto = { workspace = true, default-features = false, features = ["random"] }
-fuel-tx = { workspace = true, features = ["builder", "random"] }
+fuel-tx = { path = ".", features = ["builder", "random"] }
 fuel-tx-test-helpers = { path = "test-helpers" }
 fuel-types = { workspace = true, default-features = false, features = ["random"] }
 hex = { version = "0.4" }

--- a/fuel-types/Cargo.toml
+++ b/fuel-types/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0", default-features = false, features = ["derive", "allo
 [dev-dependencies]
 bincode = { workspace = true }
 criterion = "0.4"
-fuel-types = { workspace = true, features = ["random", "serde"] }
+fuel-types = { path = ".", features = ["random", "serde"] }
 postcard = { version = "1.0", features = ["use-std"] }
 rand = { version = "0.8", default-features = false, features = ["std_rng"] }
 serde_json = "1.0"

--- a/fuel-vm/Cargo.toml
+++ b/fuel-vm/Cargo.toml
@@ -35,7 +35,7 @@ thiserror = "1.0"
 
 [dev-dependencies]
 fuel-tx = { workspace = true, features = ["builder"] }
-fuel-vm = { workspace = true, default-features = false, features = ["test-helpers", "serde", "profile-coverage", "profile-gas"] }
+fuel-vm = { path = ".", default-features = false, features = ["test-helpers", "serde", "profile-coverage", "profile-gas"] }
 num-integer = "0.1.45"
 quickcheck = "1.0"
 quickcheck_macros = "1.0"


### PR DESCRIPTION
Fixes a publish failure due to specifying the version of crates which haven't been published yet in dev-deps implicitly via `workspace = true`