### PR TITLE
Charge for new storage bytes

### DIFF
--- a/fuel-tx/src/transaction/consensus_parameters/gas.rs
+++ b/fuel-tx/src/transaction/consensus_parameters/gas.rs
@@ -321,6 +321,7 @@ pub struct GasCostsValues {
     // Non-opcode costs
     pub contract_root: DependentCost,
     pub state_root: DependentCost,
+    pub new_storage_per_byte: Word, // TODO: this is currently per slot
 }
 
 /// Dependent cost is a cost that depends on the number of units.
@@ -474,6 +475,7 @@ impl GasCostsValues {
             swwq: DependentCost::free(),
             contract_root: DependentCost::free(),
             state_root: DependentCost::free(),
+            new_storage_per_byte: 0,
         }
     }
 
@@ -588,6 +590,7 @@ impl GasCostsValues {
             swwq: DependentCost::unit(),
             contract_root: DependentCost::unit(),
             state_root: DependentCost::unit(),
+            new_storage_per_byte: 1,
         }
     }
 }

--- a/fuel-tx/src/transaction/consensus_parameters/gas/default_gas_costs.rs
+++ b/fuel-tx/src/transaction/consensus_parameters/gas/default_gas_costs.rs
@@ -169,5 +169,6 @@ pub fn default_gas_costs() -> GasCostsValues {
             base: 412,
             units_per_gas: 1,
         },
+        new_storage_per_byte: 1,
     }
 }

--- a/fuel-vm/src/interpreter/blockchain.rs
+++ b/fuel-vm/src/interpreter/blockchain.rs
@@ -959,7 +959,7 @@ pub(crate) fn state_write_word<S: InterpreterStorage>(
         pc,
     }: StateWordCtx<S>,
     a: Word,
