### PR TITLE
Remove wee_alloc dependency, use builtin allocator instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- [#595](https://github.com/FuelLabs/fuel-vm/pull/595): Removed `wee_alloc` dependency from `fuel-asm`. It now uses the builtin allocator on web targets as well.
+
+
 ## [Version 0.38.0]
 
 ### Added

--- a/fuel-asm/Cargo.toml
+++ b/fuel-asm/Cargo.toml
@@ -17,7 +17,6 @@ fuel-types = { workspace = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 strum = { version = "0.24", default-features = false, features = ["derive"] }
 wasm-bindgen = { version = "0.2.87", optional = true }
-wee_alloc = { version = "0.4.5", optional = true }
 
 [dev-dependencies]
 bincode = { workspace = true }
@@ -26,7 +25,7 @@ rstest = "0.16"
 
 [features]
 default = ["std"]
-typescript = ["wasm-bindgen", "wee_alloc"]
+typescript = ["wasm-bindgen"]
 std = ["alloc", "serde?/default", "fuel-types/std"]
 alloc = []
 serde = ["dep:serde"]

--- a/fuel-asm/src/lib.rs
+++ b/fuel-asm/src/lib.rs
@@ -11,14 +11,6 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-#[cfg(feature = "wee_alloc")]
-use wee_alloc as _;
-
-// Use `wee_alloc` as the global allocator.
-#[cfg(all(no_std, feature = "wee_alloc"))]
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-
 mod args;
 mod panic_instruction;
 // This is `pub` to make documentation for the private `impl_instructions!` macro more


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuel-vm/issues/518

Everything seems to be working wihtout it as well.