### PR TITLE
Fix urls to specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ The release mostly fixes funding during the audit and integration with the bridg
 
 - [#506](https://github.com/FuelLabs/fuel-vm/pull/506): The `mint` and `burn` 
     opcodes accept a new `$rB` register. It is a sub-identifier used to generate an 
-    `AssetId` by [this rule](https://github.com/FuelLabs/fuel-specs/blob/SilentCicero-multi-token/src/identifiers/asset.md). 
+    `AssetId` by [this rule](https://github.com/FuelLabs/fuel-specs/blob/master/src/identifiers/asset.md). 
     This feature allows having multi-asset per one contract. It is a huge breaking change, and 
     after this point, `ContractId` can't be equal to `AssetId`.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 
 The repository contains crates implementing the 
-[FuelVM specification](https://github.com/FuelLabs/fuel-specs/blob/master/src/vm/index.md) 
+[FuelVM specification](https://github.com/FuelLabs/fuel-specs/blob/master/src/fuel-vm/index.md) 
 used by [fuel-core](https://github.com/FuelLabs/fuel-core) 
 and [the Sway compiler](https://github.com/FuelLabs/sway/).
 

--- a/fuel-asm/src/lib.rs
+++ b/fuel-asm/src/lib.rs
@@ -80,7 +80,7 @@ pub struct InvalidOpcode;
 
 bitflags::bitflags! {
     /// Possible values for the FLAG instruction.
-    /// See https://github.com/FuelLabs/fuel-specs/blob/master/src/vm/index.md#flags
+    /// See https://github.com/FuelLabs/fuel-specs/blob/master/src/fuel-vm/index.md#flags
     pub struct Flags: Word {
         /// If set, arithmetic errors result in setting $err instead of panicking.
         /// This includes cases where result of a computation is undefined, like
@@ -670,8 +670,8 @@ impl Imm24 {
 impl Opcode {
     /// Check if the opcode is allowed for predicates.
     ///
-    /// <https://github.com/FuelLabs/fuel-specs/blob/master/specs/vm/main.md#predicate-verification>
-    /// <https://github.com/FuelLabs/fuel-specs/blob/master/specs/vm/opcodes.md#contract-opcodes>
+    /// <https://github.com/FuelLabs/fuel-specs/blob/master/src/fuel-vm/index.md#predicate-verification>
+    /// <https://github.com/FuelLabs/fuel-specs/blob/master/src/fuel-vm/instruction-set.md#contract-instructions>
     #[allow(clippy::match_like_matches_macro)]
     pub fn is_predicate_allowed(&self) -> bool {
         use Opcode::*;

--- a/fuel-crypto/README.md
+++ b/fuel-crypto/README.md
@@ -5,7 +5,7 @@
 [![docs](https://docs.rs/fuel-crypto/badge.svg)](https://docs.rs/fuel-crypto/)
 [![discord](https://img.shields.io/badge/chat%20on-discord-orange?&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/xfpK4Pe)
 
-Fuel cryptographic primitives defined by the [specification](https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/cryptographic_primitives.md).
+Fuel cryptographic primitives defined by the [specification](https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/cryptographic-primitives.md).
 
 ## Compile features
 

--- a/fuel-crypto/src/secp256k1/signature.rs
+++ b/fuel-crypto/src/secp256k1/signature.rs
@@ -180,7 +180,7 @@ mod use_std {
         /// Sign a given message and compress the `v` to the signature
         ///
         /// The compression scheme is described in
-        /// <https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/cryptographic_primitives.md>
+        /// <https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/cryptographic-primitives.md>
         pub fn sign(secret: &SecretKey, message: &Message) -> Self {
             let secret = secret.borrow();
             let message = message.to_secp();

--- a/fuel-crypto/src/secp256r1.rs
+++ b/fuel-crypto/src/secp256r1.rs
@@ -12,7 +12,7 @@ use p256::ecdsa::{
 };
 
 /// Combines recovery id with the signature bytes. See the following link for explanation.
-/// https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/cryptographic_primitives.md#public-key-cryptography
+/// https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/cryptographic-primitives.md#ecdsa-public-key-cryptography
 /// Panics if the highest bit of byte at index 32 is set, as this indicates non-normalized
 /// signature. Panics if the recovery id is in reduced-x form.
 #[cfg(feature = "test-helpers")]
@@ -28,7 +28,7 @@ fn encode_signature(signature: Signature, recovery_id: RecoveryId) -> [u8; 64] {
 }
 
 /// Separates recovery id from the signature bytes. See the following link for
-/// explanation. https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/cryptographic_primitives.md#public-key-cryptography
+/// explanation. https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/cryptographic-primitives.md#ecdsa-public-key-cryptography
 fn decode_signature(mut signature: [u8; 64]) -> Option<(Signature, RecoveryId)> {
     let v = (signature[32] & 0x80) != 0;
     signature[32] &= 0x7f;

--- a/fuel-merkle/README.md
+++ b/fuel-merkle/README.md
@@ -6,5 +6,5 @@
 [![discord](https://img.shields.io/badge/chat%20on-discord-orange?&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/xfpK4Pe)
 
 The crate contains implementation for the Sparse Merkle Tree, Binary Merkle Tree, and Binary Merkle Sum Tree.
-[The specification](https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/cryptographic_primitives.md#merkle-trees) 
+[The specification](https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/cryptographic-primitives.md#merkle-trees) 
 contains more information on how they work inside and how they are [tested](https://github.com/FuelLabs/fuel-specs/blob/master/src/tests/index.md).

--- a/fuel-merkle/src/sum/merkle_tree.rs
+++ b/fuel-merkle/src/sum/merkle_tree.rs
@@ -37,7 +37,7 @@ pub enum MerkleTreeError {
 ///
 /// This is in contrast to the Binary Merkle Tree node, where a node has only a digest.
 ///
-/// See the [specification](https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/cryptographic_primitives.md#merkle-trees)
+/// See the [specification](https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/cryptographic-primitives.md#merkle-trees)
 /// for more details.
 ///
 /// **Details**

--- a/fuel-tx/README.md
+++ b/fuel-tx/README.md
@@ -5,6 +5,6 @@
 [![docs](https://docs.rs/fuel-tx/badge.svg)](https://docs.rs/fuel-tx/)
 [![discord](https://img.shields.io/badge/chat%20on-discord-orange?&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/xfpK4Pe)
 
-This crate contains a definition of types from the [specification](https://github.com/FuelLabs/fuel-specs/tree/master/src/protocol/tx_format),
+This crate contains a definition of types from the [specification](https://github.com/FuelLabs/fuel-specs/blob/master/src/tx-format/index.md),
 with canonical serialization and deserialization. The `Transaction` and `Checked<Tx>` type 
-implements fee calculation and [validation of rules](https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/tx_validity.md) defined by the specification.
+implements fee calculation and [validation of rules](https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/tx-validity.md) defined by the specification.

--- a/fuel-tx/src/contract.rs
+++ b/fuel-tx/src/contract.rs
@@ -29,7 +29,7 @@ use core::{
 /// The target size of Merkle tree leaves in bytes. Contract code will will be divided
 /// into chunks of this size and pushed to the Merkle tree.
 ///
-/// See https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/id/contract.md#contract-id
+/// See https://github.com/FuelLabs/fuel-specs/blob/master/src/identifiers/contract-id.md
 const LEAF_SIZE: usize = 16 * 1024;
 /// In the event that contract code cannot be divided evenly by the `LEAF_SIZE`, the
 /// remainder must be padded to the nearest multiple of 8 bytes. Padding is achieved by
@@ -65,7 +65,7 @@ impl Contract {
 
     /// Calculate the code root from a contract.
     ///
-    /// <https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/id/contract.md#contract-id>
+    /// <https://github.com/FuelLabs/fuel-specs/blob/master/src/identifiers/contract-id.md>
     pub fn root_from_code<B>(bytes: B) -> Bytes32
     where
         B: AsRef<[u8]>,
@@ -111,7 +111,7 @@ impl Contract {
 
     /// Calculate and return the contract id, provided a salt, code root and state root.
     ///
-    /// <https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/id/contract.md#contract-id>
+    /// <https://github.com/FuelLabs/fuel-specs/blob/master/src/identifiers/contract-id.md>
     pub fn id(&self, salt: &Salt, root: &Bytes32, state_root: &Bytes32) -> ContractId {
         let mut hasher = Hasher::default();
 

--- a/fuel-tx/src/transaction.rs
+++ b/fuel-tx/src/transaction.rs
@@ -82,7 +82,7 @@ pub use id::{
 /// Identification of transaction (also called transaction hash)
 pub type TxId = Bytes32;
 
-/// The fuel transaction entity https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/tx_format/transaction.md#transaction.
+/// The fuel transaction entity <https://github.com/FuelLabs/fuel-specs/blob/master/src/tx-format/transaction.md>.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, strum_macros::EnumCount)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Transaction {

--- a/fuel-tx/src/transaction/types/input/coin.rs
+++ b/fuel-tx/src/transaction/types/input/coin.rs
@@ -77,7 +77,7 @@ impl CoinSpecification for Full {
 }
 
 /// It is a full representation of the coin from the specification:
-/// https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/tx_format/input.md#inputcoin.
+/// <https://github.com/FuelLabs/fuel-specs/blob/master/src/tx-format/input.md#inputcoin>.
 ///
 /// The specification defines the layout of the [`Coin`] in the serialized form for the
 /// `fuel-vm`. But on the business logic level, we don't use all fields at the same time.
@@ -126,7 +126,7 @@ where
     Specification: CoinSpecification,
 {
     /// The "Note" section from the specification:
-    /// https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/tx_format/input.md#inputcoin.
+    /// <https://github.com/FuelLabs/fuel-specs/blob/master/src/tx-format/input.md#inputcoin>.
     pub fn prepare_sign(&mut self) {
         core::mem::take(&mut self.tx_pointer);
         if let Some(predicate_gas_used_field) = self.predicate_gas_used.as_mut_field() {

--- a/fuel-tx/src/transaction/types/input/contract.rs
+++ b/fuel-tx/src/transaction/types/input/contract.rs
@@ -17,7 +17,7 @@ use fuel_types::{
 };
 
 /// It is a full representation of the contract input from the specification:
-/// https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/tx_format/input.md#inputcontract.
+/// <https://github.com/FuelLabs/fuel-specs/blob/master/src/tx-format/input.md#inputcontract>.
 ///
 /// The specification defines the layout of the [`Contract`] in the serialized form for
 /// the `fuel-vm`.
@@ -33,7 +33,7 @@ pub struct Contract {
 
 impl Contract {
     /// The "Note" section from the specification:
-    /// https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/tx_format/input.md#inputcontract.
+    /// <https://github.com/FuelLabs/fuel-specs/blob/master/src/tx-format/input.md#inputcontract>.
     pub fn prepare_sign(&mut self) {
         core::mem::take(&mut self.utxo_id);
         core::mem::take(&mut self.balance_root);

--- a/fuel-tx/src/transaction/types/input/message.rs
+++ b/fuel-tx/src/transaction/types/input/message.rs
@@ -136,7 +136,7 @@ pub mod specifications {
 }
 
 /// It is a full representation of the message from the specification:
-/// https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/tx_format/input.md#inputmessage.
+/// <https://github.com/FuelLabs/fuel-specs/blob/master/src/tx-format/input.md#inputmessage>.
 ///
 /// The specification defines the layout of the [`Message`] in the serialized form for
 /// the `fuel-vm`. But on the business logic level, we don't use all fields at the same

--- a/fuel-tx/src/transaction/types/mint.rs
+++ b/fuel-tx/src/transaction/types/mint.rs
@@ -85,7 +85,7 @@ impl MintMetadata {
 }
 
 /// The definition of the `Mint` transaction from the specification:
-/// https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/tx_format/transaction.md#transactionmint
+/// <https://github.com/FuelLabs/fuel-specs/blob/master/src/tx-format/transaction.md#transactionmint>
 ///
 /// This transaction can be created by the block producer and included in the block only
 /// by it.

--- a/fuel-tx/src/transaction/validity.rs
+++ b/fuel-tx/src/transaction/validity.rs
@@ -265,7 +265,7 @@ pub trait FormatValidityChecks {
     fn check_signatures(&self, chain_id: &ChainId) -> Result<(), CheckError>;
 
     /// Validates the transactions according to rules from the specification:
-    /// https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/tx_format/transaction.md#transaction
+    /// <https://github.com/FuelLabs/fuel-specs/blob/master/src/tx-format/transaction.md>
     fn check_without_signatures(
         &self,
         block_height: BlockHeight,

--- a/fuel-types/src/array_types.rs
+++ b/fuel-types/src/array_types.rs
@@ -355,7 +355,7 @@ key_with_big_array!(Bytes64, 64);
 impl ContractId {
     /// Seed for the calculation of the contract id from its code.
     ///
-    /// <https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/id/contract.md>
+    /// <https://github.com/FuelLabs/fuel-specs/blob/master/src/identifiers/contract-id.md>
     pub const SEED: [u8; 4] = 0x4655454C_u32.to_be_bytes();
 }
 

--- a/fuel-vm/src/call.rs
+++ b/fuel-vm/src/call.rs
@@ -31,7 +31,7 @@ use std::io::{
 /// Call structure representation, composed of a called contract `to` and two
 /// word arguments.
 ///
-/// <https://github.com/FuelLabs/fuel-specs/blob/master/src/vm/instruction_set.md#call-call-contract>
+/// <https://github.com/FuelLabs/fuel-specs/blob/master/src/fuel-vm/instruction-set.md#call-call-contract>
 pub struct Call {
     to: ContractId,
     a: Word,
@@ -152,7 +152,7 @@ impl TryFrom<&[u8]> for Call {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 /// Call frame representation in the VM stack.
 ///
-/// <https://github.com/FuelLabs/fuel-specs/blob/master/src/vm/index.md#call-frames>
+/// <https://github.com/FuelLabs/fuel-specs/blob/master/src/fuel-vm/index.md#call-frames>
 pub struct CallFrame {
     to: ContractId,
     asset_id: AssetId,

--- a/fuel-vm/src/checked_transaction.rs
+++ b/fuel-vm/src/checked_transaction.rs
@@ -39,7 +39,7 @@ bitflags::bitflags! {
     /// Possible types of transaction checks.
     pub struct Checks: u32 {
         /// Basic checks defined in the specification for each transaction:
-        /// https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/tx_format/transaction.md#transaction
+        /// https://github.com/FuelLabs/fuel-specs/blob/master/src/tx-format/transaction.md#transaction
         const Basic         = 0b00000001;
         /// Check that signature in the transactions are valid.
         const Signatures    = 0b00000010;

--- a/fuel-vm/src/checked_transaction/types.rs
+++ b/fuel-vm/src/checked_transaction/types.rs
@@ -12,7 +12,7 @@ use std::collections::BTreeMap;
 
 /// The spendable unrestricted initial assets.
 /// More information about it in the specification:
-/// https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/tx_validity.md#sufficient-balance
+/// <https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/tx-validity.md#sufficient-balance>
 #[derive(Default, Debug, Clone, Eq, PartialEq, Hash)]
 pub struct NonRetryableFreeBalances(pub(crate) BTreeMap<AssetId, Word>);
 
@@ -32,7 +32,7 @@ impl core::ops::Deref for NonRetryableFreeBalances {
 
 /// The spendable only during execution [`AssetId::BASE`] asset.
 /// More information about it in the specification:
-/// https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/tx_validity.md#sufficient-balance
+/// <https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/tx-validity.md#sufficient-balance>
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct RetryableAmount(pub(crate) Word);
 


### PR DESCRIPTION
After the reshuffling of the specifications to comply with the new documentation hub format, many of the links in this repo broke. This PR updates all the links to be correct and valid.