### PR TITLE
Release v0.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.42.0]
+
 ### Changed
 
 #### Breaking

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,17 +18,17 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.41.0"
+version = "0.42.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.41.0", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.41.0", path = "fuel-crypto", default-features = false }
-fuel-derive = { version = "0.41.0", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.41.0", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.41.0", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.41.0", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.41.0", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.41.0", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.42.0", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.42.0", path = "fuel-crypto", default-features = false }
+fuel-derive = { version = "0.42.0", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.42.0", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.42.0", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.42.0", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.42.0", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.42.0", path = "fuel-vm", default-features = false }
 bitflags = "2"
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"

--- a/fuel-tx/src/transaction/types/witness.rs
+++ b/fuel-tx/src/transaction/types/witness.rs
@@ -48,22 +48,17 @@ impl Witness {
     pub fn recover_witness(
         &self,
         txhash: &TxId,
-        witness_index: usize,
+        input_index: usize,
     ) -> Result<fuel_types::Address, ValidityError> {
-        let bytes = <[u8; Signature::LEN]>::try_from(self.as_ref()).map_err(|_| {
-            ValidityError::InputInvalidSignature {
-                index: witness_index,
-            }
-        })?;
+        let bytes = <[u8; Signature::LEN]>::try_from(self.as_ref())
+            .map_err(|_| ValidityError::InputInvalidSignature { index: input_index })?;
         let signature = Signature::from_bytes(bytes);
 
         let message = Message::from_bytes_ref(txhash);
 
         signature
             .recover(message)
-            .map_err(|_| ValidityError::InputInvalidSignature {
-                index: witness_index,
-            })
+            .map_err(|_| ValidityError::InputInvalidSignature { index: input_index })
             .map(|pk| Input::owner(&pk))
     }
 }

--- a/fuel-tx/src/transaction/validity.rs
+++ b/fuel-tx/src/transaction/validity.rs
@@ -93,7 +93,7 @@ impl Input {
                         .get(*witness_index as usize)
                         .ok_or(ValidityError::InputWitnessIndexBounds { index })?;
 
-                    witness.recover_witness(txhash, *witness_index as usize)
+                    witness.recover_witness(txhash, index)
                 };
 
                 // recover the address associated with a witness, using the cache if

--- a/fuel-vm/src/interpreter/executors/main.rs
+++ b/fuel-vm/src/interpreter/executors/main.rs
@@ -500,7 +500,7 @@ where
                     false
                 }
             }) {
-                return Err(InterpreterError::Panic(PanicReason::ContractNotFound))
+                return Err(InterpreterError::Panic(PanicReason::ContractNotInInputs))
             }
 
             let gas_limit;


### PR DESCRIPTION
## Version 0.42.0

### Changed

#### Breaking

- [#629](https://github.com/FuelLabs/fuel-vm/pull/629): Charge the user for VM initialization.
- [#628](https://github.com/FuelLabs/fuel-vm/pull/628): Renamed `transaction::CheckError` to `transaction::ValidityError`.
  Created a new `checked_transaction::CheckError` that combines `ValidityError`
  and `PredicateVerificationFailed` errors into one. It allows the return of the
  `PredicateVerificationFailed` to the end user instead of losing the reason why predicate verification failed.
- [#625](https://github.com/FuelLabs/fuel-vm/pull/625): Use `ArithmeticError` only for arithmetic operations, and introduce new errors like `BalanceOverflow` for others. Whenever an error is internally caused by a type conversion to `usize`, so that an overflowing value wouldn't map to a valid index anyway, return the missing item error instead.
- [#623](https://github.com/FuelLabs/fuel-vm/pull/623):
  Added support for transaction policies. The `Script` and `Create`
  transactions received a new field, `policies`. Policies allow the addition
  of some limits to the transaction to protect the user or specify some details regarding execution.
  This change makes the `GasPrice` and `Maturity` fields optional, allowing to save space in the future.
  Also, this will enable us to support multidimensional prices later.
  `GasLimit` was renamed to `ScriptGasLimit`.

  Along with this change, we introduced two new policies:
    - `WitnessLimit` - allows the limitation of the maximum size of witnesses in bytes for the contract. Because of the changes in the gas calculation model(the blockchain also charges the user for the witness data), the user should protect himself from the block producer or third parties blowing up witness data and draining the user's funds.
    - `MaxFee` - allows the upper bound for the maximum fee that users agree to pay for the transaction.

  This change brings the following modification to the gas model:
    - The `ScriptGasLimit` only limits script execution. Previously, the `ScriptGasLimit` also limited the predicate execution time, instead predicate gas is now directly included into `min_fee`. So, it is not possible to use the `ScriptGasLimit` for transaction cost limitations. A new `MaxFee` policy is a way to do that. The `GasLimit` field was removed from the `Create` transaction because it only relates to the script execution (which the `Create` transaction doesn't have).
    - The blockchain charges the user for the size of witness data (before it was free). There is no separate price for the storage, so it uses gas to charge the user. This change affects `min_gas` and `min_fee` calculation.
    - A new policy called `WitnessLimit` also impacts the `max_gas` and `max_fee` calculation in addition to `ScriptGasLimit`(in the case of `Create` transaction only `WitnessLimit` affects the `max_gas` and `max_fee`).
    - The minimal gas also charges the user for transaction ID calculation.

  The change has the following modification to the transaction layout:
    - The `Create` transaction doesn't have the `ScriptGasLimit` field anymore. Because the `Create` transaction doesn't have any script to execute
    - The `Create` and `Script` transactions don't have explicit `maturity` and `gas_price` fields. Instead, these fields can be set via a new `policies` field.
    - The `Create` and `Script` transactions have a new `policies` field with a unique canonical serialization and deserialization for optimal space consumption.

  Other breaking changes caused by the change:
    - Each transaction requires setting the `GasPrice` policy.
    - Previously, `ScriptGasLimit` should be less than the `MAX_GAS_PER_TX` constant. After removing this field from the `Create` transaction, it is impossible to require it. Instead, it requires that `max_gas <= MAX_GAS_PER_TX` for any transaction. Consequently, any `Script` transaction that uses `MAX_GAS_PER_TX` as a `ScriptGasLimit` will always fail because of a new rule. Setting the estimated gas usage instead solves the problem.
    - If the `max_fee > policies.max_fee`, then transaction will be rejected.
    - If the `witnessses_size > policies.witness_limit`, then transaction will be rejected.
    - GTF opcode changed its hardcoded constants for fields. It should be updated according to the values from the specification on the Sway side.
- [#633](https://github.com/FuelLabs/fuel-vm/pull/633): Limit receipt count to `u16::MAX`.
- [#634](https://github.com/FuelLabs/fuel-vm/pull/634): Charge for storage per new byte written. Write opcodes now return the number of new storage slots created, instead of just a boolean on whether the value existed before.

### Fixed

- [#627](https://github.com/FuelLabs/fuel-vm/pull/627): Added removal of obsolete SMT nodes along the path during `update` and `delete` operations.

## What's Changed
* Support transaction policies by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/623
* Remove SMT nodes along the path during `update` by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/627
* Limit ReceiptsCtx to u16::MAX receipts by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/633
* Charge the user for VM initialization by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/629
* Return `PredicateVerificationFailed` error to the user by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/628
* Split ArithmeticError into more granular errors by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/625
* Charge for new storage bytes by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/634


**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.41.0...v0.42.0