### PR TITLE
Fixing NPM-publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,6 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish
-        run: pnpm -C .npm publish -r --access public
+        run: pnpm -C .npm publish -r --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Removing git checks to allow NPM-publish to occur from any branch (fixes [this](https://github.com/FuelLabs/fuel-vm/actions/runs/5650374516/job/15306807035)).