### PR TITLE
Replace thiserror with derive_more::Display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - [#578](https://github.com/FuelLabs/fuel-vm/pull/578): Support `no_std` environments for `fuel-crypto`, falling back to a pure-Rust crypto implementation.
 - [#582](https://github.com/FuelLabs/fuel-vm/pull/582): Make `fuel-vm` and `fuel-tx` crates compatible with `no_std` + `alloc`. This includes reworking all error handling that used `std::io::Error`, replacing some `std::collection::{HashMap, HashSet}` with `hashbrown::{HashMap, HashSet}` and many changes to feature-gating of APIs.
+- [#587](https://github.com/FuelLabs/fuel-vm/pull/587): Replace `thiserror` dependency with `derive_more`, so that `core::fmt::Display` is implemented without the `std` feature. Removes `std::io::Error` trait impls from the affected types.
+
 ### Added
 
 - [#586](https://github.com/FuelLabs/fuel-vm/pull/586): Added `default_asset` method to the `ContractIdExt` trait implementation, to mirror the `default` method on AssetId in the Sway std lib.

--- a/fuel-merkle/Cargo.toml
+++ b/fuel-merkle/Cargo.toml
@@ -11,12 +11,12 @@ repository = { workspace = true }
 description = "Fuel Merkle tree libraries."
 
 [dependencies]
+derive_more = { version = "0.99", default-features = false, features = ["display"] }
 digest = { version = "0.10", default-features = false }
 fuel-storage = { workspace = true, default-features = false }
 hashbrown = "0.13"
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 sha2 = { version = "0.10", default-features = false }
-thiserror = { version = "1.0", optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
@@ -25,11 +25,10 @@ fuel-merkle-test-helpers = { path = "test-helpers" }
 hex = "0.4"
 rand = "0.8"
 serde_yaml = "0.9"
-thiserror = "1.0"
 
 [features]
 default = ["std"]
-std = ["dep:thiserror", "digest/default", "hex/default", "sha2/default"]
+std = ["digest/default", "hex/default", "sha2/default"]
 test-helpers = []
 
 [[test]]

--- a/fuel-merkle/src/binary/merkle_tree.rs
+++ b/fuel-merkle/src/binary/merkle_tree.rs
@@ -24,19 +24,15 @@ use crate::{
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "std", derive(thiserror::Error))]
+#[derive(Debug, Clone, derive_more::Display)]
 pub enum MerkleTreeError<StorageError> {
-    #[cfg_attr(feature = "std", error("proof index {0} is not valid"))]
+    #[display(fmt = "proof index {_0} is not valid")]
     InvalidProofIndex(u64),
 
-    #[cfg_attr(
-        feature = "std",
-        error("cannot load node with key {0}; the key is not found in storage")
-    )]
+    #[display(fmt = "cannot load node with key {_0}; the key is not found in storage")]
     LoadError(u64),
 
-    #[cfg_attr(feature = "std", error(transparent))]
+    #[display(fmt = "{}", _0)]
     StorageError(StorageError),
 }
 

--- a/fuel-merkle/src/common/error.rs
+++ b/fuel-merkle/src/common/error.rs
@@ -1,9 +1,8 @@
 use crate::common::PrefixError;
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "std", derive(thiserror::Error))]
+#[derive(Debug, Clone, derive_more::Display)]
 pub enum DeserializeError {
-    #[cfg_attr(feature = "std", error(transparent))]
+    #[display(fmt = "{}", _0)]
     PrefixError(PrefixError),
 }
 

