### PR TITLE
Add Serialization and Deserialization support to MerkleRootCalculator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - [#603](https://github.com/FuelLabs/fuel-vm/pull/603): Added `MerkleRootCalculator`for efficient in-memory Merkle root calculation.
+- [#603](https://github.com/FuelLabs/fuel-vm/pull/606): Added Serialization and Deserialization support to `MerkleRootCalculator`.
 
 ### Changed
 

--- a/fuel-merkle/Cargo.toml
+++ b/fuel-merkle/Cargo.toml
@@ -16,7 +16,7 @@ digest = { version = "0.10", default-features = false }
 fuel-storage = { workspace = true, default-features = false }
 hashbrown = "0.13"
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
-serde = { version = "1.0.163", default-features = false }
+serde = { version = "1.0", default-features = false, optional = true }
 sha2 = { version = "0.10", default-features = false }
 
 [dev-dependencies]
@@ -25,13 +25,16 @@ datatest-stable = "0.1"
 fuel-merkle-test-helpers = { path = "test-helpers" }
 hex = "0.4"
 rand = "0.8"
-serde_json = "1.0.96"
+serde_json = "1.0"
 serde_yaml = "0.9"
 
 [features]
 default = ["std"]
 std = ["digest/default", "hex/default", "sha2/default"]
 test-helpers = []
+serde = [
+    "dep:serde",
+]
 
 [[test]]
 name = "tests-data"

--- a/fuel-merkle/Cargo.toml
+++ b/fuel-merkle/Cargo.toml
@@ -16,6 +16,7 @@ digest = { version = "0.10", default-features = false }
 fuel-storage = { workspace = true, default-features = false }
 hashbrown = "0.13"
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
+serde = { version = "1.0.163", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 
 [dev-dependencies]
@@ -24,6 +25,7 @@ datatest-stable = "0.1"
 fuel-merkle-test-helpers = { path = "test-helpers" }
 hex = "0.4"
 rand = "0.8"
+serde_json = "1.0.96"
 serde_yaml = "0.9"
 
 [features]

--- a/fuel-merkle/src/binary/node.rs
+++ b/fuel-merkle/src/binary/node.rs
@@ -10,12 +10,12 @@ use crate::{
 };
 
 use core::fmt::Debug;
-use serde::{
-    Deserialize,
-    Serialize,
-};
-
-#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+// use serde::{
+//     Deserialize,
+//     Serialize,
+// };
+#[derive(Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Node {
     position: Position,
     hash: Bytes32,

--- a/fuel-merkle/src/binary/node.rs
+++ b/fuel-merkle/src/binary/node.rs
@@ -10,10 +10,6 @@ use crate::{
 };
 
 use core::fmt::Debug;
-// use serde::{
-//     Deserialize,
-//     Serialize,
-// };
 #[derive(Clone, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Node {

--- a/fuel-merkle/src/binary/node.rs
+++ b/fuel-merkle/src/binary/node.rs
@@ -10,8 +10,12 @@ use crate::{
 };
 
 use core::fmt::Debug;
+use serde::{
+    Deserialize,
+    Serialize,
+};
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct Node {
     position: Position,
     hash: Bytes32,

--- a/fuel-merkle/src/binary/root_calculator.rs
+++ b/fuel-merkle/src/binary/root_calculator.rs
@@ -6,10 +6,15 @@ use crate::{
     common::Bytes32,
 };
 
+use serde::{
+    Deserialize,
+    Serialize,
+};
+
 use crate::alloc::borrow::ToOwned;
 use alloc::vec::Vec;
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MerkleRootCalculator {
     stack: Vec<Node>,
 }
@@ -17,6 +22,10 @@ pub struct MerkleRootCalculator {
 impl MerkleRootCalculator {
     pub fn new() -> Self {
         Self { stack: Vec::new() }
+    }
+
+    pub fn new_with_stack(stack: Vec<Node>) -> Self {
+        Self { stack }
     }
 
     pub fn push(&mut self, data: &[u8]) {
@@ -61,6 +70,10 @@ impl MerkleRootCalculator {
         }
 
         calculator.root()
+    }
+
+    pub fn stack(&self) -> &Vec<Node> {
+        &self.stack
     }
 }
 
@@ -132,5 +145,22 @@ mod test {
         let root = calculate_root.root_from_iterator(data.iter());
 
         assert_eq!(tree.root(), root);
+    }
+
+    #[test]
+    fn test_serialize_deserialize() {
+        let mut calculator = MerkleRootCalculator::new();
+
+        let data = &TEST_DATA[0..7];
+        for datum in data.iter() {
+            calculator.push(datum);
+        }
+
+        let json = serde_json::to_string(&calculator).unwrap();
+
+        let deserialized_calculator: MerkleRootCalculator =
+            serde_json::from_str(&json).unwrap();
+
+        assert_eq!(calculator.root(), deserialized_calculator.root());
     }
 }

--- a/fuel-merkle/src/binary/root_calculator.rs
+++ b/fuel-merkle/src/binary/root_calculator.rs
@@ -6,15 +6,14 @@ use crate::{
     common::Bytes32,
 };
 
-use serde::{
-    Deserialize,
-    Serialize,
-};
-
 use crate::alloc::borrow::ToOwned;
 use alloc::vec::Vec;
 
-#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg(test)]
+use serde_json as _;
+
+#[derive(Default, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MerkleRootCalculator {
     stack: Vec<Node>,
 }
@@ -148,6 +147,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn test_serialize_deserialize() {
         let mut calculator = MerkleRootCalculator::new();
 
@@ -155,11 +155,10 @@ mod test {
         for datum in data.iter() {
             calculator.push(datum);
         }
-
         let json = serde_json::to_string(&calculator).unwrap();
 
         let deserialized_calculator: MerkleRootCalculator =
-            serde_json::from_str(&json).unwrap();
+            serde_json::from_str(&json).expect("Unable to read from str");
 
         assert_eq!(calculator.root(), deserialized_calculator.root());
     }

--- a/fuel-merkle/src/binary/root_calculator.rs
+++ b/fuel-merkle/src/binary/root_calculator.rs
@@ -9,9 +9,6 @@ use crate::{
 use crate::alloc::borrow::ToOwned;
 use alloc::vec::Vec;
 
-#[cfg(test)]
-use serde_json as _;
-
 #[derive(Default, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MerkleRootCalculator {
@@ -81,6 +78,8 @@ mod test {
     use super::*;
     use crate::binary::in_memory::MerkleTree;
     use fuel_merkle_test_helpers::TEST_DATA;
+    #[cfg(test)]
+    use serde_json as _;
 
     #[test]
     fn root_returns_the_empty_root_for_0_leaves() {

--- a/fuel-merkle/src/common/position.rs
+++ b/fuel-merkle/src/common/position.rs
@@ -8,6 +8,10 @@ use crate::common::{
     PositionPath,
 };
 use core::convert::Infallible;
+use serde::{
+    Deserialize,
+    Serialize,
+};
 
 /// # Position
 ///
@@ -86,7 +90,7 @@ use core::convert::Infallible;
 /// balanced Merkle tree, using methods to retrieve a `Position's` sibling,
 /// parent, or uncle `Position`. However, in such cases, the corresponding
 /// sibling or uncle nodes are not guaranteed to exist in the tree.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Position(u64);
 
 const LEFT_CHILD_DIRECTION: i64 = -1;

--- a/fuel-merkle/src/common/position.rs
+++ b/fuel-merkle/src/common/position.rs
@@ -8,10 +8,10 @@ use crate::common::{
     PositionPath,
 };
 use core::convert::Infallible;
-use serde::{
-    Deserialize,
-    Serialize,
-};
+// use serde::{
+//     Deserialize,
+//     Serialize,
+// };
 
 /// # Position
 ///
@@ -90,7 +90,8 @@ use serde::{
 /// balanced Merkle tree, using methods to retrieve a `Position's` sibling,
 /// parent, or uncle `Position`. However, in such cases, the corresponding
 /// sibling or uncle nodes are not guaranteed to exist in the tree.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Position(u64);
 
 const LEFT_CHILD_DIRECTION: i64 = -1;

--- a/fuel-merkle/src/common/position.rs
+++ b/fuel-merkle/src/common/position.rs
@@ -8,10 +8,6 @@ use crate::common::{
     PositionPath,
 };
 use core::convert::Infallible;
-// use serde::{
-//     Deserialize,
-//     Serialize,
-// };
 
 /// # Position
 ///

--- a/fuel-tx/Cargo.toml
+++ b/fuel-tx/Cargo.toml
@@ -47,4 +47,4 @@ random = ["fuel-crypto/random", "fuel-types/random", "rand"]
 std = ["alloc", "fuel-asm/std", "fuel-crypto/std", "fuel-merkle/std", "fuel-types/std", "itertools/default", "rand?/default", "serde?/default", "hex/std"]
 alloc = ["hashbrown", "fuel-types/alloc", "itertools/use_alloc", "derivative", "fuel-merkle", "num-integer", "strum", "strum_macros"]
 # serde is requiring alloc because its mandatory for serde_json. to avoid adding a new feature only for serde_json, we just require `alloc` here since as of the moment we don't have a use case of serde without alloc.
-serde = ["alloc", "dep:serde", "fuel-asm/serde", "fuel-crypto/serde", "fuel-types/serde", "serde_json", "hashbrown/serde"]
+serde = ["alloc", "dep:serde", "fuel-asm/serde", "fuel-crypto/serde", "fuel-types/serde", "fuel-merkle/serde", "serde_json", "hashbrown/serde"]

--- a/fuel-vm/Cargo.toml
+++ b/fuel-vm/Cargo.toml
@@ -64,5 +64,5 @@ profile-gas = ["profile-any"]
 profile-coverage = ["profile-any"]
 profile-any = ["dyn-clone"] # All profiling features should depend on this
 random = ["fuel-crypto/random", "fuel-types/random", "fuel-tx/random", "rand"]
-serde = ["dep:serde", "hashbrown/serde", "fuel-asm/serde", "fuel-types/serde", "fuel-tx/serde"]
+serde = ["dep:serde", "hashbrown/serde", "fuel-asm/serde", "fuel-types/serde", "fuel-tx/serde", "fuel-merkle/serde"]
 test-helpers = ["fuel-tx/builder", "alloc", "random", "dep:anyhow", "fuel-crypto/test-helpers"]


### PR DESCRIPTION
Adds serialization and deserialization support for the MerkleRootCalculator struct. 

Additional work: 
- getter for MerkleRootCalculator stack
- constructor new_with_stack