### PR TITLE
Update CI RUST_VERSION to 1.72.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_VERSION: 1.72.0
-  NIGHTLY_RUST_VERSION: nightly-2023-05-23
+  NIGHTLY_RUST_VERSION: nightly-2023-08-28
 
 jobs:
   check-changelog:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.69.0
+  RUST_VERSION: 1.72.0
   NIGHTLY_RUST_VERSION: nightly-2023-05-23
 
 jobs:

--- a/ci_checks.sh
+++ b/ci_checks.sh
@@ -3,7 +3,7 @@
 # The script runs almost all CI checks locally.
 #
 # Requires installed:
-# - Rust `1.69.0`
+# - Rust `1.72.0`
 # - Nightly rust formatter
 # - `rustup target add thumbv6m-none-eabi`
 # - `rustup target add wasm32-unknown-unknown`

--- a/fuel-vm/src/interpreter/balances.rs
+++ b/fuel-vm/src/interpreter/balances.rs
@@ -291,7 +291,7 @@ fn try_from_iter_wont_overflow() {
 
     // Aggregated sum check
     let balances = vec![(a, u64::MAX), (b, 15), (c, 0), (b, 1)];
-    let balances_aggregated = vec![(a, u64::MAX), (b, 16), (c, 0)];
+    let balances_aggregated = [(a, u64::MAX), (b, 16), (c, 0)];
     let runtime_balances =
         RuntimeBalances::try_from_iter(balances).expect("failed to create balance set");
 

--- a/fuel-vm/src/interpreter/balances.rs
+++ b/fuel-vm/src/interpreter/balances.rs
@@ -77,7 +77,7 @@ impl TryFrom<InitialBalances> for RuntimeBalances {
                 .checked_add(*retryable_amount)
                 .ok_or(CheckError::ArithmeticOverflow)?;
         }
-        Self::try_from_iter(balances.into_iter())
+        Self::try_from_iter(balances)
     }
 }
 