--- a/fuel-merkle/src/common/node.rs
+++ b/fuel-merkle/src/common/node.rs
@@ -38,17 +38,16 @@ pub trait ParentNode: Sized + Node {
 #[allow(type_alias_bounds)]
 pub type ChildResult<T: ParentNode> = Result<T, ChildError<T::Key, T::Error>>;
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "std", derive(thiserror::Error))]
+#[derive(Debug, Clone, derive_more::Display)]
 pub enum ChildError<Key, E>
 where
     Key: KeyFormatting,
 {
-    #[cfg_attr(feature = "std", error("Child with key {} was not found in storage", .0.pretty()))]
+    #[display(fmt = "Child with key {} was not found in storage", _0.pretty())]
     ChildNotFound(Key),
-    #[cfg_attr(feature = "std", error("Node is a leaf with no children"))]
+    #[display(fmt = "Node is a leaf with no children")]
     NodeIsLeaf,
-    #[cfg_attr(feature = "std", error(transparent))]
+    #[display(fmt = "{}", _0)]
     Error(E),
 }
 

--- a/fuel-merkle/src/common/prefix.rs
+++ b/fuel-merkle/src/common/prefix.rs
@@ -27,10 +27,9 @@ impl From<Prefix> for [u8; 1] {
     }
 }
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "std", derive(thiserror::Error))]
+#[derive(Debug, Clone, derive_more::Display)]
 pub enum PrefixError {
-    #[cfg_attr(feature = "std", error("prefix {0} is not valid"))]
+    #[display(fmt = "prefix {_0} is not valid")]
     InvalidPrefix(u8),
 }
 

--- a/fuel-merkle/src/sparse/merkle_tree.rs
+++ b/fuel-merkle/src/sparse/merkle_tree.rs
@@ -30,22 +30,21 @@ use core::{
     marker::PhantomData,
 };
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "std", derive(thiserror::Error))]
+#[derive(Debug, Clone, derive_more::Display)]
 pub enum MerkleTreeError<StorageError> {
-    #[cfg_attr(
-        feature = "std",
-        error("cannot load node with key {}; the key is not found in storage", hex::encode(.0))
+    #[display(
+        fmt = "cannot load node with key {}; the key is not found in storage",
+        "hex::encode(_0)"
     )]
     LoadError(Bytes32),
 
-    #[cfg_attr(feature = "std", error(transparent))]
+    #[display(fmt = "{}", _0)]
     StorageError(StorageError),
 
-    #[cfg_attr(feature = "std", error(transparent))]
+    #[display(fmt = "{}", _0)]
     DeserializeError(DeserializeError),
 
-    #[cfg_attr(feature = "std", error(transparent))]
+    #[display(fmt = "{}", _0)]
     ChildError(ChildError<Bytes32, StorageNodeError<StorageError>>),
 }
 

--- a/fuel-merkle/src/sparse/node.rs
+++ b/fuel-merkle/src/sparse/node.rs
@@ -328,12 +328,11 @@ impl<TableType, StorageType> NodeTrait for StorageNode<'_, TableType, StorageTyp
     }
 }
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "std", derive(thiserror::Error))]
+#[derive(Debug, Clone, derive_more::Display)]
 pub enum StorageNodeError<StorageError> {
-    #[cfg_attr(feature = "std", error(transparent))]
+    #[display(fmt = "{}", _0)]
     StorageError(StorageError),
-    #[cfg_attr(feature = "std", error(transparent))]
+    #[display(fmt = "{}", _0)]
     DeserializeError(DeserializeError),
 }
 

--- a/fuel-merkle/src/sum/merkle_tree.rs
+++ b/fuel-merkle/src/sum/merkle_tree.rs
@@ -16,10 +16,9 @@ use fuel_storage::{
 
 use core::marker::PhantomData;
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "std", derive(thiserror::Error))]
+#[derive(Debug, Clone, derive_more::Display)]
 pub enum MerkleTreeError {
-    #[cfg_attr(feature = "std", error("proof index {0} is not valid"))]
+    #[display(fmt = "proof index {_0} is not valid")]
     InvalidProofIndex(u64),
 }
 

--- a/fuel-tx/Cargo.toml
+++ b/fuel-tx/Cargo.toml
@@ -12,6 +12,7 @@ description = "FuelVM transaction."
 
 [dependencies]
 derivative = { version = "2.2.0", default-features = false, features = ["use_core"], optional = true }
