### PR TITLE
chore: Update `vm_initialization` to be dependent cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 #### Breaking
 
+- [#640](https://github.com/FuelLabs/fuel-vm/pull/640): Update VM initialization cost to dependent cost; this is required because the time it takes to initialize the VM depends on the size of the transaction
 - [#629](https://github.com/FuelLabs/fuel-vm/pull/629): Charge the user for VM initialization.
 - [#628](https://github.com/FuelLabs/fuel-vm/pull/628): Renamed `transaction::CheckError` to `transaction::ValidityError`.
   Created a new `checked_transaction::CheckError` that combines `ValidityError`

--- a/fuel-tx/src/transaction/consensus_parameters/gas.rs
+++ b/fuel-tx/src/transaction/consensus_parameters/gas.rs
@@ -322,7 +322,7 @@ pub struct GasCostsValues {
     pub contract_root: DependentCost,
     pub state_root: DependentCost,
     pub new_storage_per_byte: Word,
-    pub vm_initialization: Word,
+    pub vm_initialization: DependentCost,
 }
 
 /// Dependent cost is a cost that depends on the number of units.
@@ -479,7 +479,7 @@ impl GasCostsValues {
             contract_root: DependentCost::free(),
             state_root: DependentCost::free(),
             new_storage_per_byte: 0,
-            vm_initialization: 0,
+            vm_initialization: DependentCost::free(),
         }
     }
 
@@ -597,7 +597,7 @@ impl GasCostsValues {
             contract_root: DependentCost::unit(),
             state_root: DependentCost::unit(),
             new_storage_per_byte: 1,
-            vm_initialization: 1,
+            vm_initialization: DependentCost::unit(),
         }
     }
 }

--- a/fuel-tx/src/transaction/consensus_parameters/gas/default_gas_costs.rs
+++ b/fuel-tx/src/transaction/consensus_parameters/gas/default_gas_costs.rs
@@ -172,6 +172,9 @@ pub fn default_gas_costs() -> GasCostsValues {
             units_per_gas: 1,
         },
         new_storage_per_byte: 1,
-        vm_initialization: 2000,
+        vm_initialization: DependentCost::HeavyOperation {
+            base: 2000,
+            gas_per_unit: 1,
+        },
     }
 }

--- a/fuel-tx/src/transaction/consensus_parameters/gas/default_gas_costs.rs
+++ b/fuel-tx/src/transaction/consensus_parameters/gas/default_gas_costs.rs
@@ -174,7 +174,7 @@ pub fn default_gas_costs() -> GasCostsValues {
         new_storage_per_byte: 1,
         vm_initialization: DependentCost::HeavyOperation {
             base: 2000,
-            gas_per_unit: 1,
+            gas_per_unit: 0,
         },
     }
 }

