### PR TITLE
Release v0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.36.0]
+
 ### Changed
 
 - [#525](https://github.com/FuelLabs/fuel-vm/pull/525): The `$hp` register is no longer restored to it's previous value when returning from a call, making it possible to return heap-allocated types from `CALL`.
-- [#531](https://github.com/FuelLabs/fuel-vm/pull/531): UtxoId::from_str and TxPointer::from_str no longer crash on invalid input with multibyte characters. Also adds clippy lints to prevent future issues.
-- [#535](https://github.com/FuelLabs/fuel-vm/pull/535): Add better test coverage for TR and TRO
+- [#535](https://github.com/FuelLabs/fuel-vm/pull/535): Add better test coverage for TR and TRO.
 
 #### Breaking
 
@@ -21,9 +22,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- [#511](https://github.com/FuelLabs/fuel-vm/pull/511): Changes multiple panic reasons to be more accurate, and internally refactors instruction fetch logic to be less error-prone.
+
 - [#529](https://github.com/FuelLabs/fuel-vm/pull/529) [#534](https://github.com/FuelLabs/fuel-vm/pull/534): Enforcing async WASM initialization for all NPM wrapper packages.
 
-- [#511](https://github.com/FuelLabs/fuel-vm/pull/511): Changes multiple panic reasons to be more accurate, and internally refactors instruction fetch logic to be less error-prone.
+- [#531](https://github.com/FuelLabs/fuel-vm/pull/531): UtxoId::from_str and TxPointer::from_str no longer crash on invalid input with multibyte characters. Also adds clippy lints to prevent future issues.
 
 #### Breaking
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,15 +18,15 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.35.3"
+version = "0.36.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.35.3", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.35.3", path = "fuel-crypto", default-features = false }
-fuel-merkle = { version = "0.35.3", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.35.3", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.35.3", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.35.3", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.35.3", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.36.0", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.36.0", path = "fuel-crypto", default-features = false }
+fuel-merkle = { version = "0.36.0", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.36.0", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.36.0", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.36.0", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.36.0", path = "fuel-vm", default-features = false }
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
## Version 0.36.0

### Changed

- [#525](https://github.com/FuelLabs/fuel-vm/pull/525): The `$hp` register is no longer restored to it's previous value when returning from a call, making it possible to return heap-allocated types from `CALL`.
- [#535](https://github.com/FuelLabs/fuel-vm/pull/535): Add better test coverage for TR and TRO.

#### Breaking

- [#514](https://github.com/FuelLabs/fuel-vm/pull/514/): Add `ChainId` and `GasCosts` to `ConsensusParameters`. 
    Break down `ConsensusParameters` into sub-structs to match usage. Change signatures of functions to ask for
    necessary fields only.
- [#532](https://github.com/FuelLabs/fuel-vm/pull/532): The `TRO` instruction now reverts when attempting to send zero coins to an output. Panic reason of this `TransferZeroCoins`, and `TR` was changed to use the same panic reason as well.

### Fixed

- [#511](https://github.com/FuelLabs/fuel-vm/pull/511): Changes multiple panic reasons to be more accurate, and internally refactors instruction fetch logic to be less error-prone.

- [#529](https://github.com/FuelLabs/fuel-vm/pull/529) [#534](https://github.com/FuelLabs/fuel-vm/pull/534): Enforcing async WASM initialization for all NPM wrapper packages.

- [#531](https://github.com/FuelLabs/fuel-vm/pull/531): UtxoId::from_str and TxPointer::from_str no longer crash on invalid input with multibyte characters. Also adds clippy lints to prevent future issues.

#### Breaking

- [#527](https://github.com/FuelLabs/fuel-vm/pull/527): The balances are empty during predicate estimation/verification.

## What's Changed
* Decompose consensus params by @MitchTurner in https://github.com/FuelLabs/fuel-vm/pull/514
* Make `ConsensusParameters` Serialize/Derserialize again by @MitchTurner in https://github.com/FuelLabs/fuel-vm/pull/526
* Follow-up clean ups and fixed for the VM initialization by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/527
* Add a CI action to enforce changelog modification by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/528
* Initializing WASM synchronously by @arboleya in https://github.com/FuelLabs/fuel-vm/pull/529
* Reimplement `with_params` method for TxBuilder by @MitchTurner in https://github.com/FuelLabs/fuel-vm/pull/530
* Do not restore $hp when returning from a context by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/525
* Make TRO instruction revert on zero coin amount by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/532
* Fix a crash in UtxoId::from_str and TxPointer::from_str with multibyte characters by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/531
* Forcing async wasm initialization by @arboleya in https://github.com/FuelLabs/fuel-vm/pull/534
* Duplicate release 0.35.2 by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/540
* Add more test cases for `transfer` and `transfer_output` by @MitchTurner in https://github.com/FuelLabs/fuel-vm/pull/535
* Duplicate changes from 0.35.3 release by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/543
* Return correct PanicReason on memory-related panics by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/511
* Add push/pop instructions by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/498
* Fix urls to specification by @Voxelot in https://github.com/FuelLabs/fuel-vm/pull/544

## New Contributors
* @MitchTurner made their first contribution in https://github.com/FuelLabs/fuel-vm/pull/514

**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.35.3...v0.36.0