### PR TITLE
Release v0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Description of the upcoming release here.
 
+## [Version 0.35.0]
+
+The release mostly fixes funding during the audit and integration with the bridge. But the release also contains some new features like:
+- Asynchronous predicate estimation/verification.
+- Multi-asset support per contract.
+- Support Secp256r1 signature recovery and Ed25519 verificaiton.
+
+
 ### Added
 
 - [#486](https://github.com/FuelLabs/fuel-vm/pull/486/): Adds `ed25519` signature verification and `secp256r1` signature recovery to `fuel-crypto`, and corresponding opcodes `ED19` and `ECR1` to `fuel-vm`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,15 +18,15 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.34.1"
+version = "0.35.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.34.1", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.34.1", path = "fuel-crypto", default-features = false }
-fuel-merkle = { version = "0.34.1", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.34.1", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.34.1", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.34.1", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.34.1", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.35.0", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.35.0", path = "fuel-crypto", default-features = false }
+fuel-merkle = { version = "0.35.0", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.35.0", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.35.0", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.35.0", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.35.0", path = "fuel-vm", default-features = false }
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
## [Version 0.35.0]

The release mostly fixes funding during the audit and integration with the bridge. But the release also contains some new features like:
- Asynchronous predicate estimation/verification.
- Multi-asset support per contract.
- Support Secp256r1 signature recovery and Ed25519 verificaiton.


### Added

- [#486](https://github.com/FuelLabs/fuel-vm/pull/486/): Adds `ed25519` signature verification and `secp256r1` signature recovery to `fuel-crypto`, and corresponding opcodes `ED19` and `ECR1` to `fuel-vm`.

- [#500](https://github.com/FuelLabs/fuel-vm/pull/500): Introduced `ParallelExecutor` trait
    and made available async versions of verify and estimate predicates.
    Updated tests to test for both parallel and sequential execution.
    Fixed a bug in `transaction/check_predicate_owners`.

#### Breaking

- [#506](https://github.com/FuelLabs/fuel-vm/pull/506): Added new `Mint` and `Burn` variants to `Receipt` enum.
    It affects serialization and deserialization with new variants.

### Changed

#### Breaking

- [#506](https://github.com/FuelLabs/fuel-vm/pull/506): The `mint` and `burn` 
    opcodes accept a new `$rB` register. It is a sub-identifier used to generate an 
    `AssetId` by [this rule](https://github.com/FuelLabs/fuel-specs/blob/SilentCicero-multi-token/src/identifiers/asset.md). 
    This feature allows having multi-asset per one contract. It is a huge breaking change, and 
    after this point, `ContractId` can't be equal to `AssetId`.

    The conversion like `AssetId::from(*contract_id)` is no longer valid. Instead, the `ContractId` implements the `ContractIdExt` trait:
    ```rust
    /// Trait extends the functionality of the `ContractId` type.
    pub trait ContractIdExt {
        /// Creates an `AssetId` from the `ContractId` and `sub_id`.
        fn asset_id(&self, sub_id: &Bytes32) -> AssetId;
    }
    ```

- [#506](https://github.com/FuelLabs/fuel-vm/pull/506): The `mint` and `burn` 
    opcodes affect the `receipts_root` of the `Script` transaction.

### Removed

#### Breaking

- [#486](https://github.com/FuelLabs/fuel-vm/pull/486/): Removes apparently unused `Keystore` and `Signer` traits from `fuel-crypto`. Also renames `ECR` opcode to `ECK1`.

### Fixed

- [#500](https://github.com/FuelLabs/fuel-vm/pull/500): Fixed a bug where `MessageCoinPredicate` wasn't checked for in `check_predicate_owners`.

#### Breaking

- [#502](https://github.com/FuelLabs/fuel-vm/pull/502): The algorithm used by the
    binary Merkle tree for generating Merkle proofs has been updated to remove
    the leaf data from the proof set. This change allows BMT proofs to conform
    to the format expected by the Solidity contracts used for verifying proofs.

- [#503](https://github.com/FuelLabs/fuel-vm/pull/503): Use correct amount of gas in call
    receipts when limited by cgas. Before this change, the `Receipt::Call` could show an incorrect value for the gas limit.

- [#504](https://github.com/FuelLabs/fuel-vm/pull/504): The `CROO` and `CSIZ` opcodes require 
    the existence of corresponding `ContractId` in the transaction's 
    inputs(the same behavior as for the `CROO` opcode).

- [#504](https://github.com/FuelLabs/fuel-vm/pull/504): The size of the contract 
    was incorrectly padded. It affects the end of the call frame in the memory, 
    making it not 8 bytes align. Also, it affects the cost of the contract 
    call(in some cases, we charged less in some more).

- [#504](https://github.com/FuelLabs/fuel-vm/pull/504): The charging for `DependentCost`
    was done incorrectly, devaluing the `dep_per_unit` part. After the fixing of 
    this, the execution should become much more expensive.

- [#505](https://github.com/FuelLabs/fuel-vm/pull/505): The `data` field of the `Receipt` 
    is not part of the canonical serialization and deserialization anymore. The SDK should use the 
    `Receipt` type instead of `OpaqueReceipt`. The `Receipt.raw_payload` will be removed for the 
    `fuel-core 0.20`. The `data` field is optional now. The SDK should update serialization and 
    deserialization for `MessageOut`, `LogData`, and `ReturnData` receipts.

- [#505](https://github.com/FuelLabs/fuel-vm/pull/505): The `len` field of the `Receipt` 
    is not padded anymore and represents an initial value.

## All changes:
## What's Changed
* Some additional test to verify ecrecovery with `TxId` and coin witness by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/495
* Add argument names to fuel-asm opcodes by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/497
* Use correct amount of gas in call receipts when limited by cgas by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/503
* bug: Remove leaf data from BMT proofs by @bvrooman in https://github.com/FuelLabs/fuel-vm/pull/502
* Bugfixes found during chatting with Auditors on July 7th by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/504
* Removed the `data` field from canonical serialization and deserialization of receipts by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/505
* Secp256r1 signature recovery and Ed25519 verification by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/486
* enable parallel predicate verification by @leviathanbeak in https://github.com/FuelLabs/fuel-vm/pull/500
* Support of the multi-assets per contract by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/506


**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.34.1...v0.35.0