+derive_more = { version = "0.99", default-features = false, features = ["display"] }
 fuel-asm = { workspace = true, default-features = false }
 fuel-crypto = { workspace = true, default-features = false }
 fuel-merkle = { workspace = true, default-features = false, optional = true }
@@ -25,7 +26,6 @@ serde = { version = "1.0", default-features = false, features = ["alloc", "deriv
 serde_json = { version = "1.0", default-features = false, features = ["alloc"], optional = true }
 strum = { version = "0.24", default-features = false, optional = true }
 strum_macros = { version = "0.24", optional = true }
-thiserror = { version = "1.0", optional = true }
 
 [dev-dependencies]
 bincode = { workspace = true }
@@ -45,7 +45,7 @@ default = ["fuel-asm/default", "fuel-crypto/default", "fuel-merkle/default", "fu
 builder = ["alloc", "internals"]
 internals = []
 random = ["fuel-crypto/random", "fuel-types/random", "rand"]
-std = ["alloc", "dep:thiserror", "fuel-asm/std", "fuel-crypto/std", "fuel-merkle/std", "fuel-types/std", "itertools/default", "rand?/default", "serde?/default", "hex/std"]
+std = ["alloc", "fuel-asm/std", "fuel-crypto/std", "fuel-merkle/std", "fuel-types/std", "itertools/default", "rand?/default", "serde?/default", "hex/std"]
 alloc = ["hashbrown", "fuel-types/alloc", "itertools/use_alloc", "derivative", "fuel-merkle", "num_enum", "num-integer", "strum", "strum_macros"]
 # serde is requiring alloc because its mandatory for serde_json. to avoid adding a new feature only for serde_json, we just require `alloc` here since as of the moment we don't have a use case of serde without alloc.
 serde = ["alloc", "dep:serde", "fuel-asm/serde", "fuel-crypto/serde", "fuel-types/serde", "serde_json", "hashbrown/serde"]

--- a/fuel-tx/src/transaction/types/utxo_id.rs
+++ b/fuel-tx/src/transaction/types/utxo_id.rs
@@ -82,6 +82,16 @@ impl fmt::UpperHex for UtxoId {
     }
 }
 
+impl core::fmt::Display for UtxoId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        if f.alternate() {
+            write!(f, "{:#x}{:02x}", self.tx_id, self.output_index)
+        } else {
+            write!(f, "{:x}{:02x}", self.tx_id, self.output_index)
+        }
+    }
+}
+
 impl str::FromStr for UtxoId {
     type Err = &'static str;
 

--- a/fuel-tx/src/transaction/validity/error.rs
+++ b/fuel-tx/src/transaction/validity/error.rs
@@ -1,5 +1,3 @@
-use core::fmt;
-
 use crate::UtxoId;
 use fuel_types::{
     AssetId,
@@ -7,9 +5,8 @@ use fuel_types::{
     MessageId,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, derive_more::Display)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "std", derive(thiserror::Error))]
 #[non_exhaustive]
 pub enum CheckError {
     /// Transaction doesn't have spendable input message or coin.
@@ -99,6 +96,11 @@ pub enum CheckError {
     TransactionOutputCoinAssetIdNotFound(AssetId),
     /// The transaction doesn't provide enough input amount of the native chain asset to
     /// cover all potential execution fees
+    #[display(
+        fmt = "Insufficient fee amount: expected {}, provided {}",
+        expected,
+        provided
+    )]
     InsufficientFeeAmount {
         /// The expected amount of fees required to cover the transaction
         expected: u64,
@@ -107,6 +109,12 @@ pub enum CheckError {
     },
     /// The transaction doesn't provide enough input amount of the given asset to cover
     /// the amounts used in the outputs.
+    #[display(
+        fmt = "Insufficient input amount: asset {}, expected {}, provided {}",
+        asset,
+        expected,
+        provided
+    )]
     InsufficientInputAmount {
         /// The asset id being spent
         asset: AssetId,
@@ -122,11 +130,4 @@ pub enum CheckError {
     PredicateVerificationFailed,
     /// Predicate used all available gas
     PredicateExhaustedGas,
-}
-
-impl fmt::Display for CheckError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // TODO better describe the error variants
-        write!(f, "{self:?}")
-    }
 }

