### PR TITLE
Instruction debug fmt improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- [#546](https://github.com/FuelLabs/fuel-vm/pull/546): Improve debug formatting of instruction in panic receipts.
+
 ## [Version 0.36.0]
 
 ### Changed

--- a/fuel-asm/src/macros.rs
+++ b/fuel-asm/src/macros.rs
@@ -903,7 +903,7 @@ macro_rules! op_debug_fmt {
         fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
             let ra = self.unpack();
             f.debug_struct(stringify!($Op))
-                .field(stringify!($ra), &u8::from(ra))
+                .field(stringify!($ra), &format_args!("{:#02x}", u8::from(ra)))
                 .finish()
         }
     };
@@ -911,8 +911,8 @@ macro_rules! op_debug_fmt {
         fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
             let (ra, rb) = self.unpack();
             f.debug_struct(stringify!($Op))
-                .field(stringify!($ra), &u8::from(ra))
-                .field(stringify!($rb), &u8::from(rb))
+                .field(stringify!($ra), &format_args!("{:#02x}", u8::from(ra)))
+                .field(stringify!($rb), &format_args!("{:#02x}", u8::from(rb)))
                 .finish()
         }
     };
@@ -920,9 +920,9 @@ macro_rules! op_debug_fmt {
         fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
             let (ra, rb, rc) = self.unpack();
             f.debug_struct(stringify!($Op))
-                .field(stringify!($ra), &u8::from(ra))
-                .field(stringify!($rb), &u8::from(rb))
-                .field(stringify!($rc), &u8::from(rc))
+                .field(stringify!($ra), &format_args!("{:#02x}", u8::from(ra)))
+                .field(stringify!($rb), &format_args!("{:#02x}", u8::from(rb)))
+                .field(stringify!($rc), &format_args!("{:#02x}", u8::from(rc)))
                 .finish()
         }
     };
@@ -932,10 +932,10 @@ macro_rules! op_debug_fmt {
         fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
             let (ra, rb, rc, rd) = self.unpack();
             f.debug_struct(stringify!($Op))
-                .field(stringify!($ra), &u8::from(ra))
-                .field(stringify!($rb), &u8::from(rb))
-                .field(stringify!($rc), &u8::from(rc))
-                .field(stringify!($rd), &u8::from(rd))
+                .field(stringify!($ra), &format_args!("{:#02x}", u8::from(ra)))
+                .field(stringify!($rb), &format_args!("{:#02x}", u8::from(rb)))
+                .field(stringify!($rc), &format_args!("{:#02x}", u8::from(rc)))
+                .field(stringify!($rd), &format_args!("{:#02x}", u8::from(rd)))
                 .finish()
         }
     };
@@ -945,9 +945,9 @@ macro_rules! op_debug_fmt {
         fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
             let (ra, rb, rc, imm) = self.unpack();
             f.debug_struct(stringify!($Op))
-                .field(stringify!($ra), &u8::from(ra))
-                .field(stringify!($rb), &u8::from(rb))
-                .field(stringify!($rc), &u8::from(rc))
+                .field(stringify!($ra), &format_args!("{:#02x}", u8::from(ra)))
+                .field(stringify!($rb), &format_args!("{:#02x}", u8::from(rb)))
+                .field(stringify!($rc), &format_args!("{:#02x}", u8::from(rc)))
                 .field(stringify!($imm), &u8::from(imm))
                 .finish()
         }
@@ -956,8 +956,8 @@ macro_rules! op_debug_fmt {
         fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
             let (ra, rb, imm) = self.unpack();
             f.debug_struct(stringify!($Op))
-                .field(stringify!($ra), &u8::from(ra))
-                .field(stringify!($rb), &u8::from(rb))
+                .field(stringify!($ra), &format_args!("{:#02x}", u8::from(ra)))
+                .field(stringify!($rb), &format_args!("{:#02x}", u8::from(rb)))
                 .field(stringify!($imm), &u16::from(imm))
                 .finish()
         }
