### PR TITLE
chore: BMT clean up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Description of the upcoming release here.
 
+### Changed
+
+- [#492](https://github.com/FuelLabs/fuel-vm/pull/492) Minor improvements to BMT
+    internals, including a reduction in usage of `Box`, using `expect(...)` over
+    `unwrap()`, and additional comments.
+
 ## [Version 0.34.0]
 
 This release contains fixes for critical issues that we found before the audit. 

--- a/fuel-merkle/src/binary/merkle_tree.rs
+++ b/fuel-merkle/src/binary/merkle_tree.rs
@@ -343,9 +343,9 @@ where
 
     fn join_all_subtrees(&mut self) -> Result<(), StorageError> {
         while {
-            // Iterate through all subtrees in tree to see which subtrees can be
-            // merged. Two subtrees will be merged if, and only if, their heads
-            // are at the same height.
+            // Iterate through all subtrees in the tree to see which subtrees
+            // can be merged. Two consecutive subtrees will be merged if, and
+            // only if, their heads are the same height.
             if let Some((head, next)) = self
                 .head()
                 .and_then(|head| head.next().map(|next| (head, next)))

--- a/fuel-merkle/src/binary/merkle_tree.rs
+++ b/fuel-merkle/src/binary/merkle_tree.rs
@@ -353,15 +353,11 @@ where
             }
         } {
             // Merge the two front heads of the list into a single head
-            let joined_head = {
-                let mut head = self.head.take().expect("Expected head to be present");
-                let mut head_next =
-                    head.take_next().expect("Expected next to be present");
-                let joined_head = join_subtrees(&mut head_next, &mut head);
-                self.storage
-                    .insert(&joined_head.node().key(), &joined_head.node().into())?;
-                joined_head
-            };
+            let mut head = self.head.take().expect("Expected head to be present");
+            let mut head_next = head.take_next().expect("Expected next to be present");
+            let joined_head = join_subtrees(&mut head_next, &mut head);
+            self.storage
+                .insert(&joined_head.node().key(), &joined_head.node().into())?;
             self.head = Some(joined_head);
         }
 

--- a/fuel-merkle/src/binary/merkle_tree.rs
+++ b/fuel-merkle/src/binary/merkle_tree.rs
@@ -310,7 +310,7 @@ where
                 .ok_or(MerkleTreeError::LoadError(key))?
                 .into_owned()
                 .into();
-            let next = Subtree::<Node>::new(node, current_head);
+            let next = Subtree::new(node, current_head);
             current_head = Some(next);
         }
 
@@ -329,7 +329,7 @@ where
         let node = Node::create_leaf(self.leaves_count, data);
         self.storage.insert(&node.key(), &node.as_ref().into())?;
         let next = self.head.take();
-        let head = Subtree::<Node>::new(node, next);
+        let head = Subtree::new(node, next);
         self.head = Some(head);
         self.join_all_subtrees()?;
 

--- a/fuel-merkle/src/binary/merkle_tree.rs
+++ b/fuel-merkle/src/binary/merkle_tree.rs
@@ -21,10 +21,7 @@ use crate::{
     },
 };
 
-use alloc::{
-    boxed::Box,
-    vec::Vec,
-};
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 
 #[derive(Debug, Clone)]
@@ -52,7 +49,7 @@ impl<StorageError> From<StorageError> for MerkleTreeError<StorageError> {
 #[derive(Debug, Clone)]
 pub struct MerkleTree<TableType, StorageType> {
     storage: StorageType,
-    head: Option<Box<Subtree<Node>>>,
+    head: Option<Subtree<Node>>,
     leaves_count: u64,
     phantom_table: PhantomData<TableType>,
 }
@@ -71,7 +68,7 @@ impl<TableType, StorageType> MerkleTree<TableType, StorageType> {
         }
     }
 
