### PR TITLE
Initializing WASM synchronously

### DIFF
--- a/.npm/.scripts/template/rollup.config.mjs
+++ b/.npm/.scripts/template/rollup.config.mjs
@@ -1,15 +1,17 @@
 import { wasm } from '@rollup/plugin-wasm'
 import dts from 'rollup-plugin-dts'
 
+const sync = ['src/{{NAME_UNDERSCORED}}_bg.wasm'];
+
 export default [
   {
-    plugins: [wasm({ targetEnv: 'auto-inline' })],
+    plugins: [wasm({ sync, targetEnv: 'auto-inline' })],
     input: 'src/index.js',
     output: [
       { file: 'dist/node/index.cjs', format: 'cjs' },
     ]
   }, {
-    plugins: [wasm({ targetEnv: 'auto-inline' })],
+    plugins: [wasm({ sync, targetEnv: 'auto-inline' })],
     input: 'src/index.js',
     output: [
       { file: 'dist/web/index.mjs', format: 'es' },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- [#529](https://github.com/FuelLabs/fuel-vm/pull/529): Fix WASM initialization for NPM wrapper packages.
+
 #### Breaking
 
 - [#527](https://github.com/FuelLabs/fuel-vm/pull/527): The balances are empty during predicate estimation/verification.


### PR DESCRIPTION
Ensures that the WASM binary is initialized [synchronously](https://github.com/rollup/plugins/tree/master/packages/wasm/#synchronous-modules) so that it is available right after being imported.