### PR TITLE
Memory write xor execute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - [#607](https://github.com/FuelLabs/fuel-vm/pull/607): The `Interpreter` expects the third generic argument during type definition that specifies the implementer of the `EcalHandler` trait for `ecal` opcode.
 - [#609](https://github.com/FuelLabs/fuel-vm/pull/609): Checked transactions (`Create`, `Script`, and `Mint`) now enforce a maximum size. The maximum size is specified by `MAX_TRANSACTION_SIZE` in the transaction parameters, under consensus parameters. Checking a transaction above this size raises `CheckError::TransactionSizeLimitExceeded`.
+- [#617](https://github.com/FuelLabs/fuel-vm/pull/617): Makes memory outside `$is..$ssp` range not executable. Separates `ErrorFlag` into `InvalidFlags`, `MemoryNotExecutable` and `InvalidInstruction`. Fixes related tests.
 
 ## [Version 0.39.0]
 

--- a/fuel-asm/src/panic_reason.rs
+++ b/fuel-asm/src/panic_reason.rs
@@ -111,8 +111,10 @@ enum_from! {
         ContractInstructionNotAllowed = 0x24,
         /// Transfer of zero coins is not allowed.
         TransferZeroCoins = 0x25,
+        /// Attempted to execute an invalid instruction
+        InvalidInstruction = 0x26,
         /// Memory after $ssp is not executable
-        MemoryNotExecutable = 0x26,
+        MemoryNotExecutable = 0x27,
     }
 }
 

--- a/fuel-asm/src/panic_reason.rs
+++ b/fuel-asm/src/panic_reason.rs
@@ -111,6 +111,8 @@ enum_from! {
         ContractInstructionNotAllowed = 0x24,
         /// Transfer of zero coins is not allowed.
         TransferZeroCoins = 0x25,
+        /// Memory after $ssp is not executable
+        MemoryNotExecutable = 0x26,
     }
 }
 

--- a/fuel-asm/src/panic_reason.rs
+++ b/fuel-asm/src/panic_reason.rs
@@ -113,7 +113,7 @@ enum_from! {
         TransferZeroCoins = 0x25,
         /// Attempted to execute an invalid instruction
         InvalidInstruction = 0x26,
-        /// Memory after $ssp is not executable
+        /// Memory outside $is..$ssp range is not executable
         MemoryNotExecutable = 0x27,
     }
 }

--- a/fuel-asm/src/panic_reason.rs
+++ b/fuel-asm/src/panic_reason.rs
@@ -70,7 +70,7 @@ enum_from! {
         /// The provided register does not allow write operations.
         ReservedRegisterNotWritable = 0x11,
         /// The execution resulted in an erroneous state of the interpreter.
-        ErrorFlag = 0x12,
+        InvalidFlags = 0x12,
         /// The provided immediate value is not valid for this instruction.
         InvalidImmediateValue = 0x13,
         /// The provided transaction input is not of type `Coin`.

--- a/fuel-vm/src/interpreter/executors/instruction.rs
+++ b/fuel-vm/src/interpreter/executors/instruction.rs
@@ -96,7 +96,7 @@ where
         raw: RawInstruction,
     ) -> IoResult<ExecuteState, S::DataError> {
         let instruction = Instruction::try_from(raw)
-            .map_err(|_| RuntimeError::from(PanicReason::ErrorFlag))?;
+            .map_err(|_| RuntimeError::from(PanicReason::InvalidInstruction))?;
 
         // TODO additional branch that might be optimized after
         // https://github.com/FuelLabs/fuel-asm/issues/68

--- a/fuel-vm/src/interpreter/executors/instruction.rs
+++ b/fuel-vm/src/interpreter/executors/instruction.rs
@@ -67,10 +67,10 @@ where
             )),
         )?;
         if pc < self.registers[RegId::IS] || pc >= self.registers[RegId::SSP] {
-            return Err(InterpreterError::PanicInstruction(
-                PanicInstruction::error(PanicReason::MemoryNotExecutable, instruction)
-                    .into(),
-            ))
+            return Err(InterpreterError::PanicInstruction(PanicInstruction::error(
+                PanicReason::MemoryNotExecutable,
+                instruction,
+            )))
         }
         Ok(instruction)
     }

