### PR TITLE
Simplify asm in some tests

### DIFF
--- a/fuel-vm/src/tests/blockchain.rs
+++ b/fuel-vm/src/tests/blockchain.rs
@@ -509,9 +509,8 @@ fn ldc__load_len_of_target_contract<'a>(
         let index = i as Immediate12;
         let value = *byte as Immediate12;
         load_contract.extend([
-            op::xor(reg_a, reg_a, reg_a),    // r[a] := 0
-            op::ori(reg_a, reg_a, value),    // r[a] := r[a] | value
-            op::sb(RegId::HP, reg_a, index), // m[$hp+index] := r[a] (=value)
+            op::movi(reg_a, value.try_into().unwrap()), // r[a] := r[a] | value
+            op::sb(RegId::HP, reg_a, index),            // m[$hp+index] := r[a] (=value)
         ]);
     }
 
@@ -911,9 +910,7 @@ fn code_copy_a_gt_vmmax_sub_d() {
 
     // test memory offset above reg_hp value
     let code_copy = vec![
-        op::xor(reg_a, reg_a, reg_a),
-        op::ori(reg_a, reg_a, 1),
-        op::slli(reg_a, reg_a, MAX_MEM_SHL),
+        op::slli(reg_a, RegId::ONE, MAX_MEM_SHL),
         op::addi(reg_a, reg_a, 1),
         op::ccp(reg_a, RegId::ZERO, RegId::ZERO, RegId::ZERO),
     ];
@@ -926,8 +923,7 @@ fn code_copy_b_plus_32_overflow() {
     let reg_a = 0x20;
     // test overflow add
     let code_copy = vec![
-        op::xor(reg_a, reg_a, reg_a),
-        op::not(reg_a, reg_a),
+        op::not(reg_a, RegId::ZERO),
         op::ccp(RegId::ZERO, reg_a, RegId::ZERO, RegId::ZERO),
     ];
 
@@ -939,9 +935,7 @@ fn code_copy_b_gt_vm_max_ram() {
     let reg_a = 0x20;
     // test overflow add
     let code_copy = vec![
-        op::xor(reg_a, reg_a, reg_a),
-        op::ori(reg_a, reg_a, 1),
-        op::slli(reg_a, reg_a, MAX_MEM_SHL),
+        op::slli(reg_a, RegId::ONE, MAX_MEM_SHL),
         op::subi(reg_a, reg_a, 31),
         op::ccp(RegId::ZERO, reg_a, RegId::ZERO, RegId::ZERO),
     ];
@@ -954,9 +948,7 @@ fn code_copy_c_gt_vm_max_ram() {
     let reg_a = 0x20;
     // test overflow add
     let code_copy = vec![
-        op::xor(reg_a, reg_a, reg_a),
-        op::ori(reg_a, reg_a, 1),
-        op::slli(reg_a, reg_a, MAX_MEM_SHL),
+        op::slli(reg_a, RegId::ONE, MAX_MEM_SHL),
         op::addi(reg_a, reg_a, 1),
         op::ccp(RegId::ZERO, RegId::ZERO, reg_a, RegId::ZERO),
     ];
@@ -970,11 +962,7 @@ fn code_root_a_plus_32_overflow() {
     let reg_a = 0x20;
 
     // cover contract_id_end beyond max ram
-    let code_root = vec![
-        op::xor(reg_a, reg_a, reg_a),
-        op::not(reg_a, reg_a),
-        op::croo(reg_a, RegId::ZERO),
-    ];
+    let code_root = vec![op::not(reg_a, RegId::ZERO), op::croo(reg_a, RegId::ZERO)];
 
     check_expected_reason_for_instructions(code_root, MemoryOverflow);
 }
@@ -985,11 +973,7 @@ fn code_root_b_plus_32_overflow() {
     let reg_a = 0x20;
 
     // cover contract_id_end beyond max ram
-    let code_root = vec![
-        op::xor(reg_a, reg_a, reg_a),
-        op::not(reg_a, reg_a),
-        op::croo(RegId::ZERO, reg_a),
-    ];
+    let code_root = vec![op::not(reg_a, RegId::ZERO), op::croo(RegId::ZERO, reg_a)];
 
     check_expected_reason_for_instructions(code_root, MemoryOverflow);
 }
@@ -1001,9 +985,7 @@ fn code_root_a_over_max_ram() {
 
     // cover contract_id_end beyond max ram
     let code_root = vec![
-        op::xor(reg_a, reg_a, reg_a),
-        op::ori(reg_a, reg_a, 1),
-        op::slli(reg_a, reg_a, MAX_MEM_SHL),
+        op::slli(reg_a, RegId::ONE, MAX_MEM_SHL),
         op::subi(reg_a, reg_a, 31 as Immediate12),
         op::croo(reg_a, RegId::ZERO),
     ];
@@ -1018,9 +1000,7 @@ fn code_root_b_over_max_ram() {
 
     // cover contract_id_end beyond max ram
     let code_root = vec![
-        op::xor(reg_a, reg_a, reg_a),
-        op::ori(reg_a, reg_a, 1),
-        op::slli(reg_a, reg_a, MAX_MEM_SHL),
+        op::slli(reg_a, RegId::ONE, MAX_MEM_SHL),
         op::subi(reg_a, reg_a, 31 as Immediate12),
         op::croo(RegId::ZERO, reg_a),
     ];
@@ -1034,11 +1014,7 @@ fn code_size_b_plus_32_overflow() {
     let reg_a = 0x20;
 
     // cover contract_id_end beyond max ram
-    let code_root = vec![
-        op::xor(reg_a, reg_a, reg_a),
-        op::not(reg_a, reg_a),
-        op::csiz(reg_a, reg_a),
-    ];
+    let code_root = vec![op::not(reg_a, RegId::ZERO), op::csiz(reg_a, reg_a)];
 
     check_expected_reason_for_instructions(code_root, MemoryOverflow);
 }
@@ -1050,9 +1026,7 @@ fn code_size_b_over_max_ram() {
 
     // cover contract_id_end beyond max ram
     let code_root = vec![
-        op::xor(reg_a, reg_a, reg_a),
-        op::ori(reg_a, reg_a, 1),
-        op::slli(reg_a, reg_a, MAX_MEM_SHL),
+        op::slli(reg_a, RegId::ONE, MAX_MEM_SHL),
         op::subi(reg_a, reg_a, 31 as Immediate12),
         op::csiz(reg_a, reg_a),
     ];
@@ -1276,8 +1250,7 @@ fn state_r_word_b_plus_32_over() {
 
     // cover contract_id_end beyond max ram
     let state_read_word = vec![
-        op::xor(reg_a, reg_a, reg_a),
-        op::not(reg_a, reg_a),
+        op::not(reg_a, RegId::ZERO),
         op::subi(reg_a, reg_a, 31 as Immediate12),
         op::srw(reg_a, SET_STATUS_REG, reg_a),
     ];
@@ -1292,9 +1265,7 @@ fn state_r_word_b_over_max_ram() {
 
     // cover contract_id_end beyond max ram
     let state_read_word = vec![
-        op::xor(reg_a, reg_a, reg_a),
-        op::ori(reg_a, reg_a, 1),
-        op::slli(reg_a, reg_a, MAX_MEM_SHL),
+        op::slli(reg_a, RegId::ONE, MAX_MEM_SHL),
         op::subi(reg_a, reg_a, 31 as Immediate12),
         op::srw(reg_a, SET_STATUS_REG, reg_a),
     ];
@@ -1309,8 +1280,7 @@ fn state_r_qword_a_plus_32_over() {
 
     // cover contract_id_end beyond max ram
     let state_read_qword = vec![
-        op::xor(reg_a, reg_a, reg_a),
-        op::not(reg_a, reg_a),
+        op::not(reg_a, RegId::ZERO),
         op::subi(reg_a, reg_a, 31 as Immediate12),
         op::srwq(reg_a, SET_STATUS_REG, RegId::ZERO, RegId::ONE),
     ];
@@ -1327,8 +1297,7 @@ fn state_r_qword_c_plus_32_over() {
     let state_read_qword = vec![
         op::movi(0x11, 100),
         op::aloc(0x11),
-        op::xor(reg_a, reg_a, reg_a),
-        op::not(reg_a, reg_a),
+        op::not(reg_a, RegId::ZERO),
         op::subi(reg_a, reg_a, 31 as Immediate12),
         op::srwq(RegId::HP, SET_STATUS_REG, reg_a, RegId::ONE),
     ];
@@ -1343,9 +1312,7 @@ fn state_r_qword_a_over_max_ram() {
 
     // cover contract_id_end beyond max ram
     let state_read_qword = vec![
-        op::xor(reg_a, reg_a, reg_a),
-        op::ori(reg_a, reg_a, 1),
-        op::slli(reg_a, reg_a, MAX_MEM_SHL),
+        op::slli(reg_a, RegId::ONE, MAX_MEM_SHL),
         op::subi(reg_a, reg_a, 31 as Immediate12),
         op::srwq(reg_a, SET_STATUS_REG, RegId::ZERO, RegId::ONE),
     ];
@@ -1363,9 +1330,7 @@ fn state_r_qword_c_over_max_ram() {
         op::movi(0x11, 100),
         op::aloc(0x11),
         op::move_(0x31, RegId::HP),
-        op::xor(reg_a, reg_a, reg_a),
-        op::ori(reg_a, reg_a, 1),
-        op::slli(reg_a, reg_a, MAX_MEM_SHL),
+        op::slli(reg_a, RegId::ONE, MAX_MEM_SHL),
         op::subi(reg_a, reg_a, 31 as Immediate12),
         op::srwq(0x31, SET_STATUS_REG, reg_a, RegId::ONE),
     ];
@@ -1380,8 +1345,7 @@ fn state_w_word_a_plus_32_over() {
 
     // cover contract_id_end beyond max ram
     let state_write_word = vec![
-        op::xor(reg_a, reg_a, reg_a),
-        op::not(reg_a, reg_a),
+        op::not(reg_a, RegId::ZERO),
         op::subi(reg_a, reg_a, 31 as Immediate12),
         op::sww(reg_a, SET_STATUS_REG, RegId::ZERO),
     ];
@@ -1396,9 +1360,7 @@ fn state_w_word_a_over_max_ram() {
 
     // cover contract_id_end beyond max ram
     let state_write_word = vec![
-        op::xor(reg_a, reg_a, reg_a),
-        op::ori(reg_a, reg_a, 1),
-        op::slli(reg_a, reg_a, MAX_MEM_SHL),
+        op::slli(reg_a, RegId::ONE, MAX_MEM_SHL),
         op::subi(reg_a, reg_a, 31 as Immediate12),
         op::sww(reg_a, SET_STATUS_REG, RegId::ZERO),
     ];
@@ -1413,8 +1375,7 @@ fn state_w_qword_a_plus_32_over() {
 
     // cover contract_id_end beyond max ram
     let state_write_qword = vec![
-        op::xor(reg_a, reg_a, reg_a),
-        op::not(reg_a, reg_a),
+        op::not(reg_a, RegId::ZERO),
         op::subi(reg_a, reg_a, 31 as Immediate12),
         op::swwq(reg_a, SET_STATUS_REG, RegId::ZERO, RegId::ONE),
     ];
@@ -1429,8 +1390,7 @@ fn state_w_qword_b_plus_32_over() {
 
     // cover contract_id_end beyond max ram
     let state_write_qword = vec![
-        op::xor(reg_a, reg_a, reg_a),
-        op::not(reg_a, reg_a),
+        op::not(reg_a, RegId::ZERO),
         op::subi(reg_a, reg_a, 31 as Immediate12),
         op::swwq(RegId::ZERO, SET_STATUS_REG, reg_a, RegId::ONE),
     ];
@@ -1445,9 +1405,7 @@ fn state_w_qword_a_over_max_ram() {
 
     // cover contract_id_end beyond max ram
     let state_write_qword = vec![
-        op::xor(reg_a, reg_a, reg_a),
-        op::ori(reg_a, reg_a, 1),
-        op::slli(reg_a, reg_a, MAX_MEM_SHL),
+        op::slli(reg_a, RegId::ONE, MAX_MEM_SHL),
         op::subi(reg_a, reg_a, 31),
         op::swwq(reg_a, SET_STATUS_REG, RegId::ZERO, RegId::ONE),
     ];
@@ -1462,9 +1420,7 @@ fn state_w_qword_b_over_max_ram() {
 
     // cover contract_id_end beyond max ram
     let state_write_qword = vec![
-        op::xor(reg_a, reg_a, reg_a),
-        op::ori(reg_a, reg_a, 1),
-        op::slli(reg_a, reg_a, MAX_MEM_SHL),
+        op::slli(reg_a, RegId::ONE, MAX_MEM_SHL),
         op::subi(reg_a, reg_a, 31),
         op::swwq(RegId::ZERO, SET_STATUS_REG, reg_a, RegId::ONE),
     ];
@@ -1491,15 +1447,11 @@ fn message_output_b_gt_msg_len() {
 fn message_output_a_b_over() {
     // Then deploy another contract that attempts to read the first one
     let reg_a = 0x20;
-    let reg_b = 0x21;
 
     // cover contract_id_end beyond max ram
     let message_output = vec![
-        op::xor(reg_a, reg_a, reg_a), // r[a] = 0
-        op::xor(reg_b, reg_b, reg_b), // r[b] = 0
-        op::not(reg_a, reg_a),        // r[a] = MAX
-        op::addi(reg_b, reg_b, 1),    // r[b] = 1
-        op::smo(reg_a, reg_b, RegId::ZERO, RegId::ZERO),
+        op::not(reg_a, RegId::ZERO), // r[a] = MAX
+        op::smo(reg_a, RegId::ONE, RegId::ZERO, RegId::ZERO),
     ];
 
     check_expected_reason_for_instructions(message_output, MemoryOverflow);
@@ -1509,16 +1461,11 @@ fn message_output_a_b_over() {
 fn message_output_a_b_gt_max_mem() {
     // Then deploy another contract that attempts to read the first one
     let reg_a = 0x20;
-    let reg_b = 0x21;
 
     // cover contract_id_end beyond max ram
     let message_output = vec![
-        op::xor(reg_a, reg_a, reg_a),
-        op::xor(reg_b, reg_b, reg_b),
-        op::ori(reg_a, reg_a, 1),
-        op::slli(reg_a, reg_a, MAX_MEM_SHL),
-        op::addi(reg_b, reg_b, 1),
-        op::smo(reg_a, reg_b, RegId::ZERO, RegId::ZERO),
+        op::slli(reg_a, RegId::ONE, MAX_MEM_SHL),
+        op::smo(reg_a, RegId::ONE, RegId::ZERO, RegId::ZERO),
     ];
 
     check_expected_reason_for_instructions(message_output, MemoryOverflow);

--- a/fuel-vm/src/tests/crypto.rs
+++ b/fuel-vm/src/tests/crypto.rs
@@ -289,9 +289,8 @@ fn secp256k1_recover_a_gt_vmaxram_sub_64() {
 
     #[rustfmt::skip]
     let script = vec![
-        op::xor(reg_a, reg_a, reg_a),
         op::xor(reg_b, reg_b, reg_b),
-        op::not(reg_a, reg_a),
+        op::not(reg_a, RegId::ZERO),
         op::subi(reg_a, reg_a, 63),
         op::eck1(reg_a, reg_b, reg_b),
         op::ret(RegId::ONE),
@@ -307,9 +306,8 @@ fn secp256k1_recover_b_gt_vmaxram_sub_64() {
 
     #[rustfmt::skip]
     let script = vec![
-        op::xor(reg_a, reg_a, reg_a),
         op::xor(reg_b, reg_b, reg_b),
-        op::not(reg_a, reg_a),
+        op::not(reg_a, RegId::ZERO),
         op::subi(reg_a, reg_a, 63),
         op::eck1(reg_b, reg_a, reg_b),
         op::ret(RegId::ONE),
@@ -325,9 +323,8 @@ fn secp256k1_recover_c_gt_vmaxram_sub_32() {
 
     #[rustfmt::skip]
     let script = vec![
-        op::xor(reg_a, reg_a, reg_a),
         op::xor(reg_b, reg_b, reg_b),
-        op::not(reg_a, reg_a),
+        op::not(reg_a, RegId::ZERO),
         op::subi(reg_a, reg_a, 31),
         op::eck1(reg_b, reg_b, reg_a),
         op::ret(RegId::ONE),
@@ -434,9 +431,8 @@ fn secp256r1_recover_a_gt_vmaxram_sub_64() {
 
     #[rustfmt::skip]
     let script = vec![
-        op::xor(reg_a, reg_a, reg_a),
         op::xor(reg_b, reg_b, reg_b),
-        op::not(reg_a, reg_a),
+        op::not(reg_a, RegId::ZERO),
         op::subi(reg_a, reg_a, 63),
         op::ecr1(reg_a, reg_b, reg_b),
         op::ret(RegId::ONE),
@@ -452,9 +448,8 @@ fn secp256r1_recover_b_gt_vmaxram_sub_64() {
 
     #[rustfmt::skip]
     let script = vec![
-        op::xor(reg_a, reg_a, reg_a),
         op::xor(reg_b, reg_b, reg_b),
-        op::not(reg_a, reg_a),
+        op::not(reg_a, RegId::ZERO),
         op::subi(reg_a, reg_a, 63),
         op::ecr1(reg_b, reg_a, reg_b),
         op::ret(RegId::ONE),
@@ -470,9 +465,8 @@ fn secp256r1_recover_c_gt_vmaxram_sub_32() {
 
     #[rustfmt::skip]
     let script = vec![
-        op::xor(reg_a, reg_a, reg_a),
         op::xor(reg_b, reg_b, reg_b),
-        op::not(reg_a, reg_a),
+        op::not(reg_a, RegId::ZERO),
         op::subi(reg_a, reg_a, 31),
         op::ecr1(reg_b, reg_b, reg_a),
         op::ret(RegId::ONE),
@@ -578,9 +572,8 @@ fn ed25519_verify_a_gt_vmaxram_sub_64() {
 
     #[rustfmt::skip]
     let script = vec![
-        op::xor(reg_a, reg_a, reg_a),
         op::xor(reg_b, reg_b, reg_b),
-        op::not(reg_a, reg_a),
+        op::not(reg_a, RegId::ZERO),
         op::subi(reg_a, reg_a, 63),
         op::ed19(reg_a, reg_b, reg_b),
         op::ret(RegId::ONE),
@@ -596,9 +589,8 @@ fn ed25519_verify_b_gt_vmaxram_sub_64() {
 
     #[rustfmt::skip]
     let script = vec![
-        op::xor(reg_a, reg_a, reg_a),
         op::xor(reg_b, reg_b, reg_b),
-        op::not(reg_a, reg_a),
+        op::not(reg_a, RegId::ZERO),
         op::subi(reg_a, reg_a, 63),
         op::ed19(reg_b, reg_a, reg_b),
         op::ret(RegId::ONE),
@@ -614,9 +606,8 @@ fn ed25519_verify_c_gt_vmaxram_sub_32() {
 
     #[rustfmt::skip]
     let script = vec![
-        op::xor(reg_a, reg_a, reg_a),
         op::xor(reg_b, reg_b, reg_b),
-        op::not(reg_a, reg_a),
+        op::not(reg_a, RegId::ZERO),
         op::subi(reg_a, reg_a, 31),
         op::ed19(reg_b, reg_b, reg_a),
         op::ret(RegId::ONE),
@@ -679,9 +670,8 @@ fn s256_a_gt_vmaxram_sub_32() {
 
     #[rustfmt::skip]
         let script = vec![
-        op::xor(reg_a, reg_a, reg_a),
         op::xor(reg_b, reg_b, reg_b),
-        op::not(reg_a, reg_a),
+        op::not(reg_a, RegId::ZERO),
         op::s256(reg_a, reg_b, reg_b),
     ];
 
@@ -691,14 +681,11 @@ fn s256_a_gt_vmaxram_sub_32() {
 #[test]
 fn s256_c_gt_mem_max() {
     let reg_a = 0x20;
-    let reg_b = 0x21;
 
     #[rustfmt::skip]
         let script = vec![
-        op::xor(reg_a, reg_a, reg_a),
-        op::xor(reg_b, reg_b, reg_b),
-        op::not(reg_a, reg_a),
-        op::s256(reg_b, reg_b, reg_a),
+        op::not(reg_a, RegId::ZERO),
+        op::s256(RegId::ZERO, RegId::ZERO, reg_a),
     ];
 
     check_expected_reason_for_instructions(script, MemoryOverflow);
@@ -711,9 +698,8 @@ fn s256_b_gt_vmaxram_sub_c() {
 
     #[rustfmt::skip]
         let script = vec![
-        op::xor(reg_a, reg_a, reg_a),
         op::xor(reg_b, reg_b, reg_b),
-        op::not(reg_a, reg_a),
+        op::not(reg_a, RegId::ZERO),
         op::s256(reg_b, reg_a, reg_b),
     ];
 
@@ -777,9 +763,8 @@ fn k256_a_gt_vmaxram_sub_32() {
 
     #[rustfmt::skip]
         let script = vec![
-        op::xor(reg_a, reg_a, reg_a),
         op::xor(reg_b, reg_b, reg_b),
-        op::not(reg_a, reg_a),
+        op::not(reg_a, RegId::ZERO),
         op::k256(reg_a, reg_b, reg_b),
     ];
 
@@ -793,9 +778,8 @@ fn k256_c_gt_mem_max() {
 
     #[rustfmt::skip]
     let script = vec![
-        op::xor(reg_a, reg_a, reg_a),
         op::xor(reg_b, reg_b, reg_b),
-        op::not(reg_a, reg_a),
+        op::not(reg_a, RegId::ZERO),
         op::k256(reg_b, reg_b, reg_a),
     ];
 
@@ -809,9 +793,8 @@ fn k256_b_gt_vmaxram_sub_c() {
 
     #[rustfmt::skip]
         let script = vec![
-        op::xor(reg_a, reg_a, reg_a),
         op::xor(reg_b, reg_b, reg_b),
-        op::not(reg_a, reg_a),
+        op::not(reg_a, RegId::ZERO),
         op::k256(reg_b, reg_a, reg_b),
     ];
 

--- a/fuel-vm/src/tests/memory.rs
+++ b/fuel-vm/src/tests/memory.rs
@@ -53,10 +53,9 @@ fn setup(program: Vec<Instruction>) -> Transactor<MemoryStorage, Script> {
 fn test_lw() {
     let ops = vec![
         op::movi(0x10, 8),
-        op::movi(0x11, 1),
         op::aloc(0x10),
         op::move_(0x10, RegId::HP),
-        op::sw(0x10, 0x11, 0),
+        op::sw(0x10, RegId::ONE, 0),
         op::lw(0x13, 0x10, 0),
         op::ret(RegId::ONE),
     ];
@@ -70,10 +69,9 @@ fn test_lw() {
 fn test_lw_unaglined() {
     let ops = vec![
         op::movi(0x10, 9),
-        op::movi(0x11, 1),
         op::aloc(0x10),
         op::move_(0x10, RegId::HP),
-        op::sw(0x10, 0x11, 0),
+        op::sw(0x10, RegId::ONE, 0),
         op::lw(0x13, 0x10, 0),
         op::ret(RegId::ONE),
     ];
@@ -87,10 +85,9 @@ fn test_lw_unaglined() {
 fn test_lb() {
     let ops = vec![
         op::movi(0x10, 8),
-        op::movi(0x11, 1),
         op::aloc(0x10),
         op::move_(0x10, RegId::HP),
-        op::sb(0x10, 0x11, 0),
+        op::sb(0x10, RegId::ONE, 0),
         op::lb(0x13, 0x10, 0),
         op::ret(RegId::ONE),
     ];


### PR DESCRIPTION
Replaces unnecessary uses of registers with values of zero and one with their hardwired counterparts. Also replaces zeroing `xor` instructions followed by assignment by just the assignment.