### PR TITLE
Support of the multi-assets per contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,37 @@ Description of the upcoming release here.
 
 - [#486](https://github.com/FuelLabs/fuel-vm/pull/486/): Adds `ed25519` signature verification and `secp256r1` signature recovery to `fuel-crypto`, and corresponding opcodes `ED19` and `ECR1` to `fuel-vm`.
 
-- [#500](https://github.com/FuelLabs/fuel-vm/pull/500) Introduced `ParallelExecutor` trait
+- [#500](https://github.com/FuelLabs/fuel-vm/pull/500): Introduced `ParallelExecutor` trait
     and made available async versions of verify and estimate predicates.
     Updated tests to test for both parallel and sequential execution.
     Fixed a bug in `transaction/check_predicate_owners`.
+
+#### Breaking
+
+- [#506](https://github.com/FuelLabs/fuel-vm/pull/506): Added new `Mint` and `Burn` variants to `Receipt` enum.
+    It affects serialization and deserialization with new variants.
+
+### Changed
+
+#### Breaking
+
+- [#506](https://github.com/FuelLabs/fuel-vm/pull/506): The `mint` and `burn` 
+    opcodes accept a new `$rB` register. It is a sub-identifier used to generate an 
+    `AssetId` by [this rule](https://github.com/FuelLabs/fuel-specs/blob/SilentCicero-multi-token/src/identifiers/asset.md). 
+    This feature allows having multi-asset per one contract. It is a huge breaking change, and 
+    after this point, `ContractId` can't be equal to `AssetId`.
+
+    The conversion like `AssetId::from(*contract_id)` is no longer valid. Instead, the `ContractId` implements the `ContractIdExt` trait:
+    ```rust
+    /// Trait extends the functionality of the `ContractId` type.
+    pub trait ContractIdExt {
+        /// Creates an `AssetId` from the `ContractId` and `sub_id`.
+        fn asset_id(&self, sub_id: &Bytes32) -> AssetId;
+    }
+    ```
+
+- [#506](https://github.com/FuelLabs/fuel-vm/pull/506): The `mint` and `burn` 
+    opcodes affect the `receipts_root` of the `Script` transaction.
 
 ### Removed
 
@@ -25,11 +52,11 @@ Description of the upcoming release here.
 
 ### Fixed
 
-- [#500](https://github.com/FuelLabs/fuel-vm/pull/500) Fixed a bug where `MessageCoinPredicate` wasn't checked for in `check_predicate_owners`.
+- [#500](https://github.com/FuelLabs/fuel-vm/pull/500): Fixed a bug where `MessageCoinPredicate` wasn't checked for in `check_predicate_owners`.
 
 #### Breaking
 
-- [#502](https://github.com/FuelLabs/fuel-vm/pull/502) The algorithm used by the
+- [#502](https://github.com/FuelLabs/fuel-vm/pull/502): The algorithm used by the
     binary Merkle tree for generating Merkle proofs has been updated to remove
     the leaf data from the proof set. This change allows BMT proofs to conform
     to the format expected by the Solidity contracts used for verifying proofs.
@@ -65,13 +92,13 @@ Mainly new opcodes prices and small performance improvements in the `BinaryMerkl
 
 ### Changed
 
-- [#492](https://github.com/FuelLabs/fuel-vm/pull/492) Minor improvements to BMT
+- [#492](https://github.com/FuelLabs/fuel-vm/pull/492): Minor improvements to BMT
     internals, including a reduction in usage of `Box`, using `expect(...)` over
     `unwrap()`, and additional comments.
 
 #### Breaking
 
-- [#493](https://github.com/FuelLabs/fuel-vm/pull/493) The default `GasCostsValues`
+- [#493](https://github.com/FuelLabs/fuel-vm/pull/493): The default `GasCostsValues`
     is updated according to the benches with `fuel-core 0.19`. 
     It may break some unit tests that compare actual gas usage with expected.
 

--- a/fuel-asm/src/lib.rs
+++ b/fuel-asm/src/lib.rs
@@ -151,8 +151,8 @@ impl_instructions! {
     0x2A BHSH bhsh [dst: RegId heigth: RegId]
     "Get current block height."
     0x2B BHEI bhei [dst: RegId]
-    "Burn coins of the current contract's asset ID."
-    0x2C BURN burn [count: RegId]
+    "Burns `amount` coins of the asset ID created from `sub_id` for the current contract."
+    0x2C BURN burn [amount: RegId sub_id_addr: RegId]
     "Call a contract."
     0x2D CALL call [target_struct: RegId fwd_coins: RegId asset_id_addr: RegId fwd_gas: RegId]
     "Copy contract code for a contract."
@@ -169,8 +169,8 @@ impl_instructions! {
     0x33 LOG log [a: RegId b: RegId c: RegId d: RegId]
     "Log data."
     0x34 LOGD logd [a: RegId b: RegId addr: RegId len: RegId]
-    "Mint coins of the current contract's asset ID."
-    0x35 MINT mint [amount: RegId]
+    "Mints `amount` coins of the asset ID created from `sub_id` for the current contract."
+    0x35 MINT mint [amount: RegId sub_id_addr: RegId]
     "Halt execution, reverting state changes and returning a value."
     0x36 RVRT rvrt [value: RegId]
     "Clear a series of slots from contract storage."

--- a/fuel-tx/src/lib.rs
+++ b/fuel-tx/src/lib.rs
@@ -100,3 +100,21 @@ pub use transaction::consensus_parameters::default_parameters;
 
 #[cfg(feature = "alloc")]
 pub use contract::Contract;
+
+/// Trait extends the functionality of the `ContractId` type.
+pub trait ContractIdExt {
+    /// Creates an `AssetId` from the `ContractId` and `sub_id`.
+    fn asset_id(&self, sub_id: &Bytes32) -> AssetId;
+}
+
+impl ContractIdExt for ContractId {
+    fn asset_id(&self, sub_id: &Bytes32) -> AssetId {
+        let hasher = fuel_crypto::Hasher::default();
+        AssetId::new(
+            *hasher
+                .chain(self.as_slice())
+                .chain(sub_id.as_slice())
+                .finalize(),
+        )
+    }
+}

--- a/fuel-tx/src/receipt/receipt_repr.rs
+++ b/fuel-tx/src/receipt/receipt_repr.rs
@@ -1,34 +1,57 @@
 use crate::receipt::Receipt;
+use fuel_types::Word;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum ReceiptRepr {
-    Call = 0x00,
-    Return = 0x01,
-    ReturnData = 0x02,
-    Panic = 0x03,
-    Revert = 0x04,
-    Log = 0x05,
-    LogData = 0x06,
-    Transfer = 0x07,
-    TransferOut = 0x08,
-    ScriptResult = 0x09,
-    MessageOut = 0x0A,
+macro_rules! enum_from {
+    (
+        $(#[$meta:meta])* $vis:vis enum $name:ident {
+            $($(#[$vmeta:meta])* $vname:ident $(= $val:expr)?,)*
+        }
+    ) => {
+        $(#[$meta])*
+        $vis enum $name {
+            $($(#[$vmeta])* $vname $(= $val)?,)*
+        }
+
+        impl From<&Receipt> for $name {
+            fn from(receipt: &Receipt) -> Self {
+                match receipt {
+                    $(Receipt::$vname { .. } => Self::$vname,)*
+                }
+            }
+        }
+
+        #[cfg(feature = "std")]
+        impl TryFrom<Word> for $name {
+            type Error = std::io::Error;
+
+            fn try_from(x: Word) -> Result<Self, Self::Error> {
+                match x {
+                    $(x if x == $name::$vname as Word => Ok($name::$vname),)*
+                    _ => Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "The provided identifier is invalid!",
+                    )),
+                }
+            }
+        }
+    }
 }
 
-impl From<&Receipt> for ReceiptRepr {
-    fn from(receipt: &Receipt) -> Self {
-        match receipt {
-            Receipt::Call { .. } => Self::Call,
-            Receipt::Return { .. } => Self::Return,
-            Receipt::ReturnData { .. } => Self::ReturnData,
-            Receipt::Panic { .. } => Self::Panic,
-            Receipt::Revert { .. } => Self::Revert,
-            Receipt::Log { .. } => Self::Log,
-            Receipt::LogData { .. } => Self::LogData,
-            Receipt::Transfer { .. } => Self::Transfer,
-            Receipt::TransferOut { .. } => Self::TransferOut,
-            Receipt::ScriptResult { .. } => Self::ScriptResult,
-            Receipt::MessageOut { .. } => Self::MessageOut,
-        }
+enum_from! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub enum ReceiptRepr {
+        Call = 0x00,
+        Return = 0x01,
+        ReturnData = 0x02,
+        Panic = 0x03,
+        Revert = 0x04,
+        Log = 0x05,
+        LogData = 0x06,
+        Transfer = 0x07,
+        TransferOut = 0x08,
+        ScriptResult = 0x09,
+        MessageOut = 0x0A,
+        Mint = 0x0B,
+        Burn = 0x0C,
     }
 }

--- a/fuel-tx/src/receipt/sizes.rs
+++ b/fuel-tx/src/receipt/sizes.rs
@@ -136,3 +136,25 @@ mem_layout!(
     len: Word = WORD_SIZE,
     digest: Bytes32 = {Bytes32::LEN}
 );
+
+pub struct MintSizes;
+mem_layout!(
+    MintSizesLayout for MintSizes
+    repr: u8 = WORD_SIZE,
+    sub_id: Bytes32 = {Bytes32::LEN},
+    contract_id: ContractId = {ContractId::LEN},
+    val: Word = WORD_SIZE,
+    pc: Word = WORD_SIZE,
+    is: Word = WORD_SIZE
+);
+
+pub struct BurnSizes;
+mem_layout!(
+    BurnSizesLayout for BurnSizes
+    repr: u8 = WORD_SIZE,
+    sub_id: Bytes32 = {Bytes32::LEN},
+    contract_id: ContractId = {ContractId::LEN},
+    val: Word = WORD_SIZE,
+    pc: Word = WORD_SIZE,
+    is: Word = WORD_SIZE
+);

--- a/fuel-tx/src/tests/bytes.rs
+++ b/fuel-tx/src/tests/bytes.rs
@@ -266,6 +266,8 @@ fn receipt() {
             rng.gen(),
             vec![rng.gen()],
         ),
+        Receipt::mint(rng.gen(), rng.gen(), rng.gen(), rng.gen(), rng.gen()),
+        Receipt::burn(rng.gen(), rng.gen(), rng.gen(), rng.gen(), rng.gen()),
     ];
 
     for panic_reason in PanicReason::iter() {

--- a/fuel-vm/src/interpreter/blockchain.rs
+++ b/fuel-vm/src/interpreter/blockchain.rs
@@ -165,7 +165,7 @@ where
     pub(crate) fn mint(&mut self, a: Word, b: Word) -> Result<(), RuntimeError> {
         let (SystemRegisters { fp, pc, is, .. }, _) =
             split_registers(&mut self.registers);
-        MindCtx {
+        MintCtx {
             storage: &mut self.storage,
             context: &self.context,
             append: AppendReceipt {
@@ -608,7 +608,7 @@ where
     }
 }
 
-struct MindCtx<'vm, S> {
+struct MintCtx<'vm, S> {
     storage: &'vm mut S,
     context: &'vm Context,
     append: AppendReceipt<'vm>,
@@ -617,7 +617,7 @@ struct MindCtx<'vm, S> {
     is: Reg<'vm, IS>,
 }
 
-impl<'vm, S> MindCtx<'vm, S>
+impl<'vm, S> MintCtx<'vm, S>
 where
     S: ContractsAssetsStorage,
     <S as StorageInspect<ContractsAssets>>::Error: Into<std::io::Error>,

--- a/fuel-vm/src/interpreter/blockchain/other_tests.rs
+++ b/fuel-vm/src/interpreter/blockchain/other_tests.rs
@@ -138,7 +138,7 @@ fn test_mint(
     let is = 0;
     const ORIGINAL_PC: Word = 4;
     let mut pc = ORIGINAL_PC;
-    MindCtx {
+    MintCtx {
         storage: &mut storage,
         context: &context,
         append: AppendReceipt {

--- a/fuel-vm/src/interpreter/blockchain/other_tests.rs
+++ b/fuel-vm/src/interpreter/blockchain/other_tests.rs
@@ -10,25 +10,30 @@ use fuel_storage::StorageAsMut;
 use fuel_types::Salt;
 use test_case::test_case;
 
-#[test_case(false, 0, None, 0 => Ok(()); "Burn nothing")]
-#[test_case(false, 0, 0, 0 => Ok(()); "Burn is idempotent")]
-#[test_case(false, 0, 100, 100 => Ok(()); "Burn all")]
-#[test_case(false, 0, 100, 10 => Ok(()); "Burn some")]
-#[test_case(true, 0, 100, 10 => Err(RuntimeError::Recoverable(PanicReason::ExpectedInternalContext)); "Can't burn from external context")]
-#[test_case(false, 1, 100, 10 => Err(RuntimeError::Recoverable(PanicReason::NotEnoughBalance)); "Can't burn when contract id not in memory")]
-#[test_case(false, 0, 100, 101 => Err(RuntimeError::Recoverable(PanicReason::NotEnoughBalance)); "Can't burn too much")]
-#[test_case(false, 0, None, 1 => Err(RuntimeError::Recoverable(PanicReason::NotEnoughBalance)); "Can't burn when no balance")]
+#[test_case(false, 0, None, 0, [0; 32] => Ok(()); "Burn nothing")]
+#[test_case(false, 0, 0, 0, [0; 32] => Ok(()); "Burn is idempotent")]
+#[test_case(false, 0, 100, 100, [0; 32] => Ok(()); "Burn all")]
+#[test_case(false, 0, 100, 100, [15; 32] => Ok(()); "Burn all for another sub id")]
+#[test_case(false, 0, 100, 10, [0; 32] => Ok(()); "Burn some")]
+#[test_case(true, 0, 100, 10, [0; 32] => Err(RuntimeError::Recoverable(PanicReason::ExpectedInternalContext)); "Can't burn from external context")]
+#[test_case(false, 1, 100, 10, [0; 32] => Err(RuntimeError::Recoverable(PanicReason::NotEnoughBalance)); "Can't burn when contract id not in memory")]
+#[test_case(false, 0, 100, 101, [0; 32] => Err(RuntimeError::Recoverable(PanicReason::NotEnoughBalance)); "Can't burn too much")]
+#[test_case(false, 0, None, 1, [0; 32] => Err(RuntimeError::Recoverable(PanicReason::NotEnoughBalance)); "Can't burn when no balance")]
 fn test_burn(
     external: bool,
     fp: Word,
     initialize: impl Into<Option<Word>>,
     amount: Word,
+    sub_id: [u8; 32],
 ) -> Result<(), RuntimeError> {
     let mut storage = MemoryStorage::new(Default::default(), Default::default());
     let mut memory: Memory<MEM_SIZE> = vec![1u8; MEM_SIZE].try_into().unwrap();
-    memory[0..ContractId::LEN].copy_from_slice(&[3u8; ContractId::LEN][..]);
     let contract_id = ContractId::from([3u8; 32]);
-    let asset_id = AssetId::from([3u8; 32]);
+    memory[0..ContractId::LEN].copy_from_slice(contract_id.as_slice());
+    memory[ContractId::LEN..ContractId::LEN + Bytes32::LEN]
+        .copy_from_slice(sub_id.as_slice());
+    let sub_id = Bytes32::from(sub_id);
+    let asset_id = contract_id.asset_id(&sub_id);
     let initialize = initialize.into();
     if let Some(initialize) = initialize {
         storage
@@ -44,46 +49,73 @@ fn test_burn(
             block_height: Default::default(),
         }
     };
-    let mut pc = 4;
-    burn(
-        &mut storage,
-        &memory,
-        &context,
-        Reg::new(&fp),
-        RegMut::new(&mut pc),
-        amount,
-    )?;
+    let mut receipts = Default::default();
+    let mut script = Some(fuel_tx::Script::default());
+
+    let is = 0;
+    const ORIGINAL_PC: Word = 4;
+    let mut pc = ORIGINAL_PC;
+    BurnCtx {
+        storage: &mut storage,
+        context: &context,
+        append: AppendReceipt {
+            receipts: &mut receipts,
+            script: script.as_mut(),
+            tx_offset: 0,
+            memory: &mut memory,
+        },
+        fp: Reg::new(&fp),
+        pc: RegMut::new(&mut pc),
+        is: Reg::new(&is),
+    }
+    .burn(amount, ContractId::LEN as Word)?;
     assert_eq!(pc, 8);
     let result = storage
         .merkle_contract_asset_id_balance(&contract_id, &asset_id)
         .unwrap()
         .unwrap();
     assert_eq!(result, initialize.unwrap_or(0) - amount);
+    assert_eq!(receipts.len(), 1);
+    assert_eq!(
+        receipts[0],
+        Receipt::Burn {
+            sub_id,
+            contract_id,
+            val: amount,
+            pc: ORIGINAL_PC,
+            is
+        }
+    );
     Ok(())
 }
 
-#[test_case(false, 0, None, 0 => Ok(()); "Mint nothing")]
-#[test_case(false, 0, 0, 0 => Ok(()); "Mint is idempotent")]
-#[test_case(false, 0, 100, 0 => Ok(()); "Mint is idempotent any")]
-#[test_case(false, 0, 100, 100 => Ok(()); "Mint Double")]
-#[test_case(false, 0, 100, 10 => Ok(()); "Mint some")]
-#[test_case(false, 0, None, 10 => Ok(()); "Mint some from nothing")]
-#[test_case(false, 0, 0, 10 => Ok(()); "Mint some from zero")]
-#[test_case(false, 0, None, Word::MAX => Ok(()); "Mint max from nothing")]
-#[test_case(false, 0, 0, Word::MAX => Ok(()); "Mint max from zero")]
-#[test_case(true, 0, 100, 10 => Err(RuntimeError::Recoverable(PanicReason::ExpectedInternalContext)); "Can't mint from external context")]
-#[test_case(false, 0, 1, Word::MAX => Err(RuntimeError::Recoverable(PanicReason::ArithmeticOverflow)); "Can't mint too much")]
+#[test_case(false, 0, None, 0, [0; 32] => Ok(()); "Mint nothing")]
+#[test_case(false, 0, 0, 0, [0; 32] => Ok(()); "Mint is idempotent")]
+#[test_case(false, 0, 100, 0, [0; 32] => Ok(()); "Mint is idempotent any")]
+#[test_case(false, 0, 100, 100, [0; 32] => Ok(()); "Mint Double")]
+#[test_case(false, 0, 100, 100, [15; 32] => Ok(()); "Mint Double for another sub id")]
+#[test_case(false, 0, 100, 10, [0; 32] => Ok(()); "Mint some")]
+#[test_case(false, 0, None, 10, [0; 32] => Ok(()); "Mint some from nothing")]
+#[test_case(false, 0, 0, 10, [0; 32] => Ok(()); "Mint some from zero")]
+#[test_case(false, 0, None, Word::MAX, [0; 32] => Ok(()); "Mint max from nothing")]
+#[test_case(false, 0, 0, Word::MAX, [0; 32] => Ok(()); "Mint max from zero")]
+#[test_case(true, 0, 100, 10, [0; 32] => Err(RuntimeError::Recoverable(PanicReason::ExpectedInternalContext)); "Can't mint from external context")]
+#[test_case(false, 0, 1, Word::MAX, [0; 32] => Err(RuntimeError::Recoverable(PanicReason::ArithmeticOverflow)); "Can't mint too much")]
 fn test_mint(
     external: bool,
     fp: Word,
     initialize: impl Into<Option<Word>>,
     amount: Word,
+    sub_id: [u8; 32],
 ) -> Result<(), RuntimeError> {
     let mut storage = MemoryStorage::new(Default::default(), Default::default());
     let mut memory: Memory<MEM_SIZE> = vec![1u8; MEM_SIZE].try_into().unwrap();
-    memory[0..ContractId::LEN].copy_from_slice(&[3u8; ContractId::LEN][..]);
     let contract_id = ContractId::from([3u8; 32]);
-    let asset_id = AssetId::from([3u8; 32]);
+    memory[0..ContractId::LEN].copy_from_slice(contract_id.as_slice());
+    memory[ContractId::LEN..ContractId::LEN + Bytes32::LEN]
+        .copy_from_slice(sub_id.as_slice());
+    let sub_id = Bytes32::from(sub_id);
+    let asset_id = contract_id.asset_id(&sub_id);
     let initialize = initialize.into();
     if let Some(initialize) = initialize {
         storage
@@ -99,21 +131,44 @@ fn test_mint(
             block_height: Default::default(),
         }
     };
-    let mut pc = 4;
-    mint(
-        &mut storage,
-        &memory,
-        &context,
-        Reg::new(&fp),
-        RegMut::new(&mut pc),
-        amount,
-    )?;
+
+    let mut receipts = Default::default();
+    let mut script = Some(fuel_tx::Script::default());
+
+    let is = 0;
+    const ORIGINAL_PC: Word = 4;
+    let mut pc = ORIGINAL_PC;
+    MindCtx {
+        storage: &mut storage,
+        context: &context,
+        append: AppendReceipt {
+            receipts: &mut receipts,
+            script: script.as_mut(),
+            tx_offset: 0,
+            memory: &mut memory,
+        },
+        fp: Reg::new(&fp),
+        pc: RegMut::new(&mut pc),
+        is: Reg::new(&is),
+    }
+    .mint(amount, ContractId::LEN as Word)?;
     assert_eq!(pc, 8);
     let result = storage
         .merkle_contract_asset_id_balance(&contract_id, &asset_id)
         .unwrap()
         .unwrap();
     assert_eq!(result, initialize.unwrap_or(0) + amount);
+    assert_eq!(receipts.len(), 1);
+    assert_eq!(
+        receipts[0],
+        Receipt::Mint {
+            sub_id,
+            contract_id,
+            val: amount,
+            pc: ORIGINAL_PC,
+            is
+        }
+    );
     Ok(())
 }
 

--- a/fuel-vm/src/interpreter/executors/instruction.rs
+++ b/fuel-vm/src/interpreter/executors/instruction.rs
@@ -704,8 +704,8 @@ where
 
             Instruction::BURN(burn) => {
                 self.gas_charge(self.gas_costs.burn)?;
-                let a = burn.unpack();
-                self.burn(r!(a))?;
+                let (a, b) = burn.unpack();
+                self.burn(r!(a), r!(b))?;
             }
 
             Instruction::CALL(call) => {
@@ -759,8 +759,8 @@ where
 
             Instruction::MINT(mint) => {
                 self.gas_charge(self.gas_costs.mint)?;
-                let a = mint.unpack();
-                self.mint(r!(a))?;
+                let (a, b) = mint.unpack();
+                self.mint(r!(a), r!(b))?;
             }
 
             Instruction::SCWQ(scwq) => {

--- a/fuel-vm/src/tests/contract.rs
+++ b/fuel-vm/src/tests/contract.rs
@@ -92,16 +92,20 @@ fn mint_burn() {
         op::lw(0x10, 0x10, 0),
         op::addi(0x11, RegId::FP, CallFrame::b_offset() as Immediate12),
         op::lw(0x11, 0x11, 0),
-        op::jnei(0x10, RegId::ZERO, 7),
-        op::mint(0x11),
-        op::ji(8),
-        op::burn(0x11),
+        // Allocate 32 bytes for the zeroed `sub_id`.
+        op::movi(0x15, Bytes32::LEN as u32),
+        op::aloc(0x15),
+        op::jnei(0x10, RegId::ZERO, 9),
+        // Mint `0x11` amount of an assets created from zeroed `sub_id`
+        op::mint(0x11, RegId::HP),
+        op::ji(10),
+        op::burn(0x11, RegId::HP),
         op::ret(RegId::ONE),
     ];
 
     let contract_id = test_context.setup_contract(program, None, None).contract_id;
 
-    let asset_id = AssetId::from(*contract_id);
+    let asset_id = contract_id.asset_id(&Bytes32::zeroed());
 
     let (script_call, _) = script_with_data_offset!(
         data_offset,


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuel-vm/issues/496

- Added new `Mint` and `Burn` receipts with serialization and deserialization.
- `mint` and `burn` opcodes accept a new `$rB` register - `sub_id`
- `mint` and `burn` opcodes produce receipts now.