### PR TITLE
Bump version to `0.34.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Description of the upcoming release here.
 
+## [Version 0.34.1]
+
+Mainly new opcodes prices and small performance improvements in the `BinaryMerkleTree`.
+
 ### Changed
 
 - [#492](https://github.com/FuelLabs/fuel-vm/pull/492) Minor improvements to BMT
     internals, including a reduction in usage of `Box`, using `expect(...)` over
     `unwrap()`, and additional comments.
+
+#### Breaking
+
+- [#493](https://github.com/FuelLabs/fuel-vm/pull/493) The default `GasCostsValues`
+    is updated according to the benches with `fuel-core 0.19`. 
+    It may break some unit tests that compare actual gas usage with expected.
 
 ## [Version 0.34.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,15 +18,15 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.34.0"
+version = "0.34.1"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.34.0", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.34.0", path = "fuel-crypto", default-features = false }
-fuel-merkle = { version = "0.34.0", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.34.0", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.34.0", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.34.0", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.34.0", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.34.1", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.34.1", path = "fuel-crypto", default-features = false }
+fuel-merkle = { version = "0.34.1", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.34.1", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.34.1", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.34.1", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.34.1", path = "fuel-vm", default-features = false }
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
## Release v0.34.1

Mainly new opcodes prices and small performance improvements in the `BinaryMerkleTree`.

### Changed

- [#492](https://github.com/FuelLabs/fuel-vm/pull/492) Minor improvements to BMT internals, including a reduction in usage of `Box`, using `expect(...)` over `unwrap()`, and additional comments.

#### Breaking

- [#493](https://github.com/FuelLabs/fuel-vm/pull/493) The default `GasCostsValues` is updated according to the benches with `fuel-core 0.19`. It may break some unit tests that compare actual gas usage with expected.

## What's Changed
* chore: BMT clean up by @bvrooman in https://github.com/FuelLabs/fuel-vm/pull/492
* Update gas prices based on `fuel-core 0.19` by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/493


**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.34.0...v0.34.1