### PR TITLE
Make TRO instruction revert on zero coin amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - [#525](https://github.com/FuelLabs/fuel-vm/pull/525): The `$hp` register is no longer restored to it's previous value when returning from a call, making it possible to return heap-allocated types from `CALL`.
 
-
 #### Breaking
 
 - [#514](https://github.com/FuelLabs/fuel-vm/pull/514/): Add `ChainId` and `GasCosts` to `ConsensusParameters`. 
     Break down `ConsensusParameters` into sub-structs to match usage. Change signatures of functions to ask for
     necessary fields only.
+- [#532](https://github.com/FuelLabs/fuel-vm/pull/532): The `TRO` instruction now reverts when attempting to send zero coins to an output. Panic reason of this `TransferZeroCoins`, and `TR` was changed to use the same panic reason as well.
 
 ### Fixed
 

--- a/fuel-asm/src/panic_reason.rs
+++ b/fuel-asm/src/panic_reason.rs
@@ -108,6 +108,8 @@ enum_from! {
         ArithmeticError = 0x23,
         /// The contract instruction is not allowed in predicates.
         ContractInstructionNotAllowed = 0x24,
+        /// Transfer of zero coins is not allowed.
+        TransferZeroCoins = 0x25,
     }
 }
 

--- a/fuel-vm/src/interpreter/contract.rs
+++ b/fuel-vm/src/interpreter/contract.rs
@@ -237,7 +237,7 @@ impl<'vm, S, Tx> TransferCtx<'vm, S, Tx> {
             .check(&destination)?;
 
         if amount == 0 {
-            return Err(PanicReason::NotEnoughBalance.into())
+            return Err(PanicReason::TransferZeroCoins.into())
         }
 
         let internal_context = match internal_contract(self.context, self.fp, self.memory)
@@ -314,6 +314,10 @@ impl<'vm, S, Tx> TransferCtx<'vm, S, Tx> {
         let asset_id = AssetId::try_from(&self.memory[d as usize..dx as usize])
             .expect("Unreachable! Checked memory range");
         let amount = c;
+
+        if amount == 0 {
+            return Err(PanicReason::TransferZeroCoins.into())
+        }
 
         let internal_context = match internal_contract(self.context, self.fp, self.memory)
         {

--- a/fuel-vm/src/tests/outputs.rs
+++ b/fuel-vm/src/tests/outputs.rs
@@ -357,14 +357,11 @@ fn zero_amount_transfer_out_reverts() {
         TxParameters::DEFAULT.tx_offset()
     );
 
-    let script_data: Vec<u8> = [
-        asset_id.as_ref(),
-        owner.as_ref(),
-    ]
-    .into_iter()
-    .flatten()
-    .copied()
-    .collect();
+    let script_data: Vec<u8> = [asset_id.as_ref(), owner.as_ref()]
+        .into_iter()
+        .flatten()
+        .copied()
+        .collect();
 
     // execute and get receipts
     let result = TestBuilder::new(2322u64)


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuel-vm/issues/522

This PR also adds a new PanicReason, `TransferZeroCoins`, for this specific issue. `TR` instruction previously used `NotEnoughBalance` for this situation, but it seems highly misleading.

Alternatively we could allow this and modify the spec accordingly.