--- a/fuel-vm/Cargo.toml
+++ b/fuel-vm/Cargo.toml
@@ -16,6 +16,7 @@ async-trait = "0.1"
 backtrace = { version = "0.3", optional = true } # requires debug symbols to work
 bitflags = "1"
 derivative = "2.2"
+derive_more = { version = "0.99", default-features = false, features = ["display"] }
 dyn-clone = { version = "1.0", optional = true }
 ethnum = "1.3"
 fuel-asm = { workspace = true, default-features = false }
@@ -36,7 +37,6 @@ sha3 = { version = "0.10", default-features = false }
 static_assertions = "1.1"
 strum = { version = "0.24", features = ["derive"], default-features = false }
 tai64 = { version = "4.0", default-features = false }
-thiserror = { version = "1.0", optional = true }
 
 [dev-dependencies]
 ed25519-dalek = { version = "2.0.0", features = ["rand_core"] }
@@ -57,7 +57,7 @@ tokio-rayon = "2.1.0"
 
 [features]
 default = ["std"]
-std = ["alloc", "fuel-crypto/std", "fuel-types/std", "fuel-asm/std", "fuel-tx/std", "itertools/use_std", "thiserror"]
+std = ["alloc", "fuel-crypto/std", "fuel-types/std", "fuel-asm/std", "fuel-tx/std", "itertools/use_std"]
 alloc = ["fuel-asm/alloc", "fuel-tx/alloc", "fuel-tx/builder"]
 arbitrary = ["fuel-asm/arbitrary"]
 profile-gas = ["profile-any"]

--- a/fuel-vm/src/error.rs
+++ b/fuel-vm/src/error.rs
@@ -7,9 +7,6 @@ use fuel_asm::{
 };
 use fuel_tx::CheckError;
 
-#[cfg(feature = "std")]
-use thiserror::Error;
-
 use alloc::{
     format,
     string::{
@@ -25,33 +22,32 @@ use core::{
 use crate::storage::predicate;
 
 /// Interpreter runtime error variants.
-#[cfg_attr(feature = "std", derive(Error))]
-#[derive(Debug)]
+#[derive(Debug, derive_more::Display)]
 pub enum InterpreterError<StorageError> {
     /// The instructions execution resulted in a well-formed panic, caused by an
     /// explicit instruction.
-    #[cfg_attr(feature = "std", error("Execution error: {0:?}"))]
+    #[display(fmt = "Execution error: {_0:?}")]
     PanicInstruction(PanicInstruction),
     /// The VM execution resulted in a well-formed panic. This panic wasn't
     /// caused by an instruction contained in the transaction or a called
     /// contract.
-    #[cfg_attr(feature = "std", error("Execution error: {0:?}"))]
+    #[display(fmt = "Execution error: {_0:?}")]
     Panic(PanicReason),
     /// The provided transaction isn't valid.
-    #[cfg_attr(feature = "std", error("Failed to check the transaction: {0}"))]
+    #[display(fmt = "Failed to check the transaction: {_0}")]
     CheckError(CheckError),
     /// No transaction was initialized in the interpreter. It cannot provide
     /// state transitions.
-    #[cfg_attr(feature = "std", error("Execution error"))]
+    #[display(fmt = "Execution error")]
     NoTransactionInitialized,
-    #[cfg_attr(feature = "std", error("Execution error"))]
+    #[display(fmt = "Execution error")]
     /// The debug state is not initialized; debug routines can't be called.
     DebugStateNotInitialized,
     /// Storage I/O error
-    #[cfg_attr(feature = "std", error("Storage error: {0}"))]
+    #[display(fmt = "Storage error: {}", _0)]
     Storage(StorageError),
     /// Encountered a bug
-    #[cfg_attr(feature = "std", error("Bug: {0}"))]
+    #[display(fmt = "Bug: {_0}")]
     Bug(Bug),
 }
 
@@ -231,61 +227,41 @@ impl<StorageError> From<Infallible> for RuntimeError<StorageError> {
 }
 
 /// Predicates checking failed
-#[cfg_attr(feature = "std", derive(Error))]
-#[derive(Debug)]
+#[derive(Debug, derive_more::Display)]
 pub enum PredicateVerificationFailed {
     /// The predicate did not use the amount of gas provided
-    #[cfg_attr(
-        feature = "std",
-        error("Predicate used less than the required amount of gas")
-    )]
+    #[display(fmt = "Predicate used less than the required amount of gas")]
     GasMismatch,
     /// The transaction doesn't contain enough gas to evaluate the predicate
-    #[cfg_attr(
-        feature = "std",
-        error("Insufficient gas available for single predicate")
-    )]
+    #[display(fmt = "Insufficient gas available for single predicate")]
     OutOfGas,
     /// The predicate owner does not correspond to the predicate code