-    exists: &mut Word,
+    created_new: &mut Word,
     c: Word,
 ) -> IoResult<(), S::DataError> {
     let key = CheckedMemConstLen::<{ Bytes32::LEN }>::new(a)?;
@@ -978,7 +978,7 @@ pub(crate) fn state_write_word<S: InterpreterStorage>(
         .merkle_contract_state_insert(contract, key, &value)
         .map_err(RuntimeError::Storage)?;
 
-    *exists = result.is_some() as Word;
+    *created_new = result.is_none() as Word;
 
     if result.is_none() {
         // New data was written, charge gas for it
@@ -1231,7 +1231,7 @@ fn state_write_qword<'vm, S: InterpreterStorage>(
     let unset_count = storage
         .merkle_contract_state_insert_range(contract_id, destination_key, &values)
         .map_err(RuntimeError::Storage)?;
-    *result_register = (unset_count != 0) as Word;
+    *result_register = unset_count as Word;
 
     if unset_count > 0 {
         // New data was written, charge gas for it

--- a/fuel-vm/src/interpreter/blockchain/test.rs
+++ b/fuel-vm/src/interpreter/blockchain/test.rs
@@ -64,6 +64,9 @@ fn test_state_read_word(
     let mut memory: Memory<MEM_SIZE> = vec![1u8; MEM_SIZE].try_into().unwrap();
     memory[0..ContractId::LEN].copy_from_slice(&[3u8; ContractId::LEN][..]);
     memory[32..64].copy_from_slice(&[4u8; 32][..]);
+    let is = 4;
+    let mut cgas = 1000;
+    let mut ggas = 1000;
     let mut pc = 4;
     let mut result = 0;
     let mut got_result = 0;
@@ -86,6 +89,12 @@ fn test_state_read_word(
             storage: &mut storage,
             memory: &mut memory,
             context: &context,
+            profiler: &mut Profiler::default(),
+            new_storage_gas_per_byte: 1,
+            current_contract: None,
+            cgas: RegMut::new(&mut cgas),
+            ggas: RegMut::new(&mut ggas),
+            is: Reg::new(&is),
             fp: Reg::new(&fp),
             pc: RegMut::new(&mut pc),
         };
@@ -97,6 +106,12 @@ fn test_state_read_word(
         storage: &mut storage,
         memory: &mut memory,
         context: &context,
+        profiler: &mut Profiler::default(),
+        new_storage_gas_per_byte: 1,
+        current_contract: None,
+        cgas: RegMut::new(&mut cgas),
+        ggas: RegMut::new(&mut ggas),
+        is: Reg::new(&is),
         fp: Reg::new(&fp),
         pc: RegMut::new(&mut pc),
     };
@@ -137,6 +152,10 @@ fn test_state_write_word(
         }
     };
 
+    let is = 4;
+    let mut cgas = 1000;
+    let mut ggas = 1000;
+
     if insert {
         let fp = 0;
         let context = Context::Call {
@@ -146,6 +165,12 @@ fn test_state_write_word(
             storage: &mut storage,
             memory: &mut memory,
             context: &context,
+            profiler: &mut Profiler::default(),
+            new_storage_gas_per_byte: 1,
+            current_contract: None,
+            cgas: RegMut::new(&mut cgas),
+            ggas: RegMut::new(&mut ggas),
+            is: Reg::new(&is),
             fp: Reg::new(&fp),
             pc: RegMut::new(&mut pc),
         };
@@ -157,6 +182,12 @@ fn test_state_write_word(
         storage: &mut storage,
         memory: &mut memory,
         context: &context,
+        new_storage_gas_per_byte: 1,
+        current_contract: None,
+        profiler: &mut Profiler::default(),
+        cgas: RegMut::new(&mut cgas),
+        ggas: RegMut::new(&mut ggas),
+        is: Reg::new(&is),
         fp: Reg::new(&fp),
         pc: RegMut::new(&mut pc),
     };

--- a/fuel-vm/src/interpreter/blockchain/test.rs
+++ b/fuel-vm/src/interpreter/blockchain/test.rs
@@ -121,13 +121,13 @@ fn test_state_read_word(
     Ok((result, got_result))
 }
 
-#[test_case(false, 0, false, 32 => Ok(0); "Nothing set")]
-#[test_case(false, 0, true, 32 => Ok(1); "Something set")]
+#[test_case(false, 0, false, 32 => Ok(1); "Nothing set")]
+#[test_case(false, 0, true, 32 => Ok(0); "Something set")]
 #[test_case(true, 0, false, 32 => Err(RuntimeError::Recoverable(PanicReason::ExpectedInternalContext)); "Can't write state from external context")]
-#[test_case(false, 1, false, 32 => Ok(0); "Wrong contract id")]
-#[test_case(false, 0, false, 33 => Ok(0); "Wrong key")]
-#[test_case(false, 1, true, 32 => Ok(0); "Wrong contract id with existing")]
-#[test_case(false, 0, true, 33 => Ok(0); "Wrong key with existing")]
+#[test_case(false, 1, false, 32 => Ok(1); "Wrong contract id")]
+#[test_case(false, 0, false, 33 => Ok(1); "Wrong key")]
+#[test_case(false, 1, true, 32 => Ok(1); "Wrong contract id with existing")]
+#[test_case(false, 0, true, 33 => Ok(1); "Wrong key with existing")]
 #[test_case(true, 0, false, Word::MAX => Err(RuntimeError::Recoverable(PanicReason::MemoryOverflow)); "Overflowing key")]
 #[test_case(true, 0, false, VM_MAX_RAM => Err(RuntimeError::Recoverable(PanicReason::MemoryOverflow)); "Overflowing key ram")]
 fn test_state_write_word(

--- a/fuel-vm/src/interpreter/blockchain/test/swwq.rs
+++ b/fuel-vm/src/interpreter/blockchain/test/swwq.rs
@@ -25,7 +25,7 @@ struct SWWQInput {
         input: StateWriteQWord::new(2, 34, 1).unwrap(),
         storage_slots: vec![],
         memory: mem(&[&[0; 2], &key(27), &[5; 32]]),
-    } => (vec![(key(27), [5; 32])], false)
+    } => (vec![(key(27), [5; 32])], 1)
     ; "Single slot write w/ offset key in memory"
 )]
 #[test_case(
@@ -33,7 +33,7 @@ struct SWWQInput {
         input: StateWriteQWord::new(0, 32, 2).unwrap(),
         storage_slots: vec![],
         memory: mem(&[&key(27), &[5; 32], &[6; 32]]),
-    } => (vec![(key(27), [5; 32]), (key(28), [6; 32])], false)
+    } => (vec![(key(27), [5; 32]), (key(28), [6; 32])], 2)
     ; "Two slot write"
 )]
 #[test_case(
@@ -41,7 +41,7 @@ struct SWWQInput {
         input: StateWriteQWord::new(0, 32, 2).unwrap(),
         storage_slots: vec![(key(27), [2; 32])],
         memory: mem(&[&key(27), &[5; 32], &[6; 32]]),
-    } => (vec![(key(27), [5; 32]), (key(28), [6; 32])], false)
+    } => (vec![(key(27), [5; 32]), (key(28), [6; 32])], 1)
     ; "Two slot writes with one pre-existing slot set"
 )]
 #[test_case(
