### PR TITLE
fix: Fixed length input for BMT `node_sum`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- [#574](https://github.com/FuelLabs/fuel-vm/pull/574): Enforce fixed 32-byte input length for LHS and RHS inputs to the BMT's internal node sum.
 - [#547](https://github.com/FuelLabs/fuel-vm/pull/547): Bump `ed25519-dalek` to `2.0.0` to deal with RustSec Advisory. 
 
 #### Breaking

--- a/fuel-merkle/src/binary/hash.rs
+++ b/fuel-merkle/src/binary/hash.rs
@@ -17,7 +17,7 @@ pub const fn empty_sum() -> &'static Bytes32 {
 
 // Merkle tree hash of an n-element list D[n]
 // MTH(D[n]) = Hash(0x01 || MTH(D[0:k]) || MTH(D[k:n])
-pub fn node_sum(lhs_data: &[u8], rhs_data: &[u8]) -> Bytes32 {
+pub fn node_sum(lhs_data: &Bytes32, rhs_data: &Bytes32) -> Bytes32 {
     let mut hash = Hash::new();
 
     hash.update(Prefix::Node);


### PR DESCRIPTION
Related issues:
- Closes https://github.com/FuelLabs/fuel-vm/issues/556

This PR enforces all inputs to the internal `node_sum` function to be `Bytes32`.