### PR TITLE
Release v0.42.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.42.1]
+
 ### Changed
 
 #### Breaking

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,17 +18,17 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.42.0"
+version = "0.42.1"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.42.0", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.42.0", path = "fuel-crypto", default-features = false }
-fuel-derive = { version = "0.42.0", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.42.0", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.42.0", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.42.0", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.42.0", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.42.0", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.42.1", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.42.1", path = "fuel-crypto", default-features = false }
+fuel-derive = { version = "0.42.1", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.42.1", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.42.1", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.42.1", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.42.1", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.42.1", path = "fuel-vm", default-features = false }
 bitflags = "2"
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
## Version 0.42.1

### Changed

#### Breaking

- [#637](https://github.com/FuelLabs/fuel-vm/pull/637): Charge for the actual size of the contract in `ccp` opcode.

## What's Changed
* v0.42.0 npm publishing fix by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/636
* Charge for the actual size of the contract in `ccp` opcode by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/637


**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.42.0...v0.42.1