@@ -49,7 +49,7 @@ struct SWWQInput {
         input: StateWriteQWord::new(0, 32, 2).unwrap(),
         storage_slots: vec![],
         memory: mem(&[&key(27), &[5; 32], &[6; 32], &[7; 32]]),
-    } => (vec![(key(27), [5; 32]), (key(28), [6; 32])], false)
+    } => (vec![(key(27), [5; 32]), (key(28), [6; 32])], 2)
     ; "Only writes two slots when memory has more data available"
 )]
 #[test_case(
@@ -57,7 +57,7 @@ struct SWWQInput {
         input: StateWriteQWord::new(0, 32, 3).unwrap(),
         storage_slots: vec![],
         memory: mem(&[&key(27), &[5; 32], &[6; 32], &[7; 32]]),
-    } => (vec![(key(27), [5; 32]), (key(28), [6; 32]), (key(29), [7; 32])], false)
+    } => (vec![(key(27), [5; 32]), (key(28), [6; 32]), (key(29), [7; 32])], 3)
     ; "Three slot write"
 )]
 #[test_case(
@@ -65,7 +65,7 @@ struct SWWQInput {
         input: StateWriteQWord::new(0, 32, 3).unwrap(),
         storage_slots: vec![(key(29), [8; 32])],
         memory: mem(&[&key(27), &[5; 32], &[6; 32], &[7; 32]]),
-    } => (vec![(key(27), [5; 32]), (key(28), [6; 32]), (key(29), [7; 32])], false)
+    } => (vec![(key(27), [5; 32]), (key(28), [6; 32]), (key(29), [7; 32])], 2)
     ; "Three slot write with one pre-existing slot set"
 )]
 #[test_case(
@@ -73,7 +73,7 @@ struct SWWQInput {
         input: StateWriteQWord::new(0, 32, 3).unwrap(),
         storage_slots: vec![(key(27), [5; 32]), (key(28), [6; 32]), (key(29), [7; 32])],
         memory: mem(&[&key(27), &[5; 32], &[6; 32], &[7; 32]]),
-    } => (vec![(key(27), [5; 32]), (key(28), [6; 32]), (key(29), [7; 32])], true)
+    } => (vec![(key(27), [5; 32]), (key(28), [6; 32]), (key(29), [7; 32])], 0)
     ; "Three slot write with all slots previously set"
 )]
 #[test_case(
@@ -81,7 +81,7 @@ struct SWWQInput {
         input: StateWriteQWord::new(0, 32, 2).unwrap(),
         storage_slots: vec![(key(29), [8; 32])],
         memory: mem(&[&key(27), &[5; 32], &[6; 32], &[7; 32]]),
-    } => (vec![(key(27), [5; 32]), (key(28), [6; 32]), (key(29), [8; 32])], false)
+    } => (vec![(key(27), [5; 32]), (key(28), [6; 32]), (key(29), [8; 32])], 2)
     ; "Does not override slots that aren't being written to (adjacent)"
 )]
 #[test_case(
@@ -89,10 +89,10 @@ struct SWWQInput {
         input: StateWriteQWord::new(0, 32, 3).unwrap(),
         storage_slots: vec![(key(100), [8; 32])],
         memory: mem(&[&key(27), &[5; 32], &[6; 32], &[7; 32]]),
-    } => (vec![(key(27), [5; 32]), (key(28), [6; 32]), (key(29), [7; 32]), (key(100), [8; 32])], false)
+    } => (vec![(key(27), [5; 32]), (key(28), [6; 32]), (key(29), [7; 32]), (key(100), [8; 32])], 3)
     ; "Does not override slots that aren't being written to (non-adjacent)"
 )]
