### PR TITLE
Follow-up clean ups and fixed for the VM initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-- [#514](https://github.com/FuelLabs/fuel-vm/pull/514/): Add `ClientId` and `GasCosts` to `ConsensusParameters`. 
+### Changed
+
+#### Breaking
+
+- [#514](https://github.com/FuelLabs/fuel-vm/pull/514/): Add `ChainId` and `GasCosts` to `ConsensusParameters`. 
     Break down `ConsensusParameters` into sub-structs to match usage. Change signatures of functions to ask for
     necessary fields only.
+
+### Fixed
+
+#### Breaking
+
+- [#527](https://github.com/FuelLabs/fuel-vm/pull/527): The balances are empty during predicate estimation/verification.
 
 ## [Version 0.35.1]
 

--- a/fuel-tx/src/builder.rs
+++ b/fuel-tx/src/builder.rs
@@ -201,14 +201,11 @@ impl<Tx> TransactionBuilder<Tx> {
         let should_prepare_predicate = false;
         let sign_keys = HashMap::new();
 
-        // TODO: What is a default chain id?
-        let chain_id = ChainId::default();
-
         Self {
             tx,
             should_prepare_script,
             should_prepare_predicate,
-            params: ConsensusParameters::standard(chain_id),
+            params: ConsensusParameters::standard(),
             sign_keys,
         }
     }

--- a/fuel-tx/src/tests/offset.rs
+++ b/fuel-tx/src/tests/offset.rs
@@ -469,8 +469,7 @@ fn iow_offset() {
             let bytes = tx.to_bytes();
 
             let mut tx_p = tx.clone();
-            let chain_id = ChainId::default();
-            tx_p.precompute(&chain_id)
+            tx_p.precompute(&ChainId::default())
                 .expect("Should be able to calculate cache");
 
             tx.inputs().iter().enumerate().for_each(|(x, i)| {

--- a/fuel-tx/src/tests/valid_cases/input.rs
+++ b/fuel-tx/src/tests/valid_cases/input.rs
@@ -156,10 +156,7 @@ fn coin_signed() {
 
     let block_height = rng.gen();
     let err = tx
-        .check(
-            block_height,
-            &ConsensusParameters::standard(Default::default()),
-        )
+        .check(block_height, &ConsensusParameters::standard())
         .expect_err("Expected failure");
 
     assert_eq!(CheckError::InputWitnessIndexBounds { index: 0 }, err);
@@ -212,8 +209,7 @@ fn coin_predicate() {
     let txhash: Bytes32 = rng.gen();
 
     let predicate = generate_nonempty_padded_bytes(rng);
-    let chain_id = ChainId::default();
-    let owner = Input::predicate_owner(&predicate, &chain_id);
+    let owner = Input::predicate_owner(&predicate, &ChainId::default());
 
     Input::coin_predicate(
         rng.gen(),
@@ -238,8 +234,7 @@ fn coin_predicate() {
     .unwrap();
 
     let predicate = vec![];
-    let chain_id = ChainId::default();
-    let owner = Input::predicate_owner(&predicate, &chain_id);
+    let owner = Input::predicate_owner(&predicate, &ChainId::default());
 
     let err = Input::coin_predicate(
         rng.gen(),
@@ -420,13 +415,12 @@ fn message_metadata() {
 
     let block_height = rng.gen();
     let err = tx
-        .check(block_height, &ConsensusParameters::standard(chain_id))
+        .check(block_height, &ConsensusParameters::standard())
         .expect_err("Expected failure");
 
     assert_eq!(CheckError::InputWitnessIndexBounds { index: 0 }, err,);
 
     let mut predicate = generate_nonempty_padded_bytes(rng);
-    let chain_id = ChainId::default();
     let recipient = Input::predicate_owner(&predicate, &chain_id);
     predicate[0] = predicate[0].wrapping_add(1);
 
@@ -588,14 +582,13 @@ fn message_message_coin() {
 
     let block_height = rng.gen();
     let err = tx
-        .check(block_height, &ConsensusParameters::standard(chain_id))
+        .check(block_height, &ConsensusParameters::standard())
         .expect_err("Expected failure");
 
     assert_eq!(CheckError::InputWitnessIndexBounds { index: 0 }, err,);
 
     let mut predicate = generate_nonempty_padded_bytes(rng);
-    let chain_id = ChainId::default();
-    let recipient = Input::predicate_owner(&predicate, &chain_id);
+    let recipient = Input::predicate_owner(&predicate, &ChainId::default());
     predicate[0] = predicate[0].wrapping_add(1);
 
     let err = Input::message_coin_predicate(
@@ -699,10 +692,7 @@ fn transaction_with_duplicate_coin_inputs_is_invalid() {
         .add_input(b)
         .add_witness(rng.gen())
         .finalize()
-        .check_without_signatures(
-            Default::default(),
-            &ConsensusParameters::standard(ChainId::default()),
-        )
+        .check_without_signatures(Default::default(), &ConsensusParameters::standard())
         .expect_err("Expected checkable failure");
 
     assert_eq!(err, CheckError::DuplicateInputUtxoId { utxo_id });
@@ -739,7 +729,7 @@ fn transaction_with_duplicate_message_inputs_is_invalid() {
         .finalize()
         .check_without_signatures(
             Default::default(),
-            &ConsensusParameters::standard(ChainId::default()),
+            &ConsensusParameters::standard(),
         )
         .expect_err("Expected checkable failure");
 
@@ -773,10 +763,7 @@ fn transaction_with_duplicate_contract_inputs_is_invalid() {
         .add_output(o)
         .add_output(p)
         .finalize()
-        .check_without_signatures(
-            Default::default(),
-            &ConsensusParameters::standard(ChainId::default()),
-        )
+        .check_without_signatures(Default::default(), &ConsensusParameters::standard())
         .expect_err("Expected checkable failure");
 
     assert_eq!(err, CheckError::DuplicateInputContractId { contract_id });
@@ -810,9 +797,6 @@ fn transaction_with_duplicate_contract_utxo_id_is_valid() {
         .add_output(p)
         .add_witness(rng.gen())
         .finalize()
-        .check_without_signatures(
-            Default::default(),
-            &ConsensusParameters::standard(ChainId::default()),
-        )
+        .check_without_signatures(Default::default(), &ConsensusParameters::standard())
         .expect("Duplicated UTXO id is valid for contract input");
 }

--- a/fuel-tx/src/transaction/consensus_parameters.rs
+++ b/fuel-tx/src/transaction/consensus_parameters.rs
@@ -32,13 +32,26 @@ pub struct ConsensusParameters {
 
 impl Default for ConsensusParameters {
     fn default() -> Self {
-        Self::standard(ChainId::default())
+        Self::standard()
     }
 }
 
 impl ConsensusParameters {
-    /// Constructor for the `ConsensusParameters` with Standard values
-    pub fn standard(chain_id: ChainId) -> Self {
+    /// Constructor for the `ConsensusParameters` with Standard values.
+    pub fn standard() -> Self {
+        Self {
+            tx_params: TxParameters::DEFAULT,
+            predicate_params: PredicateParameters::DEFAULT,
+            script_params: ScriptParameters::DEFAULT,
+            contract_params: ContractParameters::DEFAULT,
+            fee_params: FeeParameters::DEFAULT,
+            chain_id: ChainId::default(),
+            gas_costs: GasCosts::default(),
+        }
+    }
+
+    /// Constructor for the `ConsensusParameters` with Standard values around `ChainId`.
+    pub fn standard_with_id(chain_id: ChainId) -> Self {
         Self {
             tx_params: TxParameters::DEFAULT,
             predicate_params: PredicateParameters::DEFAULT,

--- a/fuel-tx/src/transaction/types/create.rs
+++ b/fuel-tx/src/transaction/types/create.rs
@@ -932,7 +932,7 @@ mod tests {
         tx.storage_slots.reverse();
 
         let err = tx
-            .check(0.into(), &ConsensusParameters::standard(ChainId::default()))
+            .check(0.into(), &ConsensusParameters::standard())
             .expect_err("Expected erroneous transaction");
 
         assert_eq!(CheckError::TransactionCreateStorageSlotOrder, err);
@@ -952,7 +952,7 @@ mod tests {
         )
         .add_random_fee_input()
         .finalize()
-        .check(0.into(), &ConsensusParameters::standard(ChainId::default()))
+        .check(0.into(), &ConsensusParameters::standard())
         .expect_err("Expected erroneous transaction");
 
         assert_eq!(CheckError::TransactionCreateStorageSlotOrder, err);

--- a/fuel-tx/src/transaction/types/script.rs
+++ b/fuel-tx/src/transaction/types/script.rs
@@ -1,6 +1,7 @@
 use crate::{
     transaction::{
         compute_transaction_id,
+        consensus_parameters::TxParameters,
         field::{
             GasLimit,
             GasPrice,
@@ -42,7 +43,6 @@ use fuel_types::{
     Word,
 };
 
-use crate::transaction::consensus_parameters::TxParameters;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 #[cfg(feature = "std")]

--- a/fuel-tx/src/transaction/validity.rs
+++ b/fuel-tx/src/transaction/validity.rs
@@ -303,9 +303,7 @@ impl FormatValidityChecks for Transaction {
 pub(crate) fn check_common_part<T>(
     tx: &T,
     block_height: BlockHeight,
-    //
     tx_params: &TxParameters,
-    //
     predicate_params: &PredicateParameters,
 ) -> Result<(), CheckError>
 where

--- a/fuel-vm/src/interpreter.rs
+++ b/fuel-vm/src/interpreter.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     call::CallFrame,
+    checked_transaction::CheckPredicateParams,
     constraints::reg_key::*,
     consts::*,
     context::Context,
@@ -23,16 +24,19 @@ use fuel_tx::{
     Chargeable,
     CheckError,
     ConsensusParameters,
+    ContractParameters,
     Create,
     Executable,
     FeeParameters,
     GasCosts,
     Output,
+    PredicateParameters,
     Receipt,
     Script,
     Transaction,
     TransactionFee,
     TransactionRepr,
+    TxParameters,
     UniqueIdentifier,
 };
 use fuel_types::{
@@ -117,7 +121,7 @@ pub struct Interpreter<S, Tx = ()> {
 }
 
 /// Interpreter parameters
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InterpreterParams {
     /// Gas costs
     pub gas_costs: GasCosts,
@@ -135,6 +139,26 @@ pub struct InterpreterParams {
     pub fee_params: FeeParameters,
 }
 
+impl Default for InterpreterParams {
+    fn default() -> Self {
+        Self {
+            gas_costs: Default::default(),
+            max_inputs: TxParameters::DEFAULT.max_inputs,
+            contract_max_size: ContractParameters::DEFAULT.contract_max_size,
+            tx_offset: TxParameters::DEFAULT.tx_offset(),
+            max_message_data_length: PredicateParameters::DEFAULT.max_message_data_length,
+            chain_id: ChainId::default(),
+            fee_params: FeeParameters::default(),
+        }
+    }
+}
+
+impl From<ConsensusParameters> for InterpreterParams {
+    fn from(value: ConsensusParameters) -> Self {
+        InterpreterParams::from(&value)
+    }
+}
+
 impl From<&ConsensusParameters> for InterpreterParams {
     fn from(value: &ConsensusParameters) -> Self {
         InterpreterParams {
@@ -145,6 +169,20 @@ impl From<&ConsensusParameters> for InterpreterParams {
             max_message_data_length: value.predicate_params.max_message_data_length,
             chain_id: value.chain_id,
             fee_params: value.fee_params,
+        }
+    }
+}
+
+impl From<CheckPredicateParams> for InterpreterParams {
+    fn from(params: CheckPredicateParams) -> Self {
+        InterpreterParams {
+            gas_costs: params.gas_costs,
+            max_inputs: params.max_inputs,
+            contract_max_size: params.contract_max_size,
+            tx_offset: params.tx_offset,
+            max_message_data_length: params.max_message_data_length,
+            chain_id: params.chain_id,
+            fee_params: params.fee_params,
         }
     }
 }

--- a/fuel-vm/src/interpreter/constructors.rs
+++ b/fuel-vm/src/interpreter/constructors.rs
@@ -15,13 +15,6 @@ use crate::{
     state::Debugger,
     storage::MemoryStorage,
 };
-use fuel_tx::{
-    ContractParameters,
-    FeeParameters,
-    PredicateParameters,
-    TxParameters,
-};
-use fuel_types::ChainId;
 
 #[cfg(feature = "profile-any")]
 use crate::profiler::ProfileReceiver;
@@ -85,16 +78,7 @@ where
     Tx: ExecutableTransaction,
 {
     fn default() -> Self {
-        let params = InterpreterParams {
-            gas_costs: Default::default(),
-            max_inputs: TxParameters::DEFAULT.max_inputs,
-            contract_max_size: ContractParameters::DEFAULT.contract_max_size,
-            tx_offset: TxParameters::default().tx_offset(),
-            max_message_data_length: PredicateParameters::DEFAULT.max_message_data_length,
-            chain_id: ChainId::default(),
-            fee_params: FeeParameters::default(),
-        };
-        Self::with_storage(Default::default(), params)
+        Self::with_storage(Default::default(), InterpreterParams::default())
     }
 }
 

--- a/fuel-vm/src/interpreter/debug.rs
+++ b/fuel-vm/src/interpreter/debug.rs
@@ -65,7 +65,7 @@ fn breakpoint_script() {
     .into_iter()
     .collect();
 
-    let consensus_params = ConsensusParameters::standard(Default::default());
+    let consensus_params = ConsensusParameters::standard();
 
     let tx = TransactionBuilder::script(script, vec![])
         .gas_limit(gas_limit)
@@ -137,7 +137,7 @@ fn single_stepping() {
     .into_iter()
     .collect();
 
-    let consensus_params = ConsensusParameters::standard(Default::default());
+    let consensus_params = ConsensusParameters::standard();
 
     let tx = TransactionBuilder::script(script, vec![])
         .gas_limit(gas_limit)

--- a/fuel-vm/src/interpreter/diff.rs
+++ b/fuel-vm/src/interpreter/diff.rs
@@ -482,7 +482,7 @@ where
             && self.initial_balances == other.initial_balances
             && self.context == other.context
             && self.balances == other.balances
-            && self.gas_costs() == other.gas_costs()
+            && self.interpreter_params == other.interpreter_params
             && self.panic_context == other.panic_context
     }
 }

--- a/fuel-vm/src/interpreter/diff/tests.rs
+++ b/fuel-vm/src/interpreter/diff/tests.rs
@@ -38,12 +38,10 @@ fn reset_vm_state() {
 }
 
 use crate::interpreter::InterpreterParams;
-use fuel_types::ChainId;
 
 #[test]
 fn record_and_invert_storage() {
-    let interpreter_params =
-        InterpreterParams::from(&ConsensusParameters::standard(ChainId::default()));
+    let interpreter_params = InterpreterParams::from(&ConsensusParameters::standard());
 
     let a = Interpreter::<_, Script>::with_storage(
         Record::new(MemoryStorage::default()),

--- a/fuel-vm/src/interpreter/initialization.rs
+++ b/fuel-vm/src/interpreter/initialization.rs
@@ -86,13 +86,12 @@ where
         &mut self,
         context: Context,
         mut tx: Tx,
-        balances: InitialBalances,
         gas_limit: Word,
     ) -> Result<(), InterpreterError> {
         self.context = context;
         tx.prepare_init_predicate();
 
-        self.init_inner(tx, balances, gas_limit)
+        self.init_inner(tx, InitialBalances::default(), gas_limit)
     }
 }
 

--- a/fuel-vm/src/interpreter/internal/tests.rs
+++ b/fuel-vm/src/interpreter/internal/tests.rs
@@ -1,8 +1,11 @@
 use crate::{
     constraints::reg_key::RegMut,
-    interpreter::internal::{
-        external_asset_id_balance_sub,
-        set_variable_output,
+    interpreter::{
+        internal::{
+            external_asset_id_balance_sub,
+            set_variable_output,
+        },
+        InterpreterParams,
     },
     prelude::*,
 };
@@ -95,7 +98,11 @@ fn external_balance() {
 fn variable_output_updates_in_memory() {
     let mut rng = StdRng::seed_from_u64(2322u64);
 
-    let mut vm = Interpreter::with_memory_storage();
+    let consensus_params = ConsensusParameters::standard();
+    let mut vm = Interpreter::with_storage(
+        MemoryStorage::default(),
+        InterpreterParams::from(&consensus_params),
+    );
 
     let gas_limit = 1_000_000;
     let height = Default::default();
@@ -107,16 +114,6 @@ fn variable_output_updates_in_memory() {
         to: rng.gen(),
         amount: 0,
         asset_id: rng.gen(),
-    };
-
-    let consensus_params = ConsensusParameters {
-        tx_params: Default::default(),
-        fee_params: Default::default(),
-        predicate_params: Default::default(),
-        script_params: Default::default(),
-        contract_params: Default::default(),
-        chain_id: Default::default(),
-        gas_costs: vm.gas_costs().to_owned(),
     };
 
     let tx = TransactionBuilder::script(vec![], vec![])

--- a/fuel-vm/src/interpreter/memory/tests.rs
+++ b/fuel-vm/src/interpreter/memory/tests.rs
@@ -1,34 +1,31 @@
 use std::ops::Range;
 
 use super::*;
-use crate::prelude::*;
+use crate::{
+    interpreter::InterpreterParams,
+    prelude::*,
+};
 use fuel_asm::op;
 use fuel_tx::ConsensusParameters;
 use test_case::test_case;
 
 #[test]
 fn memcopy() {
-    let mut vm = Interpreter::with_memory_storage();
     let tx_params = TxParameters::default().with_max_gas_per_tx(Word::MAX / 2);
+
+    let consensus_params = ConsensusParameters {
+        tx_params,
+        ..Default::default()
+    };
+
+    let mut vm = Interpreter::with_storage(
+        MemoryStorage::default(),
+        InterpreterParams::from(&consensus_params),
+    );
     let tx = TransactionBuilder::script(op::ret(0x10).to_bytes().to_vec(), vec![])
         .gas_limit(tx_params.max_gas_per_tx)
         .add_random_fee_input()
         .finalize();
-
-    let predicate_params = Default::default();
-    let script_params = Default::default();
-    let contract_params = Default::default();
-    let fee_params = &Default::default();
-
-    let consensus_params = ConsensusParameters::new(
-        tx_params,
-        predicate_params,
-        script_params,
-        contract_params,
-        *fee_params,
-        Default::default(),
-        vm.gas_costs().to_owned(),
-    );
 
     let tx = tx
         .into_checked(Default::default(), &consensus_params)
@@ -88,10 +85,7 @@ fn memrange() {
         .gas_limit(1000000)
         .add_random_fee_input()
         .finalize()
-        .into_checked(
-            Default::default(),
-            &ConsensusParameters::standard(Default::default()),
-        )
+        .into_checked(Default::default(), &ConsensusParameters::standard())
         .expect("Empty script should be valid");
     let mut vm = Interpreter::with_memory_storage();
     vm.init_script(tx).expect("Failed to init VM");
@@ -121,10 +115,7 @@ fn stack_alloc_ownership() {
         .gas_limit(1000000)
         .add_random_fee_input()
         .finalize()
-        .into_checked(
-            Default::default(),
-            &ConsensusParameters::standard(Default::default()),
-        )
+        .into_checked(Default::default(), &ConsensusParameters::standard())
         .expect("Empty script should be valid");
     vm.init_script(tx).expect("Failed to init VM");
 

--- a/fuel-vm/src/memory_client.rs
+++ b/fuel-vm/src/memory_client.rs
@@ -10,16 +10,11 @@ use crate::{
 
 use crate::interpreter::InterpreterParams;
 use fuel_tx::{
-    ContractParameters,
     Create,
-    FeeParameters,
     GasCosts,
-    PredicateParameters,
     Receipt,
     Script,
-    TxParameters,
 };
-use fuel_types::ChainId;
 
 #[derive(Default, Debug)]
 /// Client implementation with in-memory storage backend.
@@ -104,11 +99,6 @@ impl MemoryClient {
         self.as_mut().persist();
     }
 
-    // /// Consensus parameters
-    // pub const fn params(&self) -> &ConsensusParameters {
-    //     self.transactor.params()
-    // }
-
     /// Tx memory offset
     pub fn tx_offset(&self) -> usize {
         self.transactor.tx_offset()
@@ -122,16 +112,7 @@ impl MemoryClient {
 
 impl From<MemoryStorage> for MemoryClient {
     fn from(s: MemoryStorage) -> Self {
-        let interpreter_params = InterpreterParams {
-            gas_costs: Default::default(),
-            max_inputs: TxParameters::DEFAULT.max_inputs,
-            contract_max_size: ContractParameters::DEFAULT.contract_max_size,
-            tx_offset: TxParameters::default().tx_offset(),
-            max_message_data_length: PredicateParameters::DEFAULT.max_message_data_length,
-            chain_id: ChainId::default(),
-            fee_params: FeeParameters::default(),
-        };
-        Self::new(s, interpreter_params)
+        Self::new(s, InterpreterParams::default())
     }
 }
 

--- a/fuel-vm/src/predicate.rs
+++ b/fuel-vm/src/predicate.rs
@@ -131,7 +131,6 @@ fn from_tx_works() {
                     program: Default::default()
                 },
                 tx.transaction().clone(),
-                Default::default(),
                 tx.transaction().limit()
             )
             .is_ok());

--- a/fuel-vm/src/tests/blockchain.rs
+++ b/fuel-vm/src/tests/blockchain.rs
@@ -291,7 +291,7 @@ fn load_external_contract_code() {
     let output0 = Output::contract_created(contract_id, state_root);
     let output1 = Output::contract(0, rng.gen(), rng.gen());
 
-    let consensus_params = ConsensusParameters::standard(Default::default());
+    let consensus_params = ConsensusParameters::standard();
 
     let tx_create_target = TransactionBuilder::create(program.clone(), salt, vec![])
         .gas_price(gas_price)
@@ -400,25 +400,13 @@ fn ldc_reason_helper(
     let rng = &mut StdRng::seed_from_u64(2322u64);
     let salt: Salt = rng.gen();
 
-    let tx_params = TxParameters::default();
-    let predicate_params = PredicateParameters::default();
-    let script_params = ScriptParameters::default();
-    let contract_params = ContractParameters::default();
-    let fee_params = FeeParameters::default();
-    let chain_id = ChainId::default();
-
     // make gas costs free
     let gas_costs = GasCosts::free();
 
-    let consensus_params = ConsensusParameters::new(
-        tx_params,
-        predicate_params,
-        script_params,
-        contract_params,
-        fee_params,
-        chain_id,
+    let consensus_params = ConsensusParameters {
         gas_costs,
-    );
+        ..Default::default()
+    };
 
     let interpreter_params = InterpreterParams::from(&consensus_params);
 
@@ -1276,7 +1264,6 @@ fn smo_instruction_works() {
     {
         let mut client = MemoryClient::default();
         let fee_params = FeeParameters::default();
-        let chain_id = ChainId::default();
 
         let gas_limit = 1_000_000;
         let maturity = Default::default();
@@ -1327,7 +1314,7 @@ fn smo_instruction_works() {
             tx.metadata().non_retryable_balances[&AssetId::BASE];
         let retryable_balance: u64 = tx.metadata().retryable_balance.into();
 
-        let txid = tx.transaction().id(&chain_id);
+        let txid = tx.transaction().id(&ChainId::default());
         let receipts = client.transact(tx);
 
         let success = receipts.iter().any(|r| {

--- a/fuel-vm/src/tests/contract.rs
+++ b/fuel-vm/src/tests/contract.rs
@@ -11,7 +11,6 @@ use fuel_tx::{
     ConsensusParameters,
     Witness,
 };
-use fuel_types::ChainId;
 use rand::{
     rngs::StdRng,
     Rng,
@@ -68,9 +67,7 @@ fn prevent_contract_id_redeployment() {
         1,
     );
 
-    let chain_id = ChainId::default();
-
-    let consensus_params = ConsensusParameters::standard(chain_id);
+    let consensus_params = ConsensusParameters::standard();
 
     let create = create
         .into_checked_basic(1.into(), &consensus_params)

--- a/fuel-vm/src/tests/crypto.rs
+++ b/fuel-vm/src/tests/crypto.rs
@@ -140,7 +140,7 @@ fn ecrecover_tx_id() {
 
     tx.sign_inputs(&secret, &chain_id);
 
-    let consensus_params = ConsensusParameters::standard(Default::default());
+    let consensus_params = ConsensusParameters::standard_with_id(chain_id);
     let tx = tx.into_checked(height, &consensus_params).unwrap();
 
     let receipts = client.transact(tx);
@@ -165,9 +165,7 @@ async fn recover_tx_id_predicate() {
     let public = secret.public_key();
 
     let check_params = CheckPredicateParams::default();
-    let chain_id = ChainId::default();
-
-    let consensus_params = ConsensusParameters::standard(chain_id);
+    let consensus_params = ConsensusParameters::standard();
 
     #[rustfmt::skip]
     let predicate = vec![

--- a/fuel-vm/src/tests/gas_factor.rs
+++ b/fuel-vm/src/tests/gas_factor.rs
@@ -1,7 +1,6 @@
 use fuel_asm::op;
 use fuel_vm::prelude::*;
 
-use crate::fuel_types::ChainId;
 use fuel_tx::{
     field::Outputs,
     ConsensusParameters,
@@ -43,7 +42,7 @@ fn gas_factor_rounds_correctly() {
 
     let consensus_params = ConsensusParameters {
         fee_params,
-        ..ConsensusParameters::standard(ChainId::default())
+        ..ConsensusParameters::standard()
     };
 
     let interpreter_params = InterpreterParams::from(&consensus_params);

--- a/fuel-vm/src/tests/memory.rs
+++ b/fuel-vm/src/tests/memory.rs
@@ -6,7 +6,6 @@ use fuel_asm::{
     RegId,
 };
 use fuel_tx::Receipt;
-use fuel_types::ChainId;
 use fuel_vm::{
     consts::VM_MAX_RAM,
     interpreter::InterpreterParams,
@@ -28,7 +27,7 @@ fn setup(program: Vec<Instruction>) -> Transactor<MemoryStorage, Script> {
     let maturity = Default::default();
     let height = Default::default();
 
-    let consensus_params = ConsensusParameters::standard(ChainId::default());
+    let consensus_params = ConsensusParameters::standard();
 
     let script = program.into_iter().collect();
 

--- a/fuel-vm/src/tests/metadata.rs
+++ b/fuel-vm/src/tests/metadata.rs
@@ -49,7 +49,7 @@ fn metadata() {
     let maturity = Default::default();
     let height = Default::default();
 
-    let consensus_params = ConsensusParameters::standard(ChainId::default());
+    let consensus_params = ConsensusParameters::standard();
 
     #[rustfmt::skip]
     let routine_metadata_is_caller_external = vec![
@@ -225,13 +225,8 @@ fn get_metadata_chain_id() {
     let chain_id: ChainId = rng.gen();
 
     let interpreter_params = InterpreterParams {
-        gas_costs: Default::default(),
-        max_inputs: TxParameters::DEFAULT.max_inputs,
-        contract_max_size: ContractParameters::DEFAULT.contract_max_size,
-        tx_offset: TxParameters::DEFAULT.tx_offset(),
-        max_message_data_length: PredicateParameters::DEFAULT.max_message_data_length,
         chain_id,
-        fee_params: FeeParameters::default(),
+        ..Default::default()
     };
 
     let mut client = MemoryClient::new(Default::default(), interpreter_params);
@@ -242,7 +237,7 @@ fn get_metadata_chain_id() {
         op::ret(0x10),
     ];
 
-    let consensus_params = ConsensusParameters::standard(chain_id);
+    let consensus_params = ConsensusParameters::standard_with_id(chain_id);
 
     let script = TransactionBuilder::script(get_chain_id.into_iter().collect(), vec![])
         .gas_limit(gas_limit)
@@ -275,7 +270,6 @@ fn get_transaction_fields() {
     let input = 10_000_000;
 
     let tx_params = TxParameters::default();
-    let chain_id = ChainId::default();
 
     let contract: Witness = vec![op::ret(0x01)].into_iter().collect::<Vec<u8>>().into();
     let salt = rng.gen();
@@ -323,7 +317,7 @@ fn get_transaction_fields() {
     rng.fill(m_data.as_mut_slice());
     rng.fill(m_predicate_data.as_mut_slice());
 
-    let owner = Input::predicate_owner(&m_predicate, &chain_id);
+    let owner = Input::predicate_owner(&m_predicate, &ChainId::default());
     let message_predicate = Input::message_data_predicate(
         rng.gen(),
         owner,

--- a/fuel-vm/src/tests/predicate.rs
+++ b/fuel-vm/src/tests/predicate.rs
@@ -72,10 +72,9 @@ where
     let tx_pointer = rng.gen();
     let maturity = Default::default();
     let height = Default::default();
-    let chain_id = Default::default();
     let predicate_gas_used = 0;
 
-    let owner = Input::predicate_owner(&predicate, &chain_id);
+    let owner = Input::predicate_owner(&predicate, &ChainId::default());
     let input = Input::coin_predicate(
         utxo_id,
         owner,
@@ -117,7 +116,7 @@ where
     let gas_costs = GasCosts::free();
 
     let checked = transaction
-        .into_checked_basic(height, &ConsensusParameters::standard(ChainId::default()))
+        .into_checked_basic(height, &ConsensusParameters::standard())
         .expect("Should successfully convert into Checked");
 
     let params = CheckPredicateParams {
@@ -268,10 +267,7 @@ async fn execute_gas_metered_predicates(
             .map_err(|_| ())?;
 
         let tx = async_tx
-            .into_checked_basic(
-                Default::default(),
-                &ConsensusParameters::standard(Default::default()),
-            )
+            .into_checked_basic(Default::default(), &ConsensusParameters::standard())
             .expect("Should successfully create checked tranaction with predicate");
 
         Interpreter::<PredicateStorage>::check_predicates_async::<_, TokioWithRayon>(
@@ -286,10 +282,7 @@ async fn execute_gas_metered_predicates(
     transaction.estimate_predicates(&params).map_err(|_| ())?;
 
     let tx = transaction
-        .into_checked_basic(
-            Default::default(),
-            &ConsensusParameters::standard(Default::default()),
-        )
+        .into_checked_basic(Default::default(), &ConsensusParameters::standard())
         .expect("Should successfully create checked tranaction with predicate");
 
     let seq_gas_used = Interpreter::<PredicateStorage>::check_predicates(&tx, &params)
@@ -438,10 +431,7 @@ async fn gas_used_by_predicates_is_deducted_from_script_gas() {
         .expect("Predicate estimation failed");
 
     let checked = transaction
-        .into_checked_basic(
-            Default::default(),
-            &ConsensusParameters::standard(Default::default()),
-        )
+        .into_checked_basic(Default::default(), &ConsensusParameters::standard())
         .expect("Should successfully create checked tranaction with predicate");
 
     // parallel version
@@ -577,10 +567,7 @@ async fn gas_used_by_predicates_causes_out_of_gas_during_script() {
         .expect("Predicate estimation failed");
 
     let checked = transaction
-        .into_checked_basic(
-            Default::default(),
-            &ConsensusParameters::standard(Default::default()),
-        )
+        .into_checked_basic(Default::default(), &ConsensusParameters::standard())
         .expect("Should successfully create checked tranaction with predicate");
 
     // parallel version

--- a/fuel-vm/src/tests/test_helpers.rs
+++ b/fuel-vm/src/tests/test_helpers.rs
@@ -22,7 +22,7 @@ pub fn run_script(script: Vec<Instruction>) -> Vec<Receipt> {
     let script = script.into_iter().collect();
     let mut client = MemoryClient::default();
 
-    let consensus_params = ConsensusParameters::standard(Default::default());
+    let consensus_params = ConsensusParameters::standard();
 
     let tx = TransactionBuilder::script(script, vec![])
         .gas_price(0)

--- a/fuel-vm/src/transactor.rs
+++ b/fuel-vm/src/transactor.rs
@@ -22,16 +22,11 @@ use crate::{
 
 use crate::interpreter::InterpreterParams;
 use fuel_tx::{
-    ContractParameters,
     Create,
-    FeeParameters,
     GasCosts,
-    PredicateParameters,
     Receipt,
     Script,
-    TxParameters,
 };
-use fuel_types::ChainId;
 
 #[derive(Debug)]
 /// State machine to execute transactions and provide runtime entities on
@@ -253,15 +248,6 @@ where
     Tx: ExecutableTransaction,
 {
     fn default() -> Self {
-        let interpreter_params = InterpreterParams {
-            gas_costs: Default::default(),
-            max_inputs: TxParameters::DEFAULT.max_inputs,
-            contract_max_size: ContractParameters::DEFAULT.contract_max_size,
-            tx_offset: TxParameters::default().tx_offset(),
-            max_message_data_length: PredicateParameters::DEFAULT.max_message_data_length,
-            chain_id: ChainId::default(),
-            fee_params: FeeParameters::default(),
-        };
-        Self::new(S::default(), interpreter_params)
+        Self::new(S::default(), InterpreterParams::default())
     }
 }

--- a/fuel-vm/src/util.rs
+++ b/fuel-vm/src/util.rs
@@ -182,7 +182,7 @@ pub mod test_helpers {
                 builder: TransactionBuilder::script(bytecode, vec![]),
                 storage: MemoryStorage::default(),
                 block_height: Default::default(),
-                consensus_params: ConsensusParameters::standard(ChainId::default()),
+                consensus_params: ConsensusParameters::standard(),
             }
         }
 


### PR DESCRIPTION
Some follow-up improvements for the https://github.com/FuelLabs/fuel-vm/pull/514.

Also, during fixing, it found that the VM was initialized incorrectly for the predicate case. The balances should be zero.

<img width="401" alt="image" src="https://github.com/FuelLabs/fuel-vm/assets/18346821/76f49a42-e264-4623-9598-036ef7e3a639">
