### PR TITLE
fix: Organize `ConsensusParameters` gas costs in alphabetical order

### DIFF
--- a/fuel-tx/src/transaction/consensus_parameters/gas.rs
+++ b/fuel-tx/src/transaction/consensus_parameters/gas.rs
@@ -299,11 +299,10 @@ pub struct GasCostsValues {
     pub xori: Word,
 
     // Dependent
-    pub k256: DependentCost,
-    pub s256: DependentCost,
     pub call: DependentCost,
     pub ccp: DependentCost,
     pub csiz: DependentCost,
+    pub k256: DependentCost,
     pub ldc: DependentCost,
     pub logd: DependentCost,
     pub mcl: DependentCost,
@@ -313,9 +312,10 @@ pub struct GasCostsValues {
     pub meq: DependentCost,
     #[cfg_attr(feature = "serde", serde(rename = "retd_contract"))]
     pub retd: DependentCost,
+    pub s256: DependentCost,
+    pub scwq: DependentCost,
     pub smo: DependentCost,
     pub srwq: DependentCost,
-    pub scwq: DependentCost,
     pub swwq: DependentCost,
 }
 
@@ -440,11 +440,10 @@ impl GasCostsValues {
             wqmm: 0,
             xor: 0,
             xori: 0,
-            k256: DependentCost::free(),
-            s256: DependentCost::free(),
             call: DependentCost::free(),
             ccp: DependentCost::free(),
             csiz: DependentCost::free(),
+            k256: DependentCost::free(),
             ldc: DependentCost::free(),
             logd: DependentCost::free(),
             mcl: DependentCost::free(),
@@ -453,9 +452,10 @@ impl GasCostsValues {
             mcpi: DependentCost::free(),
             meq: DependentCost::free(),
             retd: DependentCost::free(),
+            s256: DependentCost::free(),
+            scwq: DependentCost::free(),
             smo: DependentCost::free(),
             srwq: DependentCost::free(),
-            scwq: DependentCost::free(),
             swwq: DependentCost::free(),
         }
     }
@@ -552,11 +552,10 @@ impl GasCostsValues {
             wqmm: 1,
             xor: 1,
             xori: 1,
-            k256: DependentCost::unit(),
-            s256: DependentCost::unit(),
             call: DependentCost::unit(),
             ccp: DependentCost::unit(),
             csiz: DependentCost::unit(),
+            k256: DependentCost::unit(),
             ldc: DependentCost::unit(),
             logd: DependentCost::unit(),
             mcl: DependentCost::unit(),
@@ -565,9 +564,10 @@ impl GasCostsValues {
             mcpi: DependentCost::unit(),
             meq: DependentCost::unit(),
             retd: DependentCost::unit(),
+            s256: DependentCost::unit(),
+            scwq: DependentCost::unit(),
             smo: DependentCost::unit(),
             srwq: DependentCost::unit(),
-            scwq: DependentCost::unit(),
             swwq: DependentCost::unit(),
         }
     }


### PR DESCRIPTION
Currently some gas costs are not presented in alphabetical order, creating confusion around the way the chainspec gas costs should be ordered. By putting them in alphabetical order, there is a deterministic way to define the gas costs in a chainspec. 

Putting the chainspec gas costs in alphabetical order alone is insufficient, as it creates a discrepancy in the serialized versions of the chainspec. This also causes tests to fail. 