### PR TITLE
Release 0.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.38.0]
+
 ### Added
 
 - [#586](https://github.com/FuelLabs/fuel-vm/pull/586): Added `default_asset` method to the `ContractIdExt` trait implementation, to mirror the `default` method on AssetId in the Sway std lib.
@@ -19,9 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [#587](https://github.com/FuelLabs/fuel-vm/pull/587): Replace `thiserror` dependency with `derive_more`, so that `core::fmt::Display` is implemented without the `std` feature. Removes `std::io::Error` trait impls from the affected types.
 - [#588](https://github.com/FuelLabs/fuel-vm/pull/588): Re-worked the size calculation of the canonical serialization/deserialization.
 
-### Removed
+#### Removed
 
-#### Breaking
 - [#588](https://github.com/FuelLabs/fuel-vm/pull/588): Removed `SerializedSize` and `SerializedFixedSize` traits. Removed support for `SIZE_NO_DYNAMIC` and `SIZE_STATIC`. Removed enum attributes from derive macro for `Serialize` and `Deserialize` traits..
 
 ## [Version 0.37.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 #### Removed
 
-- [#588](https://github.com/FuelLabs/fuel-vm/pull/588): Removed `SerializedSize` and `SerializedFixedSize` traits. Removed support for `SIZE_NO_DYNAMIC` and `SIZE_STATIC`. Removed enum attributes from derive macro for `Serialize` and `Deserialize` traits..
+- [#588](https://github.com/FuelLabs/fuel-vm/pull/588): Removed `SerializedSize` and `SerializedFixedSize` traits. Removed support for `SIZE_NO_DYNAMIC` and `SIZE_STATIC`. Removed enum attributes from derive macro for `Serialize` and `Deserialize` traits.
 
 ## [Version 0.37.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,16 +18,16 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.37.0"
+version = "0.38.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.37.0", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.37.0", path = "fuel-crypto", default-features = false }
-fuel-derive = { version = "0.37.0", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.37.0", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.37.0", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.37.0", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.37.0", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.37.0", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.38.0", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.38.0", path = "fuel-crypto", default-features = false }
+fuel-derive = { version = "0.38.0", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.38.0", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.38.0", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.38.0", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.38.0", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.38.0", path = "fuel-vm", default-features = false }
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
## Version 0.38.0

The release adds `no_std` compatible canonical serialization/deserialization. Along with it, all crates were updated to be `no_std` compatible. The whole repository is now WASM and RiscV compatible.

### Added

- [#586](https://github.com/FuelLabs/fuel-vm/pull/586): Added `default_asset` method to the `ContractIdExt` trait implementation, to mirror the `default` method on AssetId in the Sway std lib.

### Changed

#### Breaking

- [#578](https://github.com/FuelLabs/fuel-vm/pull/578): Support `no_std` environments for `fuel-crypto`, falling back to a pure-Rust crypto implementation.
- [#582](https://github.com/FuelLabs/fuel-vm/pull/582): Make `fuel-vm` and `fuel-tx` crates compatible with `no_std` + `alloc`. This includes reworking all error handling that used `std::io::Error`, replacing some `std::collection::{HashMap, HashSet}` with `hashbrown::{HashMap, HashSet}` and many changes to feature-gating of APIs.
- [#587](https://github.com/FuelLabs/fuel-vm/pull/587): Replace `thiserror` dependency with `derive_more`, so that `core::fmt::Display` is implemented without the `std` feature. Removes `std::io::Error` trait impls from the affected types.
- [#588](https://github.com/FuelLabs/fuel-vm/pull/588): Re-worked the size calculation of the canonical serialization/deserialization.

#### Removed

- [#588](https://github.com/FuelLabs/fuel-vm/pull/588): Removed `SerializedSize` and `SerializedFixedSize` traits. Removed support for `SIZE_NO_DYNAMIC` and `SIZE_STATIC`. Removed enum attributes from derive macro for `Serialize` and `Deserialize` traits.

## What's Changed
* no_std fuel-crypto by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/578
* Add default_asset method by @SwayStar123 in https://github.com/FuelLabs/fuel-vm/pull/586
* no_std support for `fuel-tx` and `fuel-vm` by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/582
* Replace thiserror with derive_more::Display by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/587
* Follow-up for canonical se/de after an additional round of review by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/588

## New Contributors
* @SwayStar123 made their first contribution in https://github.com/FuelLabs/fuel-vm/pull/586

**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.37.0...v0.38.0