### PR TITLE
Removed the `data` field from canonical serialization and deserialization of receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,15 @@ Description of the upcoming release here.
     was done incorrectly, devaluing the `dep_per_unit` part. After the fixing of 
     this, the execution should become much more expensive.
 
+- [#505](https://github.com/FuelLabs/fuel-vm/pull/505): The `data` field of the `Receipt` 
+    is not part of the canonical serialization and deserialization anymore. The SDK should use the 
+    `Receipt` type instead of `OpaqueReceipt`. The `Receipt.raw_payload` will be removed for the 
+    `fuel-core 0.20`. The `data` field is optional now. The SDK should update serialization and 
+    deserialization for `MessageOut`, `LogData`, and `ReturnData` receipts.
+
+- [#505](https://github.com/FuelLabs/fuel-vm/pull/505): The `len` field of the `Receipt` 
+    is not padded anymore and represents an initial value.
+
 ## [Version 0.34.1]
 
 Mainly new opcodes prices and small performance improvements in the `BinaryMerkleTree`.

--- a/fuel-tx/src/receipt/sizes.rs
+++ b/fuel-tx/src/receipt/sizes.rs
@@ -134,6 +134,5 @@ mem_layout!(
     amount: Word = WORD_SIZE,
     nonce: Nonce = {Nonce::LEN},
     len: Word = WORD_SIZE,
-    digest: Bytes32 = {Bytes32::LEN},
-    data_len: Word = WORD_SIZE
+    digest: Bytes32 = {Bytes32::LEN}
 );

--- a/fuel-tx/src/tests/bytes.rs
+++ b/fuel-tx/src/tests/bytes.rs
@@ -203,9 +203,8 @@ fn receipt() {
             rng.gen(),
             rng.gen(),
             rng.gen(),
+            rng.gen(),
             vec![rng.gen(), rng.gen()],
-            rng.gen(),
-            rng.gen(),
         ),
         Receipt::revert(rng.gen(), rng.gen(), rng.gen(), rng.gen()),
         Receipt::log(
@@ -223,9 +222,8 @@ fn receipt() {
             rng.gen(),
             rng.gen(),
             rng.gen(),
+            rng.gen(),
             vec![rng.gen(), rng.gen()],
-            rng.gen(),
-            rng.gen(),
         ),
         Receipt::transfer(
             rng.gen(),
@@ -261,7 +259,7 @@ fn receipt() {
             rng.gen(),
         ),
         Receipt::message_out(
-            rng.gen(),
+            &rng.gen(),
             rng.gen(),
             rng.gen(),
             rng.gen(),

--- a/fuel-types/src/fmt.rs
+++ b/fuel-types/src/fmt.rs
@@ -18,3 +18,25 @@ pub fn fmt_truncated_hex<const N: usize>(
     };
     f.write_str(formatted.as_str())
 }
+
+/// Formatting utility to truncate a optional vector of bytes to a hex string of max
+/// length `N`
+pub fn fmt_option_truncated_hex<const N: usize>(
+    data: &Option<Vec<u8>>,
+    f: &mut Formatter,
+) -> fmt::Result {
+    if let Some(data) = data {
+        let formatted = if data.len() > N {
+            let mut s = hex::encode(&data[0..N - 3]);
+            s.push_str("...");
+            s
+        } else {
+            hex::encode(data)
+        };
+        f.write_str("Some(")?;
+        f.write_str(formatted.as_str())?;
+        f.write_str(")")
+    } else {
+        f.write_str("None")
+    }
+}

--- a/fuel-vm/src/interpreter/blockchain.rs
+++ b/fuel-vm/src/interpreter/blockchain.rs
@@ -941,7 +941,7 @@ where
         let msg_data = msg_data_range.read(self.memory).to_vec();
         let sender = Address::from_bytes_ref(sender.read(self.memory));
 
-        let receipt = Receipt::message_out_from_tx_output(
+        let receipt = Receipt::message_out(
             txid,
             self.receipts.len() as Word,
             *sender,

--- a/fuel-vm/src/interpreter/flow.rs
+++ b/fuel-vm/src/interpreter/flow.rs
@@ -54,7 +54,6 @@ use fuel_asm::{
     PanicInstruction,
     RegId,
 };
-use fuel_crypto::Hasher;
 use fuel_storage::{
     StorageAsRef,
     StorageInspect,
@@ -230,17 +229,17 @@ impl RetCtx<'_> {
         }
 
         let ab = (a + b) as usize;
-        let digest = Hasher::hash(&self.append.memory[a as usize..ab]);
 
-        let receipt = Receipt::return_data_with_len(
+        let receipt = Receipt::return_data(
             self.current_contract.unwrap_or_else(ContractId::zeroed),
             a,
-            b,
-            digest,
-            self.append.memory[a as usize..ab].to_vec(),
             self.registers[RegId::PC],
             self.registers[RegId::IS],
+            self.append.memory[a as usize..ab].to_vec(),
         );
+        let digest = *receipt
+            .digest()
+            .expect("Receipt is created above and `digest` should exist");
 
         self.registers[RegId::RET] = a;
         self.registers[RegId::RETL] = b;

--- a/fuel-vm/src/interpreter/flow/ret_tests.rs
+++ b/fuel-vm/src/interpreter/flow/ret_tests.rs
@@ -143,9 +143,9 @@ fn test_return() {
             20,
             22,
             r,
-            vec![0u8; 22],
             expected[RegId::PC] - 4,
-            expected[RegId::IS]
+            expected[RegId::IS],
+            Some(vec![0u8; 22]),
         )
     );
 }

--- a/fuel-vm/src/interpreter/log.rs
+++ b/fuel-vm/src/interpreter/log.rs
@@ -17,7 +17,6 @@ use crate::{
 };
 
 use fuel_asm::PanicReason;
-use fuel_crypto::Hasher;
 use fuel_tx::{
     Receipt,
     Script,
@@ -130,18 +129,15 @@ impl LogInput<'_> {
         }
 
         let cd = (c + d) as usize;
-        let digest = Hasher::hash(&self.memory[c as usize..cd]);
 
-        let receipt = Receipt::log_data_with_len(
+        let receipt = Receipt::log_data(
             internal_contract_or_default(self.context, self.fp, self.memory),
             a,
             b,
             c,
-            d,
-            digest,
-            self.memory[c as usize..cd].to_vec(),
             *self.pc,
             *self.is,
+            self.memory[c as usize..cd].to_vec(),
         );
 
         append_receipt(

--- a/fuel-vm/src/interpreter/log/tests.rs
+++ b/fuel-vm/src/interpreter/log/tests.rs
@@ -54,9 +54,9 @@ fn test_log() -> Result<(), RuntimeError> {
         3,
         4,
         *receipts[1].digest().unwrap(),
-        vec![1u8; 4],
         8,
         0,
+        Some(vec![1u8; 4]),
     );
     assert_eq!(receipts[1], expected);
 

--- a/fuel-vm/src/tests/blockchain.rs
+++ b/fuel-vm/src/tests/blockchain.rs
@@ -1331,7 +1331,7 @@ fn smo_instruction_works() {
         if let Some((recipient, transferred, data)) = message_receipt {
             assert_eq!(txid.as_ref(), recipient.as_ref());
             assert_eq!(message_output_amount, transferred);
-            assert_eq!(data, msg_data);
+            assert_eq!(data.unwrap(), msg_data);
         }
         // get gas used from script result
         let gas_used = if let Receipt::ScriptResult { gas_used, .. } =
@@ -1559,7 +1559,7 @@ fn block_hash_works(
         panic!("expected log receipt");
     };
 
-    assert_eq!(data, &*expected);
+    assert_eq!(data.as_ref().unwrap(), &*expected);
 }
 
 #[rstest::rstest]
@@ -1602,5 +1602,5 @@ fn coinbase_works() {
         panic!("expected log receipt");
     };
 
-    assert_eq!(data, &*expected);
+    assert_eq!(data.as_ref().unwrap(), &*expected);
 }

--- a/fuel-vm/src/tests/memory.rs
+++ b/fuel-vm/src/tests/memory.rs
@@ -256,6 +256,7 @@ fn test_mcl_and_mcli(
     let vm: &Interpreter<MemoryStorage, Script> = vm.as_ref();
 
     if let Some(Receipt::LogData { data, .. }) = vm.receipts().first() {
+        let data = data.as_ref().unwrap();
         let c = count as usize;
         assert_eq!(data.len(), c + 1);
         if half {
@@ -309,6 +310,7 @@ fn test_mcp_and_mcpi(
     let vm: &Interpreter<MemoryStorage, Script> = vm.as_ref();
 
     if let Some(Receipt::LogData { data, .. }) = vm.receipts().first() {
+        let data = data.as_ref().unwrap();
         let c = count as usize;
         assert_eq!(data.len(), (c + 1) * 2);
         let mut expected = vec![1u8; c * 2 + 1];

--- a/fuel-vm/src/tests/wideint.rs
+++ b/fuel-vm/src/tests/wideint.rs
@@ -165,6 +165,7 @@ fn incr_u128(
 
     if let Receipt::LogData { data, .. } = receipts.first().unwrap() {
         let expected = v + 1;
+        let data = data.as_ref().unwrap();
         let bytes: [u8; 16] = data.clone().try_into().unwrap();
         let result = u128::from_be_bytes(bytes);
         assert_eq!(result, expected);
@@ -197,6 +198,7 @@ fn incr_u256(
     let receipts = run_script(ops);
 
     if let Receipt::LogData { data, .. } = receipts.first().unwrap() {
+        let data = data.as_ref().unwrap();
         let expected = v + 1;
         let bytes: [u8; 32] = data.clone().try_into().unwrap();
         let result = U256::from_be_bytes(bytes);
@@ -283,6 +285,7 @@ fn incr_wrapping_u128() {
     let receipts = run_script(ops);
 
     if let Receipt::LogData { data, .. } = receipts.first().unwrap() {
+        let data = data.as_ref().unwrap();
         let bytes: [u8; 16] = data.clone().try_into().unwrap();
         let result = u128::from_be_bytes(bytes);
         assert_eq!(result, 0);
@@ -314,6 +317,7 @@ fn incr_wrapping_u256() {
     let receipts = run_script(ops);
 
     if let Receipt::LogData { data, .. } = receipts.first().unwrap() {
+        let data = data.as_ref().unwrap();
         let bytes: [u8; 32] = data.clone().try_into().unwrap();
         let result = U256::from_be_bytes(bytes);
         assert_eq!(result, 0);
@@ -395,6 +399,7 @@ fn multiply_overflow_wrapping_u128() {
     let receipts = run_script(ops);
 
     if let Receipt::LogData { data, .. } = receipts.first().unwrap() {
+        let data = data.as_ref().unwrap();
         let bytes: [u8; 16] = data.clone().try_into().unwrap();
         let result = u128::from_be_bytes(bytes);
         assert_eq!(result, u128::MAX.wrapping_mul(u128::MAX));
@@ -426,6 +431,7 @@ fn multiply_overflow_wrapping_u256() {
     let receipts = run_script(ops);
 
     if let Receipt::LogData { data, .. } = receipts.first().unwrap() {
+        let data = data.as_ref().unwrap();
         let bytes: [u8; 32] = data.clone().try_into().unwrap();
         let result = U256::from_be_bytes(bytes);
         assert_eq!(result, U256::MAX.wrapping_mul(U256::MAX));
@@ -459,6 +465,7 @@ fn multiply_ok_u128(
     let receipts = run_script(ops);
 
     if let Receipt::LogData { data, .. } = receipts.first().unwrap() {
+        let data = data.as_ref().unwrap();
         let bytes: [u8; 16] = data.clone().try_into().unwrap();
         let result = u128::from_be_bytes(bytes);
         assert_eq!(result, a * b);
@@ -492,6 +499,7 @@ fn multiply_ok_u256(
     let receipts = run_script(ops);
 
     if let Receipt::LogData { data, .. } = receipts.first().unwrap() {
+        let data = data.as_ref().unwrap();
         let bytes: [u8; 32] = data.clone().try_into().unwrap();
         let result = U256::from_be_bytes(bytes);
         assert_eq!(result, a * b);
@@ -545,6 +553,7 @@ fn multiply_single_indirect_u128(
     let expected = a * u128::from(b);
 
     if let Receipt::LogData { data, .. } = lhs_receipts.first().unwrap() {
+        let data = data.as_ref().unwrap();
         let bytes: [u8; 16] = data.clone().try_into().unwrap();
         let result = u128::from_be_bytes(bytes);
         assert_eq!(result, expected);
@@ -553,6 +562,7 @@ fn multiply_single_indirect_u128(
     }
 
     if let Receipt::LogData { data, .. } = rhs_receipts.first().unwrap() {
+        let data = data.as_ref().unwrap();
         let bytes: [u8; 16] = data.clone().try_into().unwrap();
         let result = u128::from_be_bytes(bytes);
         assert_eq!(result, expected);
@@ -606,6 +616,7 @@ fn multiply_single_indirect_u256(
     let expected = a * U256::from(b);
 
     if let Receipt::LogData { data, .. } = lhs_receipts.first().unwrap() {
+        let data = data.as_ref().unwrap();
         let bytes: [u8; 32] = data.clone().try_into().unwrap();
         let result = U256::from_be_bytes(bytes);
         assert_eq!(result, expected);
@@ -614,6 +625,7 @@ fn multiply_single_indirect_u256(
     }
 
     if let Receipt::LogData { data, .. } = rhs_receipts.first().unwrap() {
+        let data = data.as_ref().unwrap();
         let bytes: [u8; 32] = data.clone().try_into().unwrap();
         let result = U256::from_be_bytes(bytes);
         assert_eq!(result, expected);
@@ -647,6 +659,7 @@ fn multiply_two_directs_u128(
     let receipts = run_script(ops);
 
     if let Receipt::LogData { data, .. } = receipts.first().unwrap() {
+        let data = data.as_ref().unwrap();
         let bytes: [u8; 16] = data.clone().try_into().unwrap();
         let result = u128::from_be_bytes(bytes);
         assert_eq!(result, u128::from(a * b));
@@ -680,6 +693,7 @@ fn multiply_two_directs_u256(
     let receipts = run_script(ops);
 
     if let Receipt::LogData { data, .. } = receipts.first().unwrap() {
+        let data = data.as_ref().unwrap();
         let bytes: [u8; 32] = data.clone().try_into().unwrap();
         let result = U256::from_be_bytes(bytes);
         assert_eq!(result, U256::from(a * b));
@@ -752,6 +766,7 @@ fn divide_by_zero_unsafemath_u128() {
     let receipts = run_script(ops);
 
     if let Receipt::LogData { data, .. } = receipts.first().unwrap() {
+        let data = data.as_ref().unwrap();
         let bytes: [u8; 16] = data.clone().try_into().unwrap();
         let result = u128::from_be_bytes(bytes);
         assert_eq!(result, 0);
@@ -780,6 +795,7 @@ fn divide_by_zero_unsafemath_u256() {
     let receipts = run_script(ops);
 
     if let Receipt::LogData { data, .. } = receipts.first().unwrap() {
+        let data = data.as_ref().unwrap();
         let bytes: [u8; 32] = data.clone().try_into().unwrap();
         let result = U256::from_be_bytes(bytes);
         assert_eq!(result, 0);
@@ -810,6 +826,7 @@ fn divide_ok_u128(
     let receipts = run_script(ops);
 
     if let Receipt::LogData { data, .. } = receipts.first().unwrap() {
+        let data = data.as_ref().unwrap();
         let bytes: [u8; 16] = data.clone().try_into().unwrap();
         let result = u128::from_be_bytes(bytes);
         assert_eq!(result, a / b);
@@ -840,6 +857,7 @@ fn divide_ok_u256(
     let receipts = run_script(ops);
 
     if let Receipt::LogData { data, .. } = receipts.first().unwrap() {
+        let data = data.as_ref().unwrap();
         let bytes: [u8; 32] = data.clone().try_into().unwrap();
         let result = U256::from_be_bytes(bytes);
         assert_eq!(result, a / b);
@@ -877,6 +895,7 @@ fn fused_mul_div_u128(
     let receipts = run_script(ops);
 
     if let Receipt::LogData { data, .. } = receipts.first().unwrap() {
+        let data = data.as_ref().unwrap();
         let bytes: [u8; 16] = data.clone().try_into().unwrap();
         let v = u128::from_be_bytes(bytes);
         assert_eq!(v, expected);
@@ -987,6 +1006,7 @@ fn fused_mul_div_u256(
     let receipts = run_script(ops);
 
     if let Receipt::LogData { data, .. } = receipts.first().unwrap() {
+        let data = data.as_ref().unwrap();
         let bytes: [u8; 32] = data.clone().try_into().unwrap();
         let v = U256::from_be_bytes(bytes);
         assert_eq!(v, expected);
@@ -1088,6 +1108,7 @@ fn addmod_u128(
     let receipts = run_script(ops);
 
     if let Receipt::LogData { data, .. } = receipts.first().unwrap() {
+        let data = data.as_ref().unwrap();
         let bytes: [u8; 16] = data.clone().try_into().unwrap();
         let v = u128::from_be_bytes(bytes);
         assert_eq!(v, expected);
@@ -1126,6 +1147,7 @@ fn addmod_u256(
     let receipts = run_script(ops);
 
     if let Receipt::LogData { data, .. } = receipts.first().unwrap() {
+        let data = data.as_ref().unwrap();
         let bytes: [u8; 32] = data.clone().try_into().unwrap();
         let v = U256::from_be_bytes(bytes);
         assert_eq!(v, expected);
@@ -1230,6 +1252,7 @@ fn mulmod_u128(
     let receipts = run_script(ops);
 
     if let Receipt::LogData { data, .. } = receipts.first().unwrap() {
+        let data = data.as_ref().unwrap();
         let bytes: [u8; 16] = data.clone().try_into().unwrap();
         let v = u128::from_be_bytes(bytes);
         assert_eq!(v, expected);
@@ -1270,6 +1293,7 @@ fn mulmod_u256(
     let receipts = run_script(ops);
 
     if let Receipt::LogData { data, .. } = receipts.first().unwrap() {
+        let data = data.as_ref().unwrap();
         let bytes: [u8; 32] = data.clone().try_into().unwrap();
         let v = U256::from_be_bytes(bytes);
         assert_eq!(v, expected);


### PR DESCRIPTION
- The `data` field is optional now and is not recovered during canonical deserialization. 
- The `len` field is not padded anymore.

ref https://github.com/FuelLabs/fuel-core/issues/1240