### PR TITLE
Fix a crash in UtxoId::from_str and TxPointer::from_str with multibyte characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - [#525](https://github.com/FuelLabs/fuel-vm/pull/525): The `$hp` register is no longer restored to it's previous value when returning from a call, making it possible to return heap-allocated types from `CALL`.
+- [#531](https://github.com/FuelLabs/fuel-vm/pull/531): UtxoId::from_str and TxPointer::from_str no longer crash on invalid input with multibyte characters. Also adds clippy lints to prevent future issues.
 
 
 #### Breaking

--- a/fuel-asm/src/lib.rs
+++ b/fuel-asm/src/lib.rs
@@ -3,6 +3,7 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "std", doc = include_str!("../README.md"))]
+#![deny(clippy::string_slice)]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
 #![deny(unused_crate_dependencies)]

--- a/fuel-crypto/src/lib.rs
+++ b/fuel-crypto/src/lib.rs
@@ -2,10 +2,11 @@
 
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![warn(missing_docs)]
 // Wrong clippy convention; check
 // https://rust-lang.github.io/api-guidelines/naming.html
 #![allow(clippy::wrong_self_convention)]
+#![deny(clippy::string_slice)]
+#![warn(missing_docs)]
 #![deny(unsafe_code)]
 #![deny(unused_crate_dependencies)]
 

--- a/fuel-tx/src/lib.rs
+++ b/fuel-tx/src/lib.rs
@@ -4,6 +4,7 @@
 // Wrong clippy convention; check
 // https://rust-lang.github.io/api-guidelines/naming.html
 #![allow(clippy::wrong_self_convention)]
+#![deny(clippy::string_slice)]
 #![deny(unused_crate_dependencies)]
 #![deny(unsafe_code)]
 

--- a/fuel-tx/src/transaction/types/utxo_id.rs
+++ b/fuel-tx/src/transaction/types/utxo_id.rs
@@ -214,4 +214,10 @@ mod tests {
         assert_eq!(utxo_id.tx_id[0], 12);
         Ok(())
     }
+
+    #[test]
+    fn from_str_utxo_id_multibyte_bug() {
+        UtxoId::from_str("0x00😎").expect_err("Should fail on incorrect input");
+        UtxoId::from_str("0x000😎").expect_err("Should fail on incorrect input");
+    }
 }

--- a/fuel-tx/src/transaction/types/utxo_id.rs
+++ b/fuel-tx/src/transaction/types/utxo_id.rs
@@ -215,6 +215,7 @@ mod tests {
         Ok(())
     }
 
+    /// See https://github.com/FuelLabs/fuel-vm/issues/521
     #[test]
     fn from_str_utxo_id_multibyte_bug() {
         UtxoId::from_str("0x00😎").expect_err("Should fail on incorrect input");

--- a/fuel-tx/src/tx_pointer.rs
+++ b/fuel-tx/src/tx_pointer.rs
@@ -196,6 +196,7 @@ fn fmt_encode_decode() {
     }
 }
 
+/// See https://github.com/FuelLabs/fuel-vm/issues/521
 #[test]
 fn decode_bug() {
     use core::str::FromStr;

--- a/fuel-tx/src/tx_pointer.rs
+++ b/fuel-tx/src/tx_pointer.rs
@@ -92,15 +92,20 @@ impl fmt::UpperHex for TxPointer {
 impl str::FromStr for TxPointer {
     type Err = &'static str;
 
+    /// TxPointer is encoded as 12 hex characters:
+    /// - 8 characters for block height
+    /// - 4 characters for tx index
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         const ERR: &str = "Invalid encoded byte";
 
-        if s.len() != 12 {
+        if s.len() != 12 || !s.is_char_boundary(8) {
             return Err(ERR)
         }
 
-        let block_height = u32::from_str_radix(&s[..8], 16).map_err(|_| ERR)?;
-        let tx_index = u16::from_str_radix(&s[8..12], 16).map_err(|_| ERR)?;
+        let (block_height, tx_index) = s.split_at(8);
+
+        let block_height = u32::from_str_radix(block_height, 16).map_err(|_| ERR)?;
+        let tx_index = u16::from_str_radix(tx_index, 16).map_err(|_| ERR)?;
 
         Ok(Self::new(block_height.into(), tx_index))
     }

--- a/fuel-tx/src/tx_pointer.rs
+++ b/fuel-tx/src/tx_pointer.rs
@@ -195,3 +195,9 @@ fn fmt_encode_decode() {
         }
     }
 }
+
+#[test]
+fn decode_bug() {
+    use core::str::FromStr;
+    TxPointer::from_str("00000😎000").expect_err("Should fail on incorrect input");
+}

--- a/fuel-vm/src/lib.rs
+++ b/fuel-vm/src/lib.rs
@@ -3,6 +3,7 @@
 #![warn(missing_docs)]
 #![deny(unsafe_code)]
 #![deny(unused_crate_dependencies)]
+#![deny(clippy::string_slice)]
 
 pub mod arith;
 pub mod backtrace;


### PR DESCRIPTION
Fixes #521. Adds clippy lints to disallow raw string slicing, so this wont happen again so easily.