### PR TITLE
feat: Impl `fmt::Display` for canonical Error

### DIFF
--- a/fuel-types/src/canonical.rs
+++ b/fuel-types/src/canonical.rs
@@ -7,6 +7,7 @@
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
+use core::fmt;
 
 use core::mem::MaybeUninit;
 pub use fuel_derive::{
@@ -28,6 +29,27 @@ pub enum Error {
     AllocationLimit,
     /// Unknown error.
     Unknown(&'static str),
+}
+
+impl Error {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            Error::BufferIsTooShort => "buffer is too short",
+            Error::UnknownDiscriminant => "unknown discriminant",
+            Error::InvalidPrefix => {
+                "prefix set with #[canonical(prefix = ...)] was invalid"
+            }
+            Error::AllocationLimit => "allocation too large",
+            Error::Unknown(str) => str,
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    /// Shows a human-readable description of the `Error`.
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.write_str(self.as_str())
+    }
 }
 
 /// Allows writing of data.


### PR DESCRIPTION
Progress towards upgrading `fuel-vm` inside `fuel-core`:

This PR adds `fmt::Display` to `canonical::Error`. This is helpful because it allows `canonical::Error` to be used seamlessly in places where it is replacing `std::io::Error`. Specific areas include:
```
    async fn estimate_predicates(
        &self,
        ctx: &Context<'_>,
        tx: HexString,
    ) -> async_graphql::Result<Transaction> {
        let mut tx = FuelTx::from_bytes(&tx.0)?;
        ...
```

This example requires that the possible error returned by `from_bytes(..)` implements `Display`. Without this implementation, the code will fail to compile.

With this change, the [upgrade branch](https://github.com/FuelLabs/fuel-core/pull/1338) compiles locally without error or warning.