@@ -966,7 +966,7 @@ macro_rules! op_debug_fmt {
         fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
             let (ra, imm) = self.unpack();
             f.debug_struct(stringify!($Op))
-                .field(stringify!($ra), &u8::from(ra))
+                .field(stringify!($ra), &format_args!("{:#02x}", u8::from(ra)))
                 .field(stringify!($imm), &u32::from(imm))
                 .finish()
         }

--- a/fuel-asm/src/panic_instruction.rs
+++ b/fuel-asm/src/panic_instruction.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 use crate::{
     Instruction,
     PanicReason,
@@ -5,7 +7,7 @@ use crate::{
     Word,
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "typescript", wasm_bindgen::prelude::wasm_bindgen)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
@@ -32,6 +34,35 @@ impl PanicInstruction {
     /// Underlying instruction
     pub const fn instruction(&self) -> &RawInstruction {
         &self.instruction
+    }
+}
+
+/// Helper struct to debug-format a `RawInstruction` in `PanicInstruction::fmt`.
+struct InstructionDbg(RawInstruction);
+impl fmt::Debug for InstructionDbg {
+    /// Formats like this: `MOVI { dst: 32, val: 32 } (bytes 72 80 00 20)`}`
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match Instruction::try_from(self.0) {
+            Ok(instr) => write!(f, "{:?}", instr)?,
+            Err(_) => write!(f, "Unknown")?,
+        };
+        write!(f, " (bytes ")?;
+        for (i, byte) in self.0.to_be_bytes().iter().enumerate() {
+            if i != 0 {
+                write!(f, " ")?;
+            }
+            write!(f, "{:02x}", byte)?;
+        }
+        write!(f, ")")
+    }
+}
+
+impl fmt::Debug for PanicInstruction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PanicInstruction")
+            .field("reason", &self.reason)
+            .field("instruction", &InstructionDbg(self.instruction))
+            .finish()
     }
 }
 

--- a/fuel-asm/src/panic_instruction.rs
+++ b/fuel-asm/src/panic_instruction.rs
@@ -40,13 +40,13 @@ impl PanicInstruction {
 /// Helper struct to debug-format a `RawInstruction` in `PanicInstruction::fmt`.
 struct InstructionDbg(RawInstruction);
 impl fmt::Debug for InstructionDbg {
-    /// Formats like this: `MOVI { dst: 32, val: 32 } (bytes 72 80 00 20)`}`
+    /// Formats like this: `MOVI { dst: 32, val: 32 } (bytes: 72 80 00 20)`}`
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match Instruction::try_from(self.0) {
             Ok(instr) => write!(f, "{:?}", instr)?,
             Err(_) => write!(f, "Unknown")?,
         };
-        write!(f, " (bytes ")?;
+        write!(f, " (bytes: ")?;
         for (i, byte) in self.0.to_be_bytes().iter().enumerate() {
             if i != 0 {
                 write!(f, " ")?;


### PR DESCRIPTION
Currently the `reason.instruction` sub-field of `PanicInstruction` is just a raw integer representation of the instruction bytes. This PR changes the `Debug` implementation to decode the instruction when possible. It will also show the bytes in hexadecimal format, which is more useful for debugging as it can be used to spot the instruction in a hexdump, and it shows the opcode byte separately.

This PR also changes the debug format of register (non-immediate) operands to be hexadecimal, as it is the established convention (e.g. the specification lists registers using hex values, and do does most of the test code). 

### Before

```rust
reason: PanicInstruction {
    reason: OutOfGas,
    instruction: 1920991264,
},
```

```rust
reason: PanicInstruction {
    reason: ErrorFlag,
    instruction: 0,
},
```

### After

```rust
reason: PanicInstruction {
    reason: OutOfGas,
    instruction: MOVI { dst: 0x20, val: 32 } (bytes 72 80 00 20),
}
```

```rust
reason: PanicInstruction {
    reason: ErrorFlag,
    instruction: Unknown (bytes 00 00 00 00),
},
```