--- a/fuel-vm/src/checked_transaction.rs
+++ b/fuel-vm/src/checked_transaction.rs
@@ -1009,7 +1009,7 @@ mod tests {
 
         let min_fee = fee.min_fee();
         let expected_min_fee = (tx.metered_bytes_size() as u64 * fee_params.gas_per_byte
-            + gas_costs.vm_initialization
+            + gas_costs.vm_initialization.resolve(tx.size() as u64)
             + 3 * gas_costs.ecr1
             + gas_costs.s256.resolve(tx.size() as u64))
             * gas_price;
@@ -1061,7 +1061,7 @@ mod tests {
         // be recovered once. Therefore, we charge only once for the address
         // recovery of the signed inputs.
         let expected_min_fee = (tx.metered_bytes_size() as u64 * fee_params.gas_per_byte
-            + gas_costs.vm_initialization
+            + gas_costs.vm_initialization.resolve(tx.size() as u64)
             + gas_costs.ecr1
             + gas_costs.s256.resolve(tx.size() as u64))
             * gas_price;
@@ -1125,12 +1125,12 @@ mod tests {
         let fee = TransactionFee::checked_from_tx(&gas_costs, &fee_params, &tx).unwrap();
 
         let min_fee = fee.min_fee();
-        let expected_min_fee = (tx.metered_bytes_size() as u64 * fee_params.gas_per_byte
-            + gas_costs.vm_initialization
+        let expected_min_fee = (tx.size() as u64 * fee_params.gas_per_byte
+            + gas_costs.vm_initialization.resolve(tx.size() as u64)
             + gas_costs.contract_root.resolve(predicate_1.len() as u64)
             + gas_costs.contract_root.resolve(predicate_2.len() as u64)
             + gas_costs.contract_root.resolve(predicate_3.len() as u64)
-            + 3 * gas_costs.vm_initialization
+            + 3 * gas_costs.vm_initialization.resolve(tx.size() as u64)
             + 50
             + 100
             + 200
@@ -1212,11 +1212,11 @@ mod tests {
         let min_fee = fee.min_fee();
         let expected_min_fee = (tx.metered_bytes_size() as u64 * fee_params.gas_per_byte
             + 3 * gas_costs.ecr1
-            + gas_costs.vm_initialization
+            + gas_costs.vm_initialization.resolve(tx.size() as u64)
             + gas_costs.contract_root.resolve(predicate_1.len() as u64)
             + gas_costs.contract_root.resolve(predicate_2.len() as u64)
             + gas_costs.contract_root.resolve(predicate_3.len() as u64)
-            + 3 * gas_costs.vm_initialization
+            + 3 * gas_costs.vm_initialization.resolve(tx.size() as u64)
             + 50
             + 100
             + 200
@@ -1254,7 +1254,7 @@ mod tests {
         let expected_min_fee = (tx.metered_bytes_size() as u64 * fee_params.gas_per_byte
             + gas_costs.state_root.resolve(storage_slots_len as Word)
             + gas_costs.contract_root.resolve(bytecode_len as Word)
-            + gas_costs.vm_initialization
+            + gas_costs.vm_initialization.resolve(tx.size() as u64)
             + gas_costs.s256.resolve(100)
             + gas_costs.s256.resolve(tx.size() as u64))
             * gas_price;
@@ -1287,7 +1287,7 @@ mod tests {
         let expected_min_fee = (tx.metered_bytes_size() as u64 * fee_params.gas_per_byte
             + gas_costs.state_root.resolve(0)
             + gas_costs.contract_root.resolve(0)
-            + gas_costs.vm_initialization
+            + gas_costs.vm_initialization.resolve(tx.size() as u64)
             + gas_costs.s256.resolve(100)
             + gas_costs.s256.resolve(tx.size() as u64))
             * gas_price;
@@ -1576,7 +1576,7 @@ mod tests {
         let min_gas = gas_used_by_bytes
             .saturating_add(gas_used_by_inputs)
             .saturating_add(gas_used_by_metadata)
-            .saturating_add(gas_costs.vm_initialization);
+            .saturating_add(gas_costs.vm_initialization.resolve(tx.size() as u64));
 
         // use different division mechanism than impl
         let witness_limit_allowance = tx
@@ -1615,7 +1615,11 @@ mod tests {
         let gas = gas_used_by_bytes
             .saturating_add(gas_used_by_inputs)
             .saturating_add(gas_used_by_metadata)
-            .saturating_add(gas_costs.vm_initialization);
+            .saturating_add(
+                gas_costs
+                    .vm_initialization
+                    .resolve(tx.metered_bytes_size() as u64),
+            );
         let total = gas as u128 * tx.price() as u128;
         // use different division mechanism than impl
         let fee = total / fee_params.gas_price_factor as u128;

--- a/fuel-vm/src/checked_transaction.rs
+++ b/fuel-vm/src/checked_transaction.rs
@@ -1576,7 +1576,11 @@ mod tests {
         let min_gas = gas_used_by_bytes
             .saturating_add(gas_used_by_inputs)
             .saturating_add(gas_used_by_metadata)
-            .saturating_add(gas_costs.vm_initialization.resolve(tx.size() as u64));
+            .saturating_add(
+                gas_costs
+                    .vm_initialization
+                    .resolve(tx.metered_bytes_size() as u64),
+            );
 
         // use different division mechanism than impl
         let witness_limit_allowance = tx


### PR DESCRIPTION
This PR updates the `vm_initialization` gas cost to a dependent cost, where it is dependent on the size of the transaction. 