### PR TITLE
chore: Use MerkleRootCalculator when only BMT root is needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- [#612](https://github.com/FuelLabs/fuel-vm/pull/612): Reduced the memory consumption in all places where we calculate BMT root.
+
 #### Breaking
 
 - [#609](https://github.com/FuelLabs/fuel-vm/pull/609): Checked transactions (`Create`, `Script`, and `Mint`) now enforce a maximum size. The maximum size is specified by `MAX_TRANSACTION_SIZE` in the transaction parameters, under consensus parameters. Checking a transaction above this size raises `CheckError::TransactionSizeLimitExceeded`.

--- a/fuel-tx/src/contract.rs
+++ b/fuel-tx/src/contract.rs
@@ -7,7 +7,7 @@ use crate::{
 use derivative::Derivative;
 use fuel_crypto::Hasher;
 use fuel_merkle::{
-    binary::in_memory::MerkleTree as BinaryMerkleTree,
+    binary::root_calculator::MerkleRootCalculator as BinaryMerkleTree,
     sparse::{
         in_memory::MerkleTree as SparseMerkleTree,
         MerkleTreeKey,

--- a/fuel-vm/src/crypto.rs
+++ b/fuel-vm/src/crypto.rs
@@ -1,6 +1,6 @@
 //! Crypto implementations for the instructions
 
-use fuel_merkle::binary::in_memory::MerkleTree;
+use fuel_merkle::binary::root_calculator::MerkleRootCalculator as MerkleTree;
 use fuel_types::Bytes32;
 
 /// Calculate a binary merkle root with in-memory storage

--- a/fuel-vm/src/interpreter/receipts.rs
+++ b/fuel-vm/src/interpreter/receipts.rs
@@ -4,7 +4,7 @@ use core::{
     ops::Index,
 };
 
-use fuel_merkle::binary;
+use fuel_merkle::binary::root_calculator::MerkleRootCalculator as MerkleTree;
 use fuel_tx::Receipt;
 use fuel_types::{
     canonical::Serialize,
@@ -14,7 +14,7 @@ use fuel_types::{
 #[derive(Debug, Default, Clone)]
 pub(crate) struct ReceiptsCtx {
     receipts: Vec<Receipt>,
-    receipts_tree: binary::in_memory::MerkleTree,
+    receipts_tree: MerkleTree,
 }
 
 impl ReceiptsCtx {
@@ -24,7 +24,7 @@ impl ReceiptsCtx {
     }
 
     pub fn clear(&mut self) {
-        self.receipts_tree.reset();
+        self.receipts_tree = MerkleTree::new();
         self.receipts.clear();
     }
 
@@ -44,7 +44,7 @@ impl ReceiptsCtx {
     /// Recalculates the Merkle root of the receipts from scratch. This should
     /// only be used when the list of receipts has been mutated externally.
     fn recalculate_root(&mut self) {
-        self.receipts_tree.reset();
+        self.receipts_tree = MerkleTree::new();
         // TODO: Remove `clone()` when `to_bytes()` no longer requires `&mut self`
         let receipts = self.as_ref().clone();
         for receipt in receipts {

--- a/fuel-vm/src/interpreter/receipts.rs
+++ b/fuel-vm/src/interpreter/receipts.rs
@@ -33,7 +33,7 @@ impl ReceiptsCtx {
     }
 
     pub fn root(&self) -> Bytes32 {
-        self.receipts_tree.root().into()
+        self.receipts_tree.clone().root().into()
     }
 
     /// Get a mutable lock on this context


### PR DESCRIPTION
Related issues: 
- https://github.com/FuelLabs/fuel-vm/issues/610

This PR updates all relevant usages of `binary::in_memory::MerkleTree` inside `fuel-vm` to use `binary::root_calculator::MerkleRootCalculator` for calculating BMT roots. 