--- a/fuel-vm/src/interpreter/blockchain/code_tests.rs
+++ b/fuel-vm/src/interpreter/blockchain/code_tests.rs
@@ -32,7 +32,7 @@ fn test_load_contract() -> Result<(), RuntimeError> {
         .unwrap();
 
     let mut panic_context = PanicContext::None;
-    let input_contracts = vec![contract_id];
+    let input_contracts = [contract_id];
     let input = LoadContractCodeCtx {
         contract_max_size: 100,
         storage: &storage,
@@ -70,7 +70,7 @@ fn test_code_copy() -> Result<(), RuntimeError> {
         .storage_contract_insert(&contract_id, &Contract::from(vec![5u8; 400]))
         .unwrap();
 
-    let input_contracts = vec![contract_id];
+    let input_contracts = [contract_id];
     let mut panic_context = PanicContext::None;
     let input = CodeCopyCtx {
         storage: &storage,

--- a/fuel-vm/src/interpreter/blockchain/other_tests.rs
+++ b/fuel-vm/src/interpreter/blockchain/other_tests.rs
@@ -238,7 +238,7 @@ fn test_code_root() {
         },
     };
     let mut pc = 4;
-    let input_contracts = vec![contract_id];
+    let input_contracts = [contract_id];
     let mut panic_context = PanicContext::None;
     CodeRootCtx {
         memory: &mut memory,
@@ -312,7 +312,7 @@ fn test_code_size() {
     let is = 0;
     let mut cgas = 0;
     let mut ggas = 0;
-    let input_contract = vec![contract_id];
+    let input_contract = [contract_id];
     let mut panic_context = PanicContext::None;
     let input = CodeSizeCtx {
         storage: &mut storage,

--- a/fuel-vm/src/interpreter/blockchain/smo_tests.rs
+++ b/fuel-vm/src/interpreter/blockchain/smo_tests.rs
@@ -214,7 +214,7 @@ fn test_smo(
         )
         .unwrap();
     let mut balances =
-        RuntimeBalances::try_from_iter([(asset, initial_balance)].into_iter())
+        RuntimeBalances::try_from_iter([(asset, initial_balance)])
             .expect("Should be valid balance");
     let fp = 0;
     let mut pc = 0;

--- a/fuel-vm/src/interpreter/blockchain/smo_tests.rs
+++ b/fuel-vm/src/interpreter/blockchain/smo_tests.rs
@@ -213,9 +213,8 @@ fn test_smo(
             initial_balance,
         )
         .unwrap();
-    let mut balances =
-        RuntimeBalances::try_from_iter([(asset, initial_balance)])
-            .expect("Should be valid balance");
+    let mut balances = RuntimeBalances::try_from_iter([(asset, initial_balance)])
+        .expect("Should be valid balance");
     let fp = 0;
     let mut pc = 0;
     let input = MessageOutputCtx {

--- a/fuel-vm/src/tests/blockchain.rs
+++ b/fuel-vm/src/tests/blockchain.rs
@@ -132,10 +132,10 @@ fn state_read_write() {
 
     let program = function_selector
         .into_iter()
-        .chain(call_arguments_parser.into_iter())
-        .chain(routine_add_word_to_state.into_iter())
-        .chain(routine_unpack_and_xor_limbs_into_state.into_iter())
-        .chain(invalid_call.into_iter())
+        .chain(call_arguments_parser)
+        .chain(routine_add_word_to_state)
+        .chain(routine_unpack_and_xor_limbs_into_state)
+        .chain(invalid_call)
         .collect_vec();
 
     let contract_id = test_context.setup_contract(program, None, None).contract_id;

--- a/fuel-vm/src/tests/flow.rs
+++ b/fuel-vm/src/tests/flow.rs
@@ -341,7 +341,7 @@ fn revert() {
 
     let program = call_arguments_parser
         .into_iter()
-        .chain(routine_add_word_to_state.into_iter())
+        .chain(routine_add_word_to_state)
         .collect_vec();
 
     let contract_id = test_context.setup_contract(program, None, None).contract_id;

--- a/fuel-vm/src/tests/predicate.rs
+++ b/fuel-vm/src/tests/predicate.rs
@@ -163,7 +163,8 @@ async fn predicate() {
     let wrong_data = wrong_data.to_be_bytes().to_vec();
 
     // A script that will succeed only if the argument is 0x23
-    let predicate = [op::movi(0x10, 0x11),
+    let predicate = [
+        op::movi(0x10, 0x11),
         op::addi(0x11, 0x10, 0x12),
         op::movi(0x12, 0x08),
         op::aloc(0x12),
@@ -172,7 +173,8 @@ async fn predicate() {
         op::movi(0x10, 0x08),
         op::gtf_args(0x11, 0, GTFArgs::InputCoinPredicateData),
         op::meq(0x10, 0x11, 0x12, 0x10),
-        op::ret(0x10)];
+        op::ret(0x10),
+    ];
 
     assert!(execute_predicate(predicate.iter().copied(), expected_data, 0).await);
     assert!(!execute_predicate(predicate.iter().copied(), wrong_data, 0).await);

--- a/fuel-vm/src/tests/predicate.rs
+++ b/fuel-vm/src/tests/predicate.rs
@@ -163,8 +163,7 @@ async fn predicate() {
     let wrong_data = wrong_data.to_be_bytes().to_vec();
 
     // A script that will succeed only if the argument is 0x23
-    let predicate = vec![
-        op::movi(0x10, 0x11),
+    let predicate = [op::movi(0x10, 0x11),
         op::addi(0x11, 0x10, 0x12),
         op::movi(0x12, 0x08),
         op::aloc(0x12),
@@ -173,8 +172,7 @@ async fn predicate() {
         op::movi(0x10, 0x08),
         op::gtf_args(0x11, 0, GTFArgs::InputCoinPredicateData),
         op::meq(0x10, 0x11, 0x12, 0x10),
-        op::ret(0x10),
-    ];
+        op::ret(0x10)];
 
     assert!(execute_predicate(predicate.iter().copied(), expected_data, 0).await);
     assert!(!execute_predicate(predicate.iter().copied(), wrong_data, 0).await);


### PR DESCRIPTION
Currently, the `fuel-vm` CI is failing because `clap v4.4.1` requires `rustc 1.70.0` or newer. This PR updates the CI's stable Rust version to 1.72.0 and nightly Rust version to 1.74.0 2023-08-28.

See https://github.com/FuelLabs/fuel-vm/actions/runs/6013665712/job/16311620446?pr=574 for example of this failure.