-    #[cfg_attr(
-        feature = "std",
-        error("Predicate owner invalid, doesn't match code root")
-    )]
+    #[display(fmt = "Predicate owner invalid, doesn't match code root")]
     InvalidOwner,
     /// The predicate wasn't successfully evaluated to true
-    #[cfg_attr(feature = "std", error("Predicate failed to evaluate"))]
+    #[display(fmt = "Predicate failed to evaluate")]
     False,
     /// The predicate gas used was not specified before execution
-    #[cfg_attr(feature = "std", error("Predicate failed to evaluate"))]
+    #[display(fmt = "Predicate failed to evaluate")]
     GasNotSpecified,
     /// The transaction doesn't contain enough gas to evaluate all predicates
-    #[cfg_attr(
-        feature = "std",
-        error("Insufficient gas available for all predicates")
-    )]
+    #[display(fmt = "Insufficient gas available for all predicates")]
     CumulativePredicateGasExceededTxGasLimit,
     /// The cumulative gas overflowed the u64 accumulator
-    #[cfg_attr(
-        feature = "std",
-        error("Cumulative gas computation overflowed the u64 accumulator")
-    )]
+    #[display(fmt = "Cumulative gas computation overflowed the u64 accumulator")]
     GasOverflow,
     /// Invalid interpreter state reached unexpectedly, this is a bug
-    #[cfg_attr(
-        feature = "std",
-        error("Invalid interpreter state reached unexpectedly")
-    )]
+    #[display(fmt = "Invalid interpreter state reached unexpectedly")]
     Bug(Bug),
     /// The VM execution resulted in a well-formed panic, caused by an instruction.
-    #[cfg_attr(feature = "std", error("Execution error: {0:?}"))]
+    #[display(fmt = "Execution error: {_0:?}")]
     PanicInstruction(PanicInstruction),
     /// The VM execution resulted in a well-formed panic not caused by an instruction.
-    #[cfg_attr(feature = "std", error("Execution error: {0:?}"))]
+    #[display(fmt = "Execution error: {_0:?}")]
     Panic(PanicReason),
     /// Predicate verification failed since it attempted to access storage
-    #[cfg_attr(
-        feature = "std",
-        error("Predicate verification failed since it attempted to access storage")
+    #[display(
+        fmt = "Predicate verification failed since it attempted to access storage"
     )]
     Storage,
 }


### PR DESCRIPTION
Follow-up to https://github.com/FuelLabs/fuel-vm/pull/582

Replaces thiserror dependency of no_std crates with a `core::fmt::Display` implementations generated by `derive_more` crate. This is a breaking change, since we lose `std::io::Error` trait impls when `std` feature is enabled.