-fn test_state_write_qword(input: SWWQInput) -> (Vec<([u8; 32], [u8; 32])>, bool) {
+fn test_state_write_qword(input: SWWQInput) -> (Vec<([u8; 32], [u8; 32])>, u64) {
     let SWWQInput {
         input,
         storage_slots,
@@ -135,7 +135,7 @@ fn test_state_write_qword(input: SWWQInput) -> (Vec<([u8; 32], [u8; 32])>, bool)
         .all_contract_state()
         .map(|(key, v)| (**key.state_key(), **v))
         .collect();
-    (results, result_register != 0)
+    (results, result_register)
 }
 
 #[test_case(

--- a/fuel-vm/src/interpreter/blockchain/test/swwq.rs
+++ b/fuel-vm/src/interpreter/blockchain/test/swwq.rs
@@ -111,11 +111,20 @@ fn test_state_write_qword(input: SWWQInput) -> (Vec<([u8; 32], [u8; 32])>, bool)
     }
 
     let mut result_register = 0u64;
+    let is = 0;
+    let mut cgas = 10_000;
+    let mut ggas = 10_000;
     let mut pc = 0;
     state_write_qword(
         &Default::default(),
         &mut storage,
         &memory,
+        &mut Profiler::default(),
+        1,
+        None,
+        RegMut::new(&mut cgas),
+        RegMut::new(&mut ggas),
+        Reg::new(&is),
         RegMut::new(&mut pc),
         &mut result_register,
         input,

--- a/fuel-vm/src/interpreter/diff/storage.rs
+++ b/fuel-vm/src/interpreter/diff/storage.rs
@@ -427,7 +427,7 @@ where
         contract: &ContractId,
         start_key: &Bytes32,
         values: &[Bytes32],
-    ) -> Result<Option<()>, Self::DataError> {
+    ) -> Result<usize, Self::DataError> {
         self.0
             .merkle_contract_state_insert_range(contract, start_key, values)
     }

--- a/fuel-vm/src/interpreter/executors/main.rs
+++ b/fuel-vm/src/interpreter/executors/main.rs
@@ -381,7 +381,7 @@ where
         if max_gas > params.max_gas_per_tx {
             return Err(
                 PredicateVerificationFailed::TransactionExceedsTotalGasAllowance(max_gas),
-            );
+            )
         }
 
         let cumulative_gas_used = checks.into_iter().try_fold(0u64, |acc, result| {

--- a/fuel-vm/src/storage/interpreter.rs
+++ b/fuel-vm/src/storage/interpreter.rs
@@ -195,13 +195,13 @@ pub trait InterpreterStorage:
     ) -> Result<Vec<Option<Cow<Bytes32>>>, Self::DataError>;
 
     /// Insert a range of key-value mappings into contract storage.
-    /// Returns None if any of the keys in the range were previously unset.
+    /// Returns the number of keys that were previously unset but are now set.
     fn merkle_contract_state_insert_range(
         &mut self,
         contract: &ContractId,
         start_key: &Bytes32,
         values: &[Bytes32],
-    ) -> Result<Option<()>, Self::DataError>;
+    ) -> Result<usize, Self::DataError>;
 
     /// Remove a range of key-values from contract storage.
     /// Returns None if any of the keys in the range were already unset.
@@ -302,7 +302,7 @@ where
         contract: &ContractId,
         start_key: &Bytes32,
         values: &[Bytes32],
-    ) -> Result<Option<()>, Self::DataError> {
+    ) -> Result<usize, Self::DataError> {
         <S as InterpreterStorage>::merkle_contract_state_insert_range(
             self.deref_mut(),
             contract,

--- a/fuel-vm/src/storage/predicate.rs
+++ b/fuel-vm/src/storage/predicate.rs
@@ -160,7 +160,7 @@ impl InterpreterStorage for PredicateStorage {
         _contract: &ContractId,
         _start_key: &Bytes32,
         _values: &[Bytes32],
-    ) -> Result<Option<()>, StorageUnavailable> {
+    ) -> Result<usize, StorageUnavailable> {
         Err(StorageUnavailable)
     }
 

--- a/fuel-vm/src/tests/blockchain.rs
+++ b/fuel-vm/src/tests/blockchain.rs
@@ -1038,7 +1038,7 @@ fn sww_sets_status() {
         op::ret(RegId::ONE),
     ];
 
-    check_receipts_for_program_call(program, vec![0, 1, 0, 0]);
+    check_receipts_for_program_call(program, vec![1, 1, 0, 0]);
 }
 
 #[test]
@@ -1052,7 +1052,7 @@ fn scwq_clears_status() {
         op::ret(RegId::ONE),
     ];
 
-    check_receipts_for_program_call(program, vec![0, 1, 0, 0]);
+    check_receipts_for_program_call(program, vec![1, 1, 0, 0]);
 }
 
 #[test]
