### PR TITLE
Release `v0.40.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.40.0]
+
 ### Added
 - [#607](https://github.com/FuelLabs/fuel-vm/pull/607): Added `ECAL` instruction support.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,16 +18,16 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.39.0"
+version = "0.40.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.39.0", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.39.0", path = "fuel-crypto", default-features = false }
-fuel-derive = { version = "0.39.0", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.39.0", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.39.0", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.39.0", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.39.0", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.39.0", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.40.0", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.40.0", path = "fuel-crypto", default-features = false }
+fuel-derive = { version = "0.40.0", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.40.0", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.40.0", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.40.0", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.40.0", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.40.0", path = "fuel-vm", default-features = false }
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION

## Version 0.40.0

### Added
- [#607](https://github.com/FuelLabs/fuel-vm/pull/607): Added `ECAL` instruction support.

### Changed

- [#612](https://github.com/FuelLabs/fuel-vm/pull/612): Reduced the memory consumption in all places where we calculate BMT root.
- [#615](https://github.com/FuelLabs/fuel-vm/pull/615): Made `ReceiptsCtx` of the VM modifiable with `test-helpers` feature.

#### Breaking

- [#618](https://github.com/FuelLabs/fuel-vm/pull/618): Transaction fees for `Create` now include the cost of metadata calculations, including: contract root calculation, state root calculation, and contract id calculation.
- [#613](https://github.com/FuelLabs/fuel-vm/pull/613): Transaction fees now include the cost of signature verification for each input. For signed inputs, the cost of an EC recovery is charged. For predicate inputs, the cost of a BMT root of bytecode is charged. 
- [#607](https://github.com/FuelLabs/fuel-vm/pull/607): The `Interpreter` expects the third generic argument during type definition that specifies the implementer of the `EcalHandler` trait for `ecal` opcode.
- [#609](https://github.com/FuelLabs/fuel-vm/pull/609): Checked transactions (`Create`, `Script`, and `Mint`) now enforce a maximum size. The maximum size is specified by `MAX_TRANSACTION_SIZE` in the transaction parameters, under consensus parameters. Checking a transaction above this size raises `CheckError::TransactionSizeLimitExceeded`.
- [#617](https://github.com/FuelLabs/fuel-vm/pull/617): Makes memory outside `$is..$ssp` range not executable. Separates `ErrorFlag` into `InvalidFlags`, `MemoryNotExecutable` and `InvalidInstruction`. Fixes related tests.
- [#619](https://github.com/FuelLabs/fuel-vm/pull/619): Avoid possible truncation of higher bits. It may invalidate the code that truncated higher bits causing different behavior on 32-bit vs. 64-bit systems.

## What's Changed
* feat: Enforce maximum tx size by @bvrooman in https://github.com/FuelLabs/fuel-vm/pull/609
* chore: Use MerkleRootCalculator when only BMT root is needed by @bvrooman in https://github.com/FuelLabs/fuel-vm/pull/612
* Add ECAL instruction by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/607
* Memory write xor execute by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/617
* feat: Charge for input signature verification (address recovery and predicate roots) by @bvrooman in https://github.com/FuelLabs/fuel-vm/pull/613
* Avoid possible truncation of higher bits by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/619
* Make ReceiptsCtx public, allow mut access in tests by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/615
* feat: Charge for `Create` metadata by @bvrooman in https://github.com/FuelLabs/fuel-vm/pull/618


**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.39.0...v0.40.0