--- a/fuel-vm/src/interpreter/internal.rs
+++ b/fuel-vm/src/interpreter/internal.rs
@@ -226,7 +226,7 @@ pub(crate) fn set_flag(
     a: Word,
 ) -> SimpleResult<()> {
     let Some(flags) = Flags::from_bits(a) else {
-        return Err(PanicReason::ErrorFlag.into())
+        return Err(PanicReason::InvalidFlags.into())
     };
 
     *flag = flags.bits();

--- a/fuel-vm/src/tests/blockchain.rs
+++ b/fuel-vm/src/tests/blockchain.rs
@@ -49,7 +49,6 @@ use fuel_asm::{
     PanicReason::{
         ContractNotInInputs,
         ExpectedUnallocatedStack,
-        InvalidFlags,
         MemoryOverflow,
     },
 };

--- a/fuel-vm/src/tests/blockchain.rs
+++ b/fuel-vm/src/tests/blockchain.rs
@@ -48,8 +48,8 @@ use fuel_asm::{
     Instruction,
     PanicReason::{
         ContractNotInInputs,
-        ErrorFlag,
         ExpectedUnallocatedStack,
+        InvalidFlags,
         MemoryOverflow,
     },
 };
@@ -1475,14 +1475,12 @@ fn message_output_b_gt_msg_len() {
 
     // cover contract_id_end beyond max ram
     let message_output = vec![
-        op::xor(reg_a, reg_a, reg_a), // r[a] = 0
-        op::ori(reg_a, reg_a, 1),     // r[a] = 1
-        op::slli(reg_a, reg_a, 20),   // r[a] = 2^20
-        op::addi(reg_a, reg_a, 1),    // r[a] = 2^20 + 1
+        op::slli(reg_a, RegId::ONE, (VM_MAX_RAM.ilog2() + 2) as u16),
         op::smo(RegId::ZERO, reg_a, RegId::ZERO, RegId::ZERO),
+        op::ret(RegId::ONE),
     ];
 
-    check_expected_reason_for_instructions(message_output, ErrorFlag);
+    check_expected_reason_for_instructions(message_output, MemoryOverflow);
 }
 
 #[test]

--- a/fuel-vm/src/tests/memory.rs
+++ b/fuel-vm/src/tests/memory.rs
@@ -400,7 +400,6 @@ fn test_heap_not_executable() {
     ]);
 
     if let Some(Receipt::Panic { reason, .. }) = receipts.first() {
-        dbg!(reason);
         assert!(matches!(reason.reason(), PanicReason::MemoryNotExecutable));
     } else {
         panic!("Expected panic receipt");

--- a/fuel-vm/src/tests/memory.rs
+++ b/fuel-vm/src/tests/memory.rs
@@ -387,3 +387,22 @@ fn test_meq(
         panic!("Expected LogData receipt");
     }
 }
+
+#[test]
+fn test_heap_not_executable() {
+    let receipts = run_script(vec![
+        op::movi(0x10, 16),
+        op::aloc(0x10),
+        op::sub(0x10, RegId::HP, RegId::IS),
+        op::divi(0x10, 0x10, 4),
+        op::jmp(0x10),
+        op::ret(RegId::ONE),
+    ]);
+
+    if let Some(Receipt::Panic { reason, .. }) = receipts.first() {
+        dbg!(reason);
+        assert!(matches!(reason.reason(), PanicReason::MemoryNotExecutable));
+    } else {
+        panic!("Expected panic receipt");
+    }
+}

--- a/fuel-vm/src/tests/spec.rs
+++ b/fuel-vm/src/tests/spec.rs
@@ -337,5 +337,5 @@ fn spec_cannot_write_reserved_flags(#[values(0b100, 0b111)] flags: Immediate18) 
     script.push(op::ret(RegId::ONE));
 
     let receipts = run_script(script.into_iter().collect());
-    assert_panics(&receipts, PanicReason::ErrorFlag);
+    assert_panics(&receipts, PanicReason::InvalidFlags);
 }


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuel-vm/issues/616. Closes https://github.com/FuelLabs/fuel-vm/issues/564.

This PR makes attempting to execute opcodes outside `$is..$ssp` range panic with `MemoryNotExecutable` error. It also separates `ErrorFlag` into `InvalidFlags` and `InvalidInstruction`, which make more sense. Then finally it fixes some tests that incorrectly assumed that any of these were equivalent, and some that had even weirder misconceptions.
