### PR TITLE
Release `0.39.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.39.0]
+
 ### Added
 - [#603](https://github.com/FuelLabs/fuel-vm/pull/603): Added `MerkleRootCalculator`for efficient in-memory Merkle root calculation.
 - [#603](https://github.com/FuelLabs/fuel-vm/pull/606): Added Serialization and Deserialization support to `MerkleRootCalculator`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,16 +18,16 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.38.0", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.38.0", path = "fuel-crypto", default-features = false }
-fuel-derive = { version = "0.38.0", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.38.0", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.38.0", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.38.0", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.38.0", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.38.0", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.39.0", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.39.0", path = "fuel-crypto", default-features = false }
+fuel-derive = { version = "0.39.0", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.39.0", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.39.0", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.39.0", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.39.0", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.39.0", path = "fuel-vm", default-features = false }
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
## Version 0.39.0

### Added
- [#603](https://github.com/FuelLabs/fuel-vm/pull/603): Added `MerkleRootCalculator`for efficient in-memory Merkle root calculation.
- [#603](https://github.com/FuelLabs/fuel-vm/pull/606): Added Serialization and Deserialization support to `MerkleRootCalculator`.

### Changed

- [#595](https://github.com/FuelLabs/fuel-vm/pull/595): Removed `wee_alloc` dependency from `fuel-asm`. It now uses the builtin allocator on web targets as well.

#### Breaking

- [#598](https://github.com/FuelLabs/fuel-vm/pull/598): Update cost model for `ldc` opcode to take into account contract size.
- [#604](https://github.com/FuelLabs/fuel-vm/pull/604): Removed `ChainId` from `PredicateId` calculation. It changes the generated address of the predicates and may break tests or logic that uses hard-coded predicate IDs.
- [#594](https://github.com/FuelLabs/fuel-vm/pull/594): Add new predicate input validation tests. Also improves error propagation so that predicate error message better reflects the reason for invalidity.
- [#596](https://github.com/FuelLabs/fuel-vm/pull/596): Remove `core::ops::{Add, Sub}` impls from `BlockHeight`. Use `succ` and `pred` to access adjacent blocks, or perform arithmetic directly on the wrapped integer instead.
- [#593](https://github.com/FuelLabs/fuel-vm/pull/593): Reworked `Mint` transaction to work with `Input::Contract` and `Output::Contract` instead of `Output::Coin`. It allows account-based fee collection for the block producer.

## What's Changed
* Remove BlockHeight arithmetic by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/596
* Remove wee_alloc dependency, use builtin allocator instead by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/595
* Predicate input validation tests by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/594
* Remove `ChainId` from `PredicateId` calculation by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/604
* Rework `Mint` transaction to work with the contract by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/593
* Improved Memory Efficiency in Merkle Root Calculation by @Salka1988 in https://github.com/FuelLabs/fuel-vm/pull/603
* Include size lookup of contract for computing LDC opcode cost by @MitchTurner in https://github.com/FuelLabs/fuel-vm/pull/598
* Add Serialization and Deserialization support to MerkleRootCalculator by @Salka1988 in https://github.com/FuelLabs/fuel-vm/pull/606


**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.38.0...v0.39.0
