### PR TITLE
Release v0.42.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.42.2]
+
+### Changed
+
+####
+
+- [#640](https://github.com/FuelLabs/fuel-vm/pull/640): Update VM initialization cost to dependent cost; this is required because the time it takes to initialize the VM depends on the size of the transaction.
+
 ## [Version 0.42.1]
 
 ### Changed
@@ -20,7 +28,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 #### Breaking
 
-- [#640](https://github.com/FuelLabs/fuel-vm/pull/640): Update VM initialization cost to dependent cost; this is required because the time it takes to initialize the VM depends on the size of the transaction
 - [#629](https://github.com/FuelLabs/fuel-vm/pull/629): Charge the user for VM initialization.
 - [#628](https://github.com/FuelLabs/fuel-vm/pull/628): Renamed `transaction::CheckError` to `transaction::ValidityError`.
   Created a new `checked_transaction::CheckError` that combines `ValidityError`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-####
+#### Breaking
 
 - [#640](https://github.com/FuelLabs/fuel-vm/pull/640): Update VM initialization cost to dependent cost; this is required because the time it takes to initialize the VM depends on the size of the transaction.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,17 +18,17 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.42.1"
+version = "0.42.2"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.42.1", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.42.1", path = "fuel-crypto", default-features = false }
-fuel-derive = { version = "0.42.1", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.42.1", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.42.1", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.42.1", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.42.1", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.42.1", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.42.2", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.42.2", path = "fuel-crypto", default-features = false }
+fuel-derive = { version = "0.42.2", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.42.2", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.42.2", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.42.2", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.42.2", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.42.2", path = "fuel-vm", default-features = false }
 bitflags = "2"
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
## Version 0.42.2

 ### Changed

 #### Breaking

 - [#640](https://github.com/FuelLabs/fuel-vm/pull/640): Update VM initialization cost to dependent cost; this is required because the time it takes to initialize the VM depends on the size of the transaction.

## What's Changed
* chore: Update `vm_initialization` to be dependent cost by @bvrooman in https://github.com/FuelLabs/fuel-vm/pull/640


**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.42.1...v0.42.2