### PR TITLE
Predicate input validation tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+#### Breaking
+
+- [#594](https://github.com/FuelLabs/fuel-vm/pull/594): Add new predicate input validation tests. Also improves error propagation so that predicate error message better reflects the reason for invalidity.
+
 ## [Version 0.38.0]
 
 ### Added

--- a/fuel-vm/src/error.rs
+++ b/fuel-vm/src/error.rs
@@ -227,7 +227,7 @@ impl<StorageError> From<Infallible> for RuntimeError<StorageError> {
 }
 
 /// Predicates checking failed
-#[derive(Debug, derive_more::Display)]
+#[derive(Debug, PartialEq, derive_more::Display)]
 pub enum PredicateVerificationFailed {
     /// The predicate did not use the amount of gas provided
     #[display(fmt = "Predicate used less than the required amount of gas")]
@@ -283,6 +283,11 @@ impl From<InterpreterError<predicate::StorageUnavailable>>
             error if error.panic_reason() == Some(PanicReason::OutOfGas) => {
                 PredicateVerificationFailed::OutOfGas
             }
+            InterpreterError::Panic(reason) => PredicateVerificationFailed::Panic(reason),
+            InterpreterError::PanicInstruction(result) => {
+                PredicateVerificationFailed::PanicInstruction(result)
+            }
+            InterpreterError::Bug(bug) => PredicateVerificationFailed::Bug(bug),
             InterpreterError::Storage(_) => PredicateVerificationFailed::Storage,
             _ => PredicateVerificationFailed::False,
         }

--- a/fuel-vm/src/predicate.rs
+++ b/fuel-vm/src/predicate.rs
@@ -41,15 +41,17 @@ impl RuntimePredicate {
 }
 
 #[cfg(test)]
-#[test]
-fn from_tx_works() {
+mod tests {
     use alloc::{
         vec,
         vec::Vec,
     };
     use fuel_asm::op;
     use fuel_tx::TransactionBuilder;
-    use fuel_types::bytes;
+    use fuel_types::{
+        bytes,
+        ChainId,
+    };
     use rand::{
         rngs::StdRng,
         Rng,
@@ -59,108 +61,205 @@ fn from_tx_works() {
     use core::iter;
 
     use crate::{
+        checked_transaction::{
+            CheckPredicateParams,
+            Checked,
+        },
+        error::PredicateVerificationFailed,
         interpreter::InterpreterParams,
         prelude::*,
         storage::PredicateStorage,
     };
 
-    let rng = &mut StdRng::seed_from_u64(2322u64);
+    #[test]
+    fn from_tx_works() {
+        let rng = &mut StdRng::seed_from_u64(2322u64);
 
-    let height = 1.into();
+        let height = 1.into();
 
-    #[rustfmt::skip]
-    let predicate: Vec<u8> = vec![
-        op::addi(0x10, 0x00, 0x01),
-        op::addi(0x10, 0x10, 0x01),
-        op::ret(0x01),
-    ].into_iter().collect();
+        #[rustfmt::skip]
+        let predicate: Vec<u8> = vec![
+            op::addi(0x10, 0x00, 0x01),
+            op::addi(0x10, 0x10, 0x01),
+            op::ret(0x01),
+        ].into_iter().collect();
 
-    let predicate_data = b"If people do not believe that mathematics is simple, it is only because they do not realize how complicated life is.".to_vec();
+        let predicate_data = b"If people do not believe that mathematics is simple, it is only because they do not realize how complicated life is.".to_vec();
 
-    let owner = (*Contract::root_from_code(&predicate)).into();
-    let a = Input::coin_predicate(
-        rng.gen(),
-        owner,
-        rng.gen(),
-        rng.gen(),
-        rng.gen(),
-        rng.gen(),
-        rng.gen(),
-        predicate.clone(),
-        predicate_data.clone(),
-    );
+        let owner = (*Contract::root_from_code(&predicate)).into();
+        let a = Input::coin_predicate(
+            rng.gen(),
+            owner,
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+            predicate.clone(),
+            predicate_data.clone(),
+        );
 
-    let b = Input::message_coin_predicate(
-        rng.gen(),
-        rng.gen(),
-        rng.gen(),
-        rng.gen(),
-        rng.gen(),
-        predicate.clone(),
-        predicate_data.clone(),
-    );
+        let b = Input::message_coin_predicate(
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+            predicate.clone(),
+            predicate_data.clone(),
+        );
 
-    let c = Input::message_data_predicate(
-        rng.gen(),
-        rng.gen(),
-        rng.gen(),
-        rng.gen(),
-        rng.gen(),
-        vec![0xff; 10],
-        predicate.clone(),
-        predicate_data,
-    );
+        let c = Input::message_data_predicate(
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+            vec![0xff; 10],
+            predicate.clone(),
+            predicate_data,
+        );
 
-    let inputs = vec![a, b, c];
+        let inputs = vec![a, b, c];
 
-    for i in inputs {
-        let tx = TransactionBuilder::script(vec![], vec![])
-            .add_input(i)
-            .add_random_fee_input()
-            .finalize_checked_basic(height);
+        for i in inputs {
+            let tx = TransactionBuilder::script(vec![], vec![])
+                .add_input(i)
+                .add_random_fee_input()
+                .finalize_checked_basic(height);
 
-        // assert invalid idx wont panic
-        let idx = 1;
-        let tx_offset = TxParameters::DEFAULT.tx_offset();
-        let runtime = RuntimePredicate::from_tx(tx.as_ref(), tx_offset, idx);
+            // assert invalid idx wont panic
+            let idx = 1;
+            let tx_offset = TxParameters::DEFAULT.tx_offset();
+            let runtime = RuntimePredicate::from_tx(tx.as_ref(), tx_offset, idx);
 
-        assert!(runtime.is_none());
+            assert!(runtime.is_none());
 
-        // fetch the input predicate
-        let idx = 0;
-        let runtime = RuntimePredicate::from_tx(tx.as_ref(), tx_offset, idx)
-            .expect("failed to generate predicate from valid tx");
+            // fetch the input predicate
+            let idx = 0;
+            let runtime = RuntimePredicate::from_tx(tx.as_ref(), tx_offset, idx)
+                .expect("failed to generate predicate from valid tx");
 
-        assert_eq!(idx, runtime.idx());
+            assert_eq!(idx, runtime.idx());
 
-        let mut interpreter =
-            Interpreter::with_storage(PredicateStorage, InterpreterParams::default());
+            let mut interpreter =
+                Interpreter::with_storage(PredicateStorage, InterpreterParams::default());
 
-        assert!(interpreter
-            .init_predicate(
-                Context::PredicateVerification {
-                    program: Default::default()
-                },
-                tx.transaction().clone(),
-                tx.transaction().limit()
-            )
-            .is_ok());
+            assert!(interpreter
+                .init_predicate(
+                    Context::PredicateVerification {
+                        program: Default::default()
+                    },
+                    tx.transaction().clone(),
+                    tx.transaction().limit()
+                )
+                .is_ok());
 
-        let pad = bytes::padded_len(&predicate) - predicate.len();
+            let pad = bytes::padded_len(&predicate) - predicate.len();
 
-        // assert we are testing an edge case
-        assert_ne!(0, pad);
+            // assert we are testing an edge case
+            assert_ne!(0, pad);
 
-        let padded_predicate: Vec<u8> = predicate
-            .iter()
-            .copied()
-            .chain(iter::repeat(0u8).take(pad))
-            .collect();
+            let padded_predicate: Vec<u8> = predicate
+                .iter()
+                .copied()
+                .chain(iter::repeat(0u8).take(pad))
+                .collect();
 
-        let program = runtime.program();
-        let program = &interpreter.memory()[program.usizes()];
+            let program = runtime.program();
+            let program = &interpreter.memory()[program.usizes()];
 
-        // assert the program in the vm memory is the same of the input
-        assert_eq!(program, &padded_predicate);
+            // assert the program in the vm memory is the same of the input
+            assert_eq!(program, &padded_predicate);
+        }
+    }
+
+    /// Verifies the runtime predicate validation rules outlined in the spec are actually
+    /// validated https://github.com/FuelLabs/fuel-specs/blob/master/src/fuel-vm/index.md#predicate-verification
+    #[test]
+    fn inputs_are_validated() {
+        let rng = &mut StdRng::seed_from_u64(2322u64);
+
+        let height = 1.into();
+        let predicate_data =
+            b"If you think it's simple, then you have misunderstood the problem."
+                .to_vec();
+
+        macro_rules! predicate_input {
+            ($predicate:expr) => {{
+                let predicate: Vec<u8> = $predicate.into_iter().collect();
+                let owner = Input::predicate_owner(&predicate, &ChainId::default());
+                Input::coin_predicate(
+                    rng.gen(),
+                    owner,
+                    rng.gen(),
+                    rng.gen(),
+                    rng.gen(),
+                    rng.gen(),
+                    15,
+                    predicate.clone(),
+                    predicate_data.clone(),
+                )
+            }};
+        }
+
+        let inputs = vec![
+            (
+                // A valid predicate
+                predicate_input!(vec![
+                    op::addi(0x10, 0x00, 0x01),
+                    op::addi(0x10, 0x10, 0x01),
+                    op::ret(0x01),
+                ]),
+                Ok(()),
+            ),
+            (
+                // A valid predicate, but gas amount mismatches
+                predicate_input!(vec![op::ret(0x01),]),
+                Err(PredicateVerificationFailed::GasMismatch),
+            ),
+            (
+                // Returning an invalid value
+                predicate_input!(vec![op::ret(0x0)]),
+                Err(PredicateVerificationFailed::Panic(
+                    PanicReason::ContractInstructionNotAllowed,
+                )),
+            ),
+            (
+                // Using a contract instruction
+                predicate_input!(vec![op::time(0x20, 0x1), op::ret(0x1)]),
+                Err(PredicateVerificationFailed::PanicInstruction(
+                    PanicInstruction::error(
+                        PanicReason::ContractInstructionNotAllowed,
+                        op::time(0x20, 0x1).into(),
+                    ),
+                )),
+            ),
+            (
+                // PC exceeding predicate bounds
+                predicate_input!(vec![op::ji(0x100), op::ret(0x1)]),
+                Err(PredicateVerificationFailed::Panic(
+                    PanicReason::MemoryOverflow,
+                )),
+            ),
+        ];
+
+        for (input, expected) in inputs {
+            let tx =
+                TransactionBuilder::script([op::ret(0x01)].into_iter().collect(), vec![])
+                    .add_input(input)
+                    .gas_price(0)
+                    .gas_limit(TxParameters::DEFAULT.max_gas_per_tx)
+                    .add_random_fee_input()
+                    .finalize_checked_basic(height);
+
+            let result =
+                Interpreter::<PredicateStorage, Checked<Script>>::check_predicates(
+                    &tx,
+                    &CheckPredicateParams::default(),
+                );
+
+            assert_eq!(result.map(|_| ()), expected);
+        }
     }
 }


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuel-vm/issues/181

Also improves error propagation so that predicate error message better reflects the reason for invalidation. For instance, it now includes the disallowed contract opcode which was not accepted in predicate exection context.