### PR TITLE
Create Release `0.36.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - [#546](https://github.com/FuelLabs/fuel-vm/pull/546): Improve debug formatting of instruction in panic receipts.
-- [#524](https://github.com/FuelLabs/fuel-vm/pull/524): Fix a crash in `CCP` instruction when overflowing contract bounds. Fix a bug in `CCP` where overflowing contract bounds in a different way would not actually copy the contract bytes, but just zeroes out the section. Fix a bug in `LDC` where it would revert the transaction when the contract bounds were exceeded, when it's just supposed to fill the rest of the bytes with zeroes.
 
 ### Fixed
 
 - [#547](https://github.com/FuelLabs/fuel-vm/pull/547): Bump `ed25519-dalek` to `2.0.0` to deal with RustSec Advisory 
+- [#524](https://github.com/FuelLabs/fuel-vm/pull/524): Fix a crash in `CCP` instruction when overflowing contract bounds. Fix a bug in `CCP` where overflowing contract bounds in a different way would not actually copy the contract bytes, but just zeroes out the section. Fix a bug in `LDC` where it would revert the transaction when the contract bounds were exceeded, when it's just supposed to fill the rest of the bytes with zeroes.
 
 
 ## [Version 0.36.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.36.1]
+
 ### Changed
 
 - [#546](https://github.com/FuelLabs/fuel-vm/pull/546): Improve debug formatting of instruction in panic receipts.
+- [#524](https://github.com/FuelLabs/fuel-vm/pull/524): Fix a crash in `CCP` instruction when overflowing contract bounds. Fix a bug in `CCP` where overflowing contract bounds in a different way would not actually copy the contract bytes, but just zeroes out the section. Fix a bug in `LDC` where it would revert the transaction when the contract bounds were exceeded, when it's just supposed to fill the rest of the bytes with zeroes.
 
 ### Fixed
 
 - [#547](https://github.com/FuelLabs/fuel-vm/pull/547): Bump `ed25519-dalek` to `2.0.0` to deal with RustSec Advisory 
 
-#### Breaking
-
-- [#524](https://github.com/FuelLabs/fuel-vm/pull/524): Fix a crash in `CCP` instruction when overflowing contract bounds. Fix a bug in `CCP` where overflowing contract bounds in a different way would not actually copy the contract bytes, but just zeroes out the section. Fix a bug in `LDC` where it would revert the transaction when the contract bounds were exceeded, when it's just supposed to fill the rest of the bytes with zeroes.
 
 ## [Version 0.36.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,15 +18,15 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.36.0"
+version = "0.36.1"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.36.0", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.36.0", path = "fuel-crypto", default-features = false }
-fuel-merkle = { version = "0.36.0", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.36.0", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.36.0", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.36.0", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.36.0", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.36.1", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.36.1", path = "fuel-crypto", default-features = false }
+fuel-merkle = { version = "0.36.1", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.36.1", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.36.1", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.36.1", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.36.1", path = "fuel-vm", default-features = false }
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
## [Version 0.36.1]

### Changed

- [#546](https://github.com/FuelLabs/fuel-vm/pull/546): Improve debug formatting of instruction in panic receipts.

### Fixed

- [#547](https://github.com/FuelLabs/fuel-vm/pull/547): Bump `ed25519-dalek` to `2.0.0` to deal with RustSec Advisory 
- [#524](https://github.com/FuelLabs/fuel-vm/pull/524): Fix a crash in `CCP` instruction when overflowing contract bounds. Fix a bug in `CCP` where overflowing contract bounds in a different way would not actually copy the contract bytes, but just zeroes out the section. Fix a bug in `LDC` where it would revert the transaction when the contract bounds were exceeded, when it's just supposed to fill the rest of the bytes with zeroes.

## What's Changed
* Instruction debug fmt improvements by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/546
* Fix a crash in CCP and zero-filling issues in CCP and LDC by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/524
* Bump dalek version because of RustSec Advisory by @MitchTurner in https://github.com/FuelLabs/fuel-vm/pull/547


**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.36.0...v0.36.1