### PR TITLE
Release v0.35.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Description of the upcoming release here.
 
+## [Version 0.35.1]
+
+### Added
+
+- [#499](https://github.com/FuelLabs/fuel-vm/pull/499/): The `wasm_bindgen` support of `fuel-asm` and `fuel-types`.
+    Each new release also publish a typescript analog of the `fuel-asm` and `fuel-types` crates to the npm.
+    
+
 ## [Version 0.35.0]
 
 The release mostly fixes funding during the audit and integration with the bridge. But the release also contains some new features like:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,15 +18,15 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.35.0"
+version = "0.35.1"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.35.0", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.35.0", path = "fuel-crypto", default-features = false }
-fuel-merkle = { version = "0.35.0", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.35.0", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.35.0", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.35.0", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.35.0", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.35.1", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.35.1", path = "fuel-crypto", default-features = false }
+fuel-merkle = { version = "0.35.1", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.35.1", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.35.1", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.35.1", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.35.1", path = "fuel-vm", default-features = false }
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
## Release v0.35.1

The minor release to trigger publishing of the `fuel-asm` and `fuel-types` to npm.

### Added

- [#499](https://github.com/FuelLabs/fuel-vm/pull/499/): The `wasm_bindgen` support of `fuel-asm` and `fuel-types`.
    Each new release also publish a typescript analog of the `fuel-asm` and `fuel-types` crates to the npm.
   
## What's Changed
* The `wasm_bindgen` support of `fuel-asm` and `fuel-types` by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/499


**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.35.0...v0.35.1