### PR TITLE
Remove BlockHeight arithmetic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+#### Breaking
+
+- [#596](https://github.com/FuelLabs/fuel-vm/pull/596): Remove `core::ops::{Add, Sub}` impls from `BlockHeight`. Use `succ` and `pred` to access adjacent blocks, or perform arithmetic directly on the wrapped integer instead.
+
 ## [Version 0.38.0]
 
 ### Added

--- a/fuel-tx/src/tests/valid_cases/transaction.rs
+++ b/fuel-tx/src/tests/valid_cases/transaction.rs
@@ -865,7 +865,7 @@ fn mint() {
         .add_output(Output::coin(rng.gen(), rng.next_u64(), AssetId::BASE))
         .add_output(Output::coin(rng.gen(), rng.next_u64(), AssetId::BASE))
         .finalize()
-        .check(block_height + 1.into(), &test_params())
+        .check(block_height.succ().unwrap(), &test_params())
         .expect_err("Expected erroneous transaction");
 
     assert_eq!(err, CheckError::TransactionMintIncorrectBlockHeight);

--- a/fuel-types/src/numeric_types.rs
+++ b/fuel-types/src/numeric_types.rs
@@ -7,10 +7,8 @@ use core::{
     convert::TryFrom,
     fmt,
     ops::{
-        Add,
         Deref,
         DerefMut,
-        Sub,
     },
     str,
 };
@@ -246,27 +244,21 @@ macro_rules! key_methods {
                     Ok(ret.into())
                 }
             }
-
-            impl Add for $i {
-                type Output = $i;
-
-                #[inline(always)]
-                fn add(self, rhs: $i) -> $i {
-                    $i(self.0.wrapping_add(rhs.0))
-                }
-            }
-
-            impl Sub for $i {
-                type Output = $i;
-
-                #[inline(always)]
-                fn sub(self, rhs: $i) -> $i {
-                    $i(self.0.wrapping_sub(rhs.0))
-                }
-            }
         };
     };
 }
 
 key!(BlockHeight, u32);
 key!(ChainId, u64);
+
+impl BlockHeight {
+    /// Successor, i.e. next block after this
+    pub fn succ(self) -> Option<BlockHeight> {
+        Some(Self(self.0.checked_add(1)?))
+    }
+
+    /// Predecessor, i.e. previous block before this
+    pub fn pred(self) -> Option<BlockHeight> {
+        Some(Self(self.0.checked_sub(1)?))
+    }
+}


### PR DESCRIPTION
As suggested in https://github.com/FuelLabs/fuel-core/issues/1334, the `BlockHeight` type should have error-prone arithmetic implementations. In this case it was possible to silently wrap the result, which is even worse.