@@ -1062,7 +1062,7 @@ fn scwq_clears_status_for_range() {
         op::movi(0x11, 100),
         op::aloc(0x11),
         op::addi(0x31, RegId::HP, 0x4),
-        op::addi(0x32, RegId::ONE, 2),
+        op::movi(0x32, 3),
         op::scwq(0x31, SET_STATUS_REG, 0x32),
         op::addi(0x31, RegId::HP, 0x4),
         op::swwq(0x31, SET_STATUS_REG + 1, 0x31, 0x32),
@@ -1072,25 +1072,26 @@ fn scwq_clears_status_for_range() {
         op::ret(RegId::ONE),
     ];
 
-    check_receipts_for_program_call(program, vec![0, 0, 1, 0]);
+    check_receipts_for_program_call(program, vec![0, 3, 1, 0]);
 }
 
 #[test]
 fn srw_reads_status() {
-    #[rustfmt::skip]
     let program = vec![
-        op::sww(0x30,  SET_STATUS_REG, RegId::ZERO),
+        op::sww(0x30, SET_STATUS_REG, RegId::ZERO),
         op::srw(0x30, SET_STATUS_REG + 1, RegId::ZERO),
         op::srw(0x30, SET_STATUS_REG + 2, RegId::ZERO),
         op::srw(0x30, SET_STATUS_REG + 3, RegId::ONE),
-        op::log(SET_STATUS_REG,
-                    SET_STATUS_REG + 1,
-                    SET_STATUS_REG + 2,
-                    SET_STATUS_REG + 3),
+        op::log(
+            SET_STATUS_REG,
+            SET_STATUS_REG + 1,
+            SET_STATUS_REG + 2,
+            SET_STATUS_REG + 3,
+        ),
         op::ret(RegId::ONE),
     ];
 
-    check_receipts_for_program_call(program, vec![0, 1, 1, 0]);
+    check_receipts_for_program_call(program, vec![1, 1, 1, 0]);
 }
 
 #[test]
@@ -1106,7 +1107,7 @@ fn srwq_reads_status() {
         op::ret(RegId::ONE),
     ];
 
-    check_receipts_for_program_call(program, vec![0, 1, 1, 0]);
+    check_receipts_for_program_call(program, vec![1, 1, 1, 0]);
 }
 
 #[test]
@@ -1126,7 +1127,7 @@ fn srwq_reads_status_with_range() {
         op::ret(RegId::ONE),
     ];
 
-    check_receipts_for_program_call(program, vec![0, 0, 1, 0]);
+    check_receipts_for_program_call(program, vec![0, 2, 1, 0]);
 }
 
 #[test]
@@ -1142,7 +1143,7 @@ fn swwq_sets_status() {
         op::ret(RegId::ONE),
     ];
 
-    check_receipts_for_program_call(program, vec![0, 0, 1, 0]);
+    check_receipts_for_program_call(program, vec![0, 1, 1, 0]);
 }
 
 #[test]
@@ -1158,7 +1159,7 @@ fn swwq_sets_status_with_range() {
         op::ret(RegId::ONE),
     ];
 
-    check_receipts_for_program_call(program, vec![0, 1, 0, 0]);
+    check_receipts_for_program_call(program, vec![2, 0, 0, 0]);
 }
 
 fn check_receipts_for_program_call(
@@ -1219,19 +1220,23 @@ fn check_receipts_for_program_call(
     // Expect the correct receipt
     assert_eq!(
         receipts[1].ra().expect("Register value expected"),
-        expected_values[0]
+        expected_values[0],
+        "$ra mismatch"
     );
     assert_eq!(
         receipts[1].rb().expect("Register value expected"),
-        expected_values[1]
+        expected_values[1],
+        "$rb mismatch"
     );
     assert_eq!(
         receipts[1].rc().expect("Register value expected"),
-        expected_values[2]
+        expected_values[2],
+        "$rc mismatch"
     );
     assert_eq!(
         receipts[1].rd().expect("Register value expected"),
-        expected_values[3]
+        expected_values[3],
+        "$rd mismatch"
     );
 
     true


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuel-vm/issues/602

This is still a rough draft.

Breaking changes:
* Write opcodes now return the number of new storage slots instead of just a boolean on whether the value existed. [The return value is currently ignored by the Sway stdlib](https://github.com/FuelLabs/sway/blob/28d3500e702337fde0d7e6975d6e0a40aa49ad1d/sway-lib-std/src/storage/storage_api.sw#L56C13-L56C31), so it shouldn't be too bad