### PR TITLE
Upgrade to version 0.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
 ## [Version 0.37.0]
 
 #### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [Version 0.37.0]
 
 #### Breaking
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,16 +18,16 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.36.1"
+version = "0.37.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.36.1", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.36.1", path = "fuel-crypto", default-features = false }
-fuel-derive = { version = "0.36.1", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.36.1", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.36.1", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.36.1", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.36.1", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.36.1", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.37.0", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.37.0", path = "fuel-crypto", default-features = false }
+fuel-derive = { version = "0.37.0", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.37.0", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.37.0", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.37.0", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.37.0", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.37.0", path = "fuel-vm", default-features = false }
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
## What's Changed
* Use dependent cost for missed opcodes by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/537
* Update CI RUST_VERSION to 1.72.0 by @bvrooman in https://github.com/FuelLabs/fuel-vm/pull/575
* Remove `debug` feature from `fuel-vm` and use debugger by default. by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/554
* fix: Fixed length input for BMT `node_sum` by @bvrooman in https://github.com/FuelLabs/fuel-vm/pull/574
* Use custom derive ser/de instead of std::io by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/533
* feat: Impl `fmt::Display` for canonical Error by @bvrooman in https://github.com/FuelLabs/fuel-vm/pull/580
* fix: Organize `ConsensusParameters` gas costs in alphabetical order by @bvrooman in https://github.com/FuelLabs/fuel-vm/pull/581
* feat: Configurable Base Asset ID by @bvrooman in https://github.com/FuelLabs/fuel-vm/pull/573