### PR TITLE
Make `ConsensusParameters` Serialize/Derserialize again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-Description of the upcoming release here.
+- [#514](https://github.com/FuelLabs/fuel-vm/pull/514/): Add `ClientId` and `GasCosts` to `ConsensusParameters`. 
+    Break down `ConsensusParameters` into sub-structs to match usage. Change signatures of functions to ask for
+    necessary fields only.
 
 ## [Version 0.35.1]
 

--- a/fuel-tx/src/transaction/consensus_parameters.rs
+++ b/fuel-tx/src/transaction/consensus_parameters.rs
@@ -17,7 +17,9 @@ pub use gas::{
 const MAX_GAS: u64 = 100_000_000;
 
 /// A collection of parameters for convenience
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 pub struct ConsensusParameters {
     pub tx_params: TxParameters,
     pub predicate_params: PredicateParameters,
@@ -26,6 +28,12 @@ pub struct ConsensusParameters {
     pub fee_params: FeeParameters,
     pub chain_id: ChainId,
     pub gas_costs: GasCosts,
+}
+
+impl Default for ConsensusParameters {
+    fn default() -> Self {
+        Self::standard(ChainId::default())
+    }
 }
 
 impl ConsensusParameters {

--- a/fuel-tx/src/transaction/consensus_parameters/gas.rs
+++ b/fuel-tx/src/transaction/consensus_parameters/gas.rs
@@ -144,7 +144,7 @@ impl GasUnit {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Gas costings for every op.
 /// The inner values are wrapped in an [`Arc`]
@@ -173,7 +173,7 @@ impl Default for GasCostsValues {
 }
 
 #[allow(missing_docs)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(default = "GasCostsValues::unit"))]
 /// Gas costs for every op.
@@ -289,7 +289,7 @@ pub struct GasCostsValues {
     pub srwq: DependentCost,
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Dependent cost is a cost that depends on the number of units.
 /// The cost starts at the base and grows by `dep_per_unit` for every unit.


### PR DESCRIPTION
This got removed during the last PR:
https://github.com/FuelLabs/fuel-vm/pull/514

Is needed by consumers (`fuel-core`).