-    fn head(&self) -> Option<&Box<Subtree<Node>>> {
+    fn head(&self) -> Option<&Subtree<Node>> {
         self.head.as_ref()
     }
 
@@ -313,7 +310,7 @@ where
                 .ok_or(MerkleTreeError::LoadError(key))?
                 .into_owned()
                 .into();
-            let next = Box::new(Subtree::<Node>::new(node, current_head));
+            let next = Subtree::<Node>::new(node, current_head);
             current_head = Some(next);
         }
 
@@ -332,7 +329,7 @@ where
         let node = Node::create_leaf(self.leaves_count, data);
         self.storage.insert(&node.key(), &node.as_ref().into())?;
         let next = self.head.take();
-        let head = Box::new(Subtree::<Node>::new(node, next));
+        let head = Subtree::<Node>::new(node, next);
         self.head = Some(head);
         self.join_all_subtrees()?;
 
@@ -365,7 +362,7 @@ where
                     .insert(&joined_head.node().key(), &joined_head.node().into())?;
                 joined_head
             };
-            self.head = Some(Box::new(joined_head));
+            self.head = Some(joined_head);
         }
 
         Ok(())

--- a/fuel-merkle/src/binary/merkle_tree.rs
+++ b/fuel-merkle/src/binary/merkle_tree.rs
@@ -379,14 +379,12 @@ where
     Table: Mappable<Key = u64, OwnedValue = Primitive, Value = Primitive>,
     Storage: StorageMutateInfallible<Table>,
 {
-    let mut current = subtree.clone();
-    while current.next().is_some() {
-        let mut head = current;
-        let mut head_next = head.take_next().unwrap();
-        current = join_subtrees(&mut head_next, &mut head);
-        storage.insert(&current.node().key(), &current.node().as_ref().into());
+    let mut head = subtree.clone();
+    while let Some(mut head_next) = head.take_next() {
+        head = join_subtrees(&mut head_next, &mut head);
+        storage.insert(&head.node().key(), &head.node().as_ref().into());
     }
-    current.node().clone()
+    head.node().clone()
 }
 
 #[cfg(test)]

--- a/fuel-merkle/src/binary/merkle_tree.rs
+++ b/fuel-merkle/src/binary/merkle_tree.rs
@@ -343,12 +343,17 @@ where
 
     fn join_all_subtrees(&mut self) -> Result<(), StorageError> {
         while {
+            // Iterate through all subtrees in tree to see which subtrees can be
+            // merged. Two subtrees will be merged if, and only if, their heads
+            // are at the same height.
             if let Some((head, next)) = self
                 .head()
                 .and_then(|head| head.next().map(|next| (head, next)))
             {
                 head.node().height() == next.node().height()
             } else {
+                // This head belongs to the last subtree and merging is
+                // complete.
                 false
             }
         } {

--- a/fuel-merkle/src/binary/node.rs
+++ b/fuel-merkle/src/binary/node.rs
@@ -45,6 +45,10 @@ impl Node {
     pub fn hash(&self) -> &Bytes32 {
         &self.hash
     }
+
+    pub fn height(&self) -> u32 {
+        self.position().height()
+    }
 }
 
 impl AsRef<Node> for Node {

--- a/fuel-merkle/src/common/subtree.rs
+++ b/fuel-merkle/src/common/subtree.rs
@@ -11,16 +11,16 @@ impl<T> Subtree<T> {
         Self { node, next }
     }
 
-    pub fn next(&self) -> &Option<Box<Subtree<T>>> {
-        &self.next
+    pub fn next(&self) -> Option<&Box<Subtree<T>>> {
+        self.next.as_ref()
     }
 
-    pub fn next_mut(&mut self) -> &mut Option<Box<Subtree<T>>> {
-        &mut self.next
+    pub fn next_mut(&mut self) -> Option<&mut Box<Subtree<T>>> {
+        self.next.as_mut()
     }
 
     pub fn take_next(&mut self) -> Option<Box<Subtree<T>>> {
-        self.next_mut().take()
+        self.next.take()
     }
 
     pub fn node(&self) -> &T {
@@ -32,6 +32,6 @@ impl<T> Subtree<T> {
     }
 
     pub fn next_node(&self) -> Option<&T> {
-        self.next().as_ref().map(|next| next.node())
+        self.next().map(|next| next.node())
     }
 }

--- a/fuel-merkle/src/common/subtree.rs
+++ b/fuel-merkle/src/common/subtree.rs
@@ -15,11 +15,11 @@ impl<T> Subtree<T> {
     }
 
     pub fn next(&self) -> Option<&Subtree<T>> {
-        self.next.as_ref().map(|next| next.as_ref())
+        self.next.as_ref().map(AsRef::as_ref)
     }
 
     pub fn next_mut(&mut self) -> Option<&mut Subtree<T>> {
-        self.next.as_mut().map(|next| next.as_mut())
+        self.next.as_mut().map(AsMut::as_mut)
     }
 
     pub fn take_next(&mut self) -> Option<Subtree<T>> {

--- a/fuel-merkle/src/common/subtree.rs
+++ b/fuel-merkle/src/common/subtree.rs
@@ -7,20 +7,23 @@ pub struct Subtree<T> {
 }
 
 impl<T> Subtree<T> {
-    pub fn new(node: T, next: Option<Box<Subtree<T>>>) -> Self {
-        Self { node, next }
+    pub fn new(node: T, next: Option<Subtree<T>>) -> Self {
+        Self {
+            node,
+            next: next.map(Box::new),
+        }
     }
 
-    pub fn next(&self) -> Option<&Box<Subtree<T>>> {
-        self.next.as_ref()
+    pub fn next(&self) -> Option<&Subtree<T>> {
+        self.next.as_ref().map(|next| next.as_ref())
     }
 
-    pub fn next_mut(&mut self) -> Option<&mut Box<Subtree<T>>> {
-        self.next.as_mut()
+    pub fn next_mut(&mut self) -> Option<&mut Subtree<T>> {
+        self.next.as_mut().map(|next| next.as_mut())
     }
 
-    pub fn take_next(&mut self) -> Option<Box<Subtree<T>>> {
-        self.next.take()
+    pub fn take_next(&mut self) -> Option<Subtree<T>> {
+        self.next.take().map(|next| *next)
     }
 
     pub fn node(&self) -> &T {

--- a/fuel-merkle/src/sum/merkle_tree.rs
+++ b/fuel-merkle/src/sum/merkle_tree.rs
@@ -14,7 +14,6 @@ use fuel_storage::{
     StorageMutate,
 };
 
-use alloc::boxed::Box;
 use core::marker::PhantomData;
 
 #[derive(Debug, Clone)]
@@ -52,7 +51,7 @@ pub enum MerkleTreeError {
 /// description above.
 pub struct MerkleTree<TableType, StorageType> {
     storage: StorageType,
-    head: Option<Box<Subtree<Node>>>,
+    head: Option<Subtree<Node>>,
     phantom_table: PhantomData<TableType>,
 }
 
@@ -90,7 +89,7 @@ where
         self.storage.insert(node.hash(), &node)?;
 
         let next = self.head.take();
-        let head = Box::new(Subtree::<Node>::new(node, next));
+        let head = Subtree::<Node>::new(node, next);
         self.head = Some(head);
         self.join_all_subtrees()?;
 
@@ -142,7 +141,7 @@ where
         &mut self,
         lhs: &mut Subtree<Node>,
         rhs: &mut Subtree<Node>,
-    ) -> Result<Box<Subtree<Node>>, StorageError> {
+    ) -> Result<Subtree<Node>, StorageError> {
         let height = lhs.node().height() + 1;
         let joined_node = Node::create_node(
             height,
@@ -155,7 +154,7 @@ where
 
         let joined_head = Subtree::new(joined_node, lhs.take_next());
 
-        Ok(Box::new(joined_head))
+        Ok(joined_head)
     }
 }
 


### PR DESCRIPTION
This PR adds small improvements to the BMT:
- simplifies the `build_root_node` method
- simplifies the `join_all_subtrees` method and adds comments
- removes `Box` from the BMT implementation and `Subtree` interface