### PR TITLE
wasm_bindgen support for fuel-tx

### DIFF
--- a/.npm/.scripts/prepare-wasm-packages.sh
+++ b/.npm/.scripts/prepare-wasm-packages.sh
@@ -39,7 +39,7 @@ build_wasm_npm_pkg_for ()
   rm -rf ${PKG_DIR}/{src,dist}
 
   cd ${ROOT_DIR}
-  cargo rustc -p ${NAME_DASHED} --target wasm32-unknown-unknown --features typescript --crate-type=cdylib --release $MORE_ARGS
+  cargo rustc -p ${NAME_DASHED} --target wasm32-unknown-unknown --features typescript --crate-type=cdylib --profile web-release $MORE_ARGS
   wasm-bindgen --typescript --target web ./target/wasm32-unknown-unknown/release/${NAME_UNDERSCORED}.wasm --out-dir ${PKG_DIR}/src
   wasm-opt ${PKG_DIR}/src/${NAME_UNDERSCORED}_bg.wasm -o ${PKG_DIR}/src/${NAME_UNDERSCORED}_bg.wasm -Oz
   cd ~-

--- a/.npm/.scripts/prepare-wasm-packages.sh
+++ b/.npm/.scripts/prepare-wasm-packages.sh
@@ -40,7 +40,7 @@ build_wasm_npm_pkg_for ()
 
   cd ${ROOT_DIR}
   cargo rustc -p ${NAME_DASHED} --target wasm32-unknown-unknown --features typescript --crate-type=cdylib --profile web-release $MORE_ARGS
-  wasm-bindgen --typescript --target web ./target/wasm32-unknown-unknown/wasm-release/${NAME_UNDERSCORED}.wasm --out-dir ${PKG_DIR}/src
+  wasm-bindgen --typescript --target web ./target/wasm32-unknown-unknown/web-release/${NAME_UNDERSCORED}.wasm --out-dir ${PKG_DIR}/src
   wasm-opt ${PKG_DIR}/src/${NAME_UNDERSCORED}_bg.wasm -o ${PKG_DIR}/src/${NAME_UNDERSCORED}_bg.wasm -Oz
   cd ~-
 

--- a/.npm/.scripts/prepare-wasm-packages.sh
+++ b/.npm/.scripts/prepare-wasm-packages.sh
@@ -32,13 +32,14 @@ build_wasm_npm_pkg_for ()
 {
   NAME_DASHED=$1
   NAME_UNDERSCORED=$(echo "${NAME_DASHED}" | sed -e 's/-/_/g')
+  MORE_ARGS=$2
 
   PKG_DIR=${PKGS_DIR}/${NAME_DASHED}
 
   rm -rf ${PKG_DIR}/{src,dist}
 
   cd ${ROOT_DIR}
-  cargo rustc -p ${NAME_DASHED} --target wasm32-unknown-unknown --features typescript --crate-type=cdylib --release
+  cargo rustc -p ${NAME_DASHED} --target wasm32-unknown-unknown --features typescript --crate-type=cdylib --release $MORE_ARGS
   wasm-bindgen --typescript --target web ./target/wasm32-unknown-unknown/release/${NAME_UNDERSCORED}.wasm --out-dir ${PKG_DIR}/src
   wasm-opt ${PKG_DIR}/src/${NAME_UNDERSCORED}_bg.wasm -o ${PKG_DIR}/src/${NAME_UNDERSCORED}_bg.wasm -Oz
   cd ~-
@@ -57,4 +58,4 @@ build_wasm_npm_pkg_for ()
 
 build_wasm_npm_pkg_for "fuel-asm"
 build_wasm_npm_pkg_for "fuel-types"
-build_wasm_npm_pkg_for "fuel-tx"
+build_wasm_npm_pkg_for "fuel-tx" --no-default-features

--- a/.npm/.scripts/prepare-wasm-packages.sh
+++ b/.npm/.scripts/prepare-wasm-packages.sh
@@ -57,3 +57,4 @@ build_wasm_npm_pkg_for ()
 
 build_wasm_npm_pkg_for "fuel-asm"
 build_wasm_npm_pkg_for "fuel-types"
+build_wasm_npm_pkg_for "fuel-tx"

--- a/.npm/.scripts/prepare-wasm-packages.sh
+++ b/.npm/.scripts/prepare-wasm-packages.sh
@@ -40,7 +40,7 @@ build_wasm_npm_pkg_for ()
 
   cd ${ROOT_DIR}
   cargo rustc -p ${NAME_DASHED} --target wasm32-unknown-unknown --features typescript --crate-type=cdylib --profile web-release $MORE_ARGS
-  wasm-bindgen --typescript --target web ./target/wasm32-unknown-unknown/release/${NAME_UNDERSCORED}.wasm --out-dir ${PKG_DIR}/src
+  wasm-bindgen --typescript --target web ./target/wasm32-unknown-unknown/wasm-release/${NAME_UNDERSCORED}.wasm --out-dir ${PKG_DIR}/src
   wasm-opt ${PKG_DIR}/src/${NAME_UNDERSCORED}_bg.wasm -o ${PKG_DIR}/src/${NAME_UNDERSCORED}_bg.wasm -Oz
   cd ~-
 

--- a/.npm/README.md
+++ b/.npm/README.md
@@ -57,7 +57,8 @@ The above commands will give ready-to-publish packages inside `.npm/packages`.
 │   └── prepare-wasm-packages
 ├── packages
 │   ├── fuel-asm   # <—— package #1
-│   └── fuel-types # <—— package #2
+│   ├── fuel-types # <—— package #2
+│   └── ...
 └── package.json
 ```
 

--- a/.npm/package.json
+++ b/.npm/package.json
@@ -17,12 +17,12 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@rollup/plugin-wasm": "^6.1.3",
-    "chai": "^4.3.7",
+    "@rollup/plugin-wasm": "^6.2.2",
+    "chai": "^4.3.10",
     "mocha": "^10.2.0",
     "npm-run-all": "^4.1.5",
-    "rollup": "^3.26.2",
-    "rollup-plugin-dts": "^5.3.0",
-    "turbo": "^1.10.9"
+    "rollup": "^3.29.4",
+    "rollup-plugin-dts": "^5.3.1",
+    "turbo": "^1.10.16"
   }
 }

--- a/.npm/packages/fuel-tx/index.test.cjs
+++ b/.npm/packages/fuel-tx/index.test.cjs
@@ -1,14 +1,14 @@
 const { expect } = require('chai')
-const types = require('.')
+const tx = require('.')
 
-describe('fuel-types [cjs]', () => {
+describe('fuel-tx [cjs]', () => {
 
   it('should export all types', () => {
-
-    expect(types.Input2).to.be.ok
-    expect(types.Output2).to.be.ok
-    expect(types.TxPointer).to.be.ok
-    expect(types.UtxoId).to.be.ok
+    expect(tx.Input2).to.be.ok
+    expect(tx.Output2).to.be.ok
+    expect(tx.TxPointer).to.be.ok
+    expect(tx.UtxoId).to.be.ok
   })
 
+  // TODO: copy from .mjs
 })

--- a/.npm/packages/fuel-tx/index.test.cjs
+++ b/.npm/packages/fuel-tx/index.test.cjs
@@ -4,8 +4,8 @@ const tx = require('.')
 describe('fuel-tx [cjs]', () => {
 
   it('should export all types', () => {
-    expect(tx.Input2).to.be.ok
-    expect(tx.Output2).to.be.ok
+    expect(tx.Input).to.be.ok
+    expect(tx.Output).to.be.ok
     expect(tx.TxPointer).to.be.ok
     expect(tx.UtxoId).to.be.ok
   })

--- a/.npm/packages/fuel-tx/index.test.cjs
+++ b/.npm/packages/fuel-tx/index.test.cjs
@@ -4,11 +4,172 @@ const tx = require('.')
 describe('fuel-tx [cjs]', () => {
 
   it('should export all types', () => {
+    expect(tx.UtxoId).to.be.ok
+    expect(tx.TxPointer).to.be.ok
+    expect(tx.PredicateParameters).to.be.ok
     expect(tx.Input).to.be.ok
     expect(tx.Output).to.be.ok
-    expect(tx.TxPointer).to.be.ok
-    expect(tx.UtxoId).to.be.ok
   })
 
-  // TODO: copy from .mjs
+  it('should serialize and deserialize UtxoId correctly', () => {
+    let utxo_id = new tx.UtxoId("0x0c0000000000000000000000000000000000000000000000000000000000000b1a");
+    let bytes = utxo_id.to_bytes();
+    let utxo_id2 = tx.UtxoId.from_bytes(bytes);
+    expect(utxo_id.toString()).to.equal(utxo_id2.toString())
+  })
+
+  it('should serialize and deserialize TxPointer correctly', () => {
+    let utxo_id = new tx.TxPointer("0123456789ab");
+    let bytes = utxo_id.to_bytes();
+    let utxo_id2 = tx.TxPointer.from_bytes(bytes);
+    expect(utxo_id.toString()).to.equal(utxo_id2.toString())
+  })
+
+
+  it('should serialize and deserialize all input variants correctly', () => {
+    [
+      tx.Input.coin_predicate(
+        new tx.UtxoId("0x0c0000000000000000000000000000000000000000000000000000000000000b1a"),
+        tx.Address.zeroed(),
+        BigInt(1234),
+        tx.AssetId.zeroed(),
+        new tx.TxPointer("0123456789ab"),
+        new tx.BlockHeight(5678),
+        BigInt(9012),
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+      ),
+      tx.Input.coin_signed(
+        new tx.UtxoId("0x0c0000000000000000000000000000000000000000000000000000000000000b1a"),
+        tx.Address.zeroed(),
+        BigInt(1234),
+        tx.AssetId.zeroed(),
+        new tx.TxPointer("0123456789ab"),
+        2,
+        new tx.BlockHeight(5678),
+      ),
+      tx.Input.contract(
+        new tx.UtxoId("0x0c0000000000000000000000000000000000000000000000000000000000000b1a"),
+        tx.Bytes32.zeroed(),
+        tx.Bytes32.zeroed(),
+        new tx.TxPointer("0123456789ab"),
+        tx.ContractId.zeroed(),
+      ),
+      tx.Input.message_coin_signed(
+        tx.Address.zeroed(),
+        tx.Address.zeroed(),
+        BigInt(1234),
+        tx.Nonce.zeroed(),
+        2,
+      ),
+      tx.Input.message_coin_predicate(
+        tx.Address.zeroed(),
+        tx.Address.zeroed(),
+        BigInt(1234),
+        tx.Nonce.zeroed(),
+        BigInt(1234),
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+      ),
+      tx.Input.message_data_signed(
+        tx.Address.zeroed(),
+        tx.Address.zeroed(),
+        BigInt(1234),
+        tx.Nonce.zeroed(),
+        2,
+        [1, 2, 3, 4],
+      ),
+      tx.Input.message_data_predicate(
+        tx.Address.zeroed(),
+        tx.Address.zeroed(),
+        BigInt(1234),
+        tx.Nonce.zeroed(),
+        BigInt(1234),
+        [0, 1, 2, 3],
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+      ),
+    ].forEach(input => {
+      let bytes = input.to_bytes();
+      let input2 = tx.Input.from_bytes(bytes);
+      expect(input.toString()).to.equal(input2.toString())
+    })
+  })
+
+
+  it('should serialize and deserialize all output variants correctly', () => {
+    [
+      tx.Output.coin(
+        tx.Address.zeroed(),
+        BigInt(1234),
+        tx.AssetId.zeroed(),
+      ),
+      tx.Output.contract(
+        2,
+        tx.Bytes32.zeroed(),
+        tx.Bytes32.zeroed(),
+      ),
+      tx.Output.change(
+        tx.Address.zeroed(),
+        BigInt(1234),
+        tx.AssetId.zeroed(),
+      ),
+      tx.Output.variable(
+        tx.Address.zeroed(),
+        BigInt(1234),
+        tx.AssetId.zeroed(),
+      ),
+      tx.Output.contract_created(
+        tx.ContractId.zeroed(),
+        tx.Bytes32.zeroed(),
+      ),
+    ].forEach(output => {
+      let bytes = output.to_bytes();
+      let output2 = tx.Output.from_bytes(bytes);
+      expect(output.toString()).to.equal(output2.toString())
+    })
+  })
+
+
+  // Hex string to byte string conversion.
+  const hexToBytes = hex => {
+    if (hex.length % 2 != 0) {
+      throw new Error("Needs full bytes");
+    }
+    const lookup = "0123456789abcdef";
+    let result = new Uint8Array(hex.length / 2);
+    for (let i = 0; i < result.length; i += 1) {
+      let high = lookup.indexOf(hex[i * 2]);
+      let low = lookup.indexOf(hex[i * 2 + 1]);
+      if (high === -1 || low === -1) {
+        throw new Error("Invalid hex char");
+      }
+      result[i] = (high << 4) | low;
+    }
+    return result;
+  }
+
+  it('should validate input correctly', () => {
+    let input = tx.Input.coin_signed(
+      new tx.UtxoId("0xc49d65de61cf04588a764b557d25cc6c6b4bc0d7429227e2a21e61c213b3a3e2:18"),
+      tx.Address.from_bytes(hexToBytes("f1e92c42b90934aa6372e30bc568a326f6e66a1a0288595e6e3fbd392a4f3e6e")),
+      10599410012256088338n,
+      tx.AssetId.from_bytes(hexToBytes("2cafad611543e0265d89f1c2b60d9ebf5d56ad7e23d9827d6b522fd4d6e44bc3")),
+      new tx.TxPointer("000000000000"),
+      0,
+      new tx.BlockHeight(0),
+    );
+
+    tx.check_input(input, 0, tx.Bytes32.from_bytes(hexToBytes("108eae4147d2c1c86ef4c2ab7c9fe94126645c8d8737495a0574ef1518ae74d8")), [], [{ data: hexToBytes("7ce4de2225f041b7f9fec727343a501d99e5b7b58d33f3d4a2cf218d3489959bdec24d13770b5d3bb084b4dac3474f95153e6ecc98f6f0f8ca37a2897b9562ee") }], new tx.PredicateParameters());
+  })
+
+  it('should validate output correctly', () => {
+    let output = tx.Output.change(
+      tx.Address.zeroed(),
+      1234n,
+      tx.AssetId.zeroed(),
+    );
+
+    tx.check_output(output, 0, []);
+  })
 })

--- a/.npm/packages/fuel-tx/index.test.cjs
+++ b/.npm/packages/fuel-tx/index.test.cjs
@@ -9,6 +9,11 @@ describe('fuel-tx [cjs]', () => {
     expect(tx.PredicateParameters).to.be.ok
     expect(tx.Input).to.be.ok
     expect(tx.Output).to.be.ok
+    expect(tx.Script).to.be.ok
+    expect(tx.Create).to.be.ok
+    expect(tx.Mint).to.be.ok
+    expect(tx.Transaction).to.be.ok
+    expect(tx.Policies).to.be.ok
   })
 
   it('should serialize and deserialize UtxoId correctly', () => {
@@ -130,6 +135,55 @@ describe('fuel-tx [cjs]', () => {
     })
   })
 
+
+  it('should serialize and deserialize all transaction variants correctly', () => {
+    [
+      [tx.Script, tx.Transaction.script(
+        1234n,
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+        new tx.Policies(),
+        [],
+        [],
+        [],
+      )],
+      [tx.Create, tx.Transaction.create(
+        1,
+        new tx.Policies(),
+        tx.Salt.zeroed(),
+        [],
+        [],
+        [],
+        [],
+      )],
+      [tx.Mint, tx.Transaction.mint(
+        new tx.TxPointer("0123456789ab"),
+        new tx.InputContract(
+          new tx.UtxoId("0xc49d65de61cf04588a764b557d25cc6c6b4bc0d7429227e2a21e61c213b3a3e2:18"),
+          tx.Bytes32.zeroed(),
+          tx.Bytes32.zeroed(),
+          new tx.TxPointer("0123456789ab"),
+          tx.ContractId.zeroed(),
+        ),
+        new tx.OutputContract(
+          3,
+          tx.Bytes32.zeroed(),
+          tx.Bytes32.zeroed(),
+        ),
+        1234n,
+        tx.AssetId.zeroed(),
+      )],
+    ].forEach(([tx_variant_type, tx_variant]) => {
+      let bytes = tx_variant.to_bytes();
+      let tx_variant2 = tx_variant_type.from_bytes(bytes);
+      expect(tx_variant.toString()).to.equal(tx_variant2.toString())
+
+      let wrapped_tx = tx_variant.as_tx();
+      let tx_bytes = wrapped_tx.to_bytes();
+      let wrapped_tx2 = tx.Transaction.from_bytes(tx_bytes);
+      expect(wrapped_tx.toString()).to.equal(wrapped_tx2.toString())
+    })
+  })
 
   // Hex string to byte string conversion.
   const hexToBytes = hex => {

--- a/.npm/packages/fuel-tx/index.test.cjs
+++ b/.npm/packages/fuel-tx/index.test.cjs
@@ -1,0 +1,14 @@
+const { expect } = require('chai')
+const types = require('.')
+
+describe('fuel-types [cjs]', () => {
+
+  it('should export all types', () => {
+
+    expect(types.Input2).to.be.ok
+    expect(types.Output2).to.be.ok
+    expect(types.TxPointer).to.be.ok
+    expect(types.UtxoId).to.be.ok
+  })
+
+})

--- a/.npm/packages/fuel-tx/index.test.cjs
+++ b/.npm/packages/fuel-tx/index.test.cjs
@@ -1,4 +1,6 @@
 const { expect } = require('chai')
+const path = require('node:path')
+const fs = require('node:fs')
 const tx = require('.')
 
 describe('fuel-tx [cjs]', () => {
@@ -225,5 +227,18 @@ describe('fuel-tx [cjs]', () => {
     );
 
     tx.check_output(output, 0, []);
+  })
+
+  it('should be able to deserialize snapshots', () => {
+    const snapshots = '../../../fuel-tx/src/transaction/types/input/snapshots';
+    fs.readdirSync(snapshots).forEach(file => {
+      fs.readFile(path.join(snapshots, file), 'utf8', (err, data) => {
+        expect(err).to.be.null;
+        let dataBytes = hexToBytes(data.split('---\n').at(-1).trim());
+        let inTx = tx.Transaction.from_bytes(dataBytes);
+        let serialized = inTx.to_bytes();
+        expect(serialized.toString()).to.eq(dataBytes.toString());
+     })
+    })
   })
 })

--- a/.npm/packages/fuel-tx/index.test.mjs
+++ b/.npm/packages/fuel-tx/index.test.mjs
@@ -14,23 +14,112 @@ describe('fuel-tx [mjs]', () => {
     let utxo_id = new tx.UtxoId("0x0c0000000000000000000000000000000000000000000000000000000000000b1a");
     let bytes = utxo_id.to_bytes();
     let utxo_id2 = tx.UtxoId.from_bytes(bytes);
-    expect(utxo_id.to_string()).to.be.equal(utxo_id2.to_string())
+    expect(utxo_id.to_string()).to.equal(utxo_id2.to_string())
   })
 
 
-  // it('should serialize and deserialize all types correctly', () => {
-  //   tx.input_coin_predicate(
-  //     utxo_id: UtxoId,
-  //     owner: Address,
-  //     amount: Word,
-  //     asset_id: AssetId,
-  //     tx_pointer: TxPointer,
-  //     maturity: BlockHeight,
-  //     predicate_gas_used: Word,
-  //     predicate: Vec < u8 >,
-  //     predicate_data: Vec < u8 >,
-  //   )
-  //   tx.input_from_bytes()
-  // })
+  it('should serialize and deserialize all input variants correctly', () => {
+    [
+      tx.Input2.coin_predicate(
+        new tx.UtxoId("0x0c0000000000000000000000000000000000000000000000000000000000000b1a"),
+        tx.Address.zeroed(),
+        BigInt(1234),
+        tx.AssetId.zeroed(),
+        new tx.TxPointer("0123456789ab"),
+        new tx.BlockHeight(5678),
+        BigInt(9012),
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+      ),
+      tx.Input2.coin_signed(
+        new tx.UtxoId("0x0c0000000000000000000000000000000000000000000000000000000000000b1a"),
+        tx.Address.zeroed(),
+        BigInt(1234),
+        tx.AssetId.zeroed(),
+        new tx.TxPointer("0123456789ab"),
+        2,
+        new tx.BlockHeight(5678),
+      ),
+      tx.Input2.contract(
+        new tx.UtxoId("0x0c0000000000000000000000000000000000000000000000000000000000000b1a"),
+        tx.Bytes32.zeroed(),
+        tx.Bytes32.zeroed(),
+        new tx.TxPointer("0123456789ab"),
+        tx.ContractId.zeroed(),
+      ),
+      tx.Input2.message_coin_signed(
+        tx.Address.zeroed(),
+        tx.Address.zeroed(),
+        BigInt(1234),
+        tx.Nonce.zeroed(),
+        2,
+      ),
+      tx.Input2.message_coin_predicate(
+        tx.Address.zeroed(),
+        tx.Address.zeroed(),
+        BigInt(1234),
+        tx.Nonce.zeroed(),
+        BigInt(1234),
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+      ),
+      tx.Input2.message_data_signed(
+        tx.Address.zeroed(),
+        tx.Address.zeroed(),
+        BigInt(1234),
+        tx.Nonce.zeroed(),
+        2,
+        [1, 2, 3, 4],
+      ),
+      tx.Input2.message_data_predicate(
+        tx.Address.zeroed(),
+        tx.Address.zeroed(),
+        BigInt(1234),
+        tx.Nonce.zeroed(),
+        BigInt(1234),
+        [0, 1, 2, 3],
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+      ),
+    ].forEach(input => {
+        let bytes = input.to_bytes();
+        let input2 = tx.Input2.from_bytes(bytes);
+        expect(input.toString()).to.equal(input2.toString())
+      })
+  })
+
+
+  it('should serialize and deserialize all output variants correctly', () => {
+    [
+      tx.Output2.coin(
+        tx.Address.zeroed(),
+        BigInt(1234),
+        tx.AssetId.zeroed(),
+      ),
+      tx.Output2.contract(
+        2,
+        tx.Bytes32.zeroed(),
+        tx.Bytes32.zeroed(),
+      ),
+      tx.Output2.change(
+        tx.Address.zeroed(),
+        BigInt(1234),
+        tx.AssetId.zeroed(),
+      ),
+      tx.Output2.variable(
+        tx.Address.zeroed(),
+        BigInt(1234),
+        tx.AssetId.zeroed(),
+      ),
+      tx.Output2.contract_created(
+        tx.ContractId.zeroed(),
+        tx.Bytes32.zeroed(),
+      ),
+    ].forEach(output => {
+      let bytes = output.to_bytes();
+      let output2 = tx.Output2.from_bytes(bytes);
+      expect(output.toString()).to.equal(output2.toString())
+    })
+  })
 
 })

--- a/.npm/packages/fuel-tx/index.test.mjs
+++ b/.npm/packages/fuel-tx/index.test.mjs
@@ -1,4 +1,6 @@
 import { expect } from 'chai'
+import * as path from 'node:path'
+import * as fs from 'node:fs'
 import * as tx from './dist/web/index.mjs'
 
 describe('fuel-tx [mjs]', () => {
@@ -225,5 +227,18 @@ describe('fuel-tx [mjs]', () => {
     );
 
     tx.check_output(output, 0, []);
+  })
+
+  it('should be able to deserialize snapshots', () => {
+    const snapshots = '../../../fuel-tx/src/transaction/types/input/snapshots';
+    fs.readdirSync(snapshots).forEach(file => {
+      fs.readFile(path.join(snapshots, file), 'utf8', (err, data) => {
+        expect(err).to.be.null;
+        let dataBytes = hexToBytes(data.split('---\n').at(-1).trim());
+        let inTx = tx.Transaction.from_bytes(dataBytes);
+        let serialized = inTx.to_bytes();
+        expect(serialized.toString()).to.eq(dataBytes.toString());
+      })
+    })
   })
 })

--- a/.npm/packages/fuel-tx/index.test.mjs
+++ b/.npm/packages/fuel-tx/index.test.mjs
@@ -9,6 +9,11 @@ describe('fuel-tx [mjs]', () => {
     expect(tx.PredicateParameters).to.be.ok
     expect(tx.Input).to.be.ok
     expect(tx.Output).to.be.ok
+    expect(tx.Script).to.be.ok
+    expect(tx.Create).to.be.ok
+    expect(tx.Mint).to.be.ok
+    expect(tx.Transaction).to.be.ok
+    expect(tx.Policies).to.be.ok
   })
 
   it('should serialize and deserialize UtxoId correctly', () => {
@@ -131,6 +136,55 @@ describe('fuel-tx [mjs]', () => {
   })
 
 
+  it('should serialize and deserialize all transaction variants correctly', () => {
+    [
+      [tx.Script, tx.Transaction.script(
+        1234n,
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+        new tx.Policies(),
+        [],
+        [],
+        [],
+      )],
+      [tx.Create, tx.Transaction.create(
+        1,
+        new tx.Policies(),
+        tx.Salt.zeroed(),
+        [],
+        [],
+        [],
+        [],
+      )],
+      [tx.Mint, tx.Transaction.mint(
+        new tx.TxPointer("0123456789ab"),
+        new tx.InputContract(
+          new tx.UtxoId("0xc49d65de61cf04588a764b557d25cc6c6b4bc0d7429227e2a21e61c213b3a3e2:18"),
+          tx.Bytes32.zeroed(),
+          tx.Bytes32.zeroed(),
+          new tx.TxPointer("0123456789ab"),
+          tx.ContractId.zeroed(),
+        ),
+        new tx.OutputContract(
+          3,
+          tx.Bytes32.zeroed(),
+          tx.Bytes32.zeroed(),
+        ),
+        1234n,
+        tx.AssetId.zeroed(),
+      )],
+    ].forEach(([tx_variant_type, tx_variant]) => {
+      let bytes = tx_variant.to_bytes();
+      let tx_variant2 = tx_variant_type.from_bytes(bytes);
+      expect(tx_variant.toString()).to.equal(tx_variant2.toString())
+
+      let wrapped_tx = tx_variant.as_tx();
+      let tx_bytes = wrapped_tx.to_bytes();
+      let wrapped_tx2 = tx.Transaction.from_bytes(tx_bytes);
+      expect(wrapped_tx.toString()).to.equal(wrapped_tx2.toString())
+    })
+  })
+
   // Hex string to byte string conversion.
   const hexToBytes = hex => {
     if (hex.length % 2 != 0) {
@@ -138,7 +192,7 @@ describe('fuel-tx [mjs]', () => {
     }
     const lookup = "0123456789abcdef";
     let result = new Uint8Array(hex.length / 2);
-    for (let i = 0; i < result.length; i+=1) {
+    for (let i = 0; i < result.length; i += 1) {
       let high = lookup.indexOf(hex[i * 2]);
       let low = lookup.indexOf(hex[i * 2 + 1]);
       if (high === -1 || low === -1) {
@@ -159,7 +213,7 @@ describe('fuel-tx [mjs]', () => {
       0,
       new tx.BlockHeight(0),
     );
-    
+
     tx.check_input(input, 0, tx.Bytes32.from_bytes(hexToBytes("108eae4147d2c1c86ef4c2ab7c9fe94126645c8d8737495a0574ef1518ae74d8")), [], [{ data: hexToBytes("7ce4de2225f041b7f9fec727343a501d99e5b7b58d33f3d4a2cf218d3489959bdec24d13770b5d3bb084b4dac3474f95153e6ecc98f6f0f8ca37a2897b9562ee") }], new tx.PredicateParameters());
   })
 

--- a/.npm/packages/fuel-tx/index.test.mjs
+++ b/.npm/packages/fuel-tx/index.test.mjs
@@ -1,0 +1,36 @@
+import { expect } from 'chai'
+import * as tx from './dist/web/index.mjs'
+
+describe('fuel-tx [mjs]', () => {
+
+  it('should export all types', () => {
+    expect(tx.Input2).to.be.ok
+    expect(tx.Output2).to.be.ok
+    expect(tx.TxPointer).to.be.ok
+    expect(tx.UtxoId).to.be.ok
+  })
+
+  it('should serialize and deserialize UtxoId correctly', () => {
+    let utxo_id = new tx.UtxoId("0x0c0000000000000000000000000000000000000000000000000000000000000b1a");
+    let bytes = utxo_id.to_bytes();
+    let utxo_id2 = tx.UtxoId.from_bytes(bytes);
+    expect(utxo_id.to_string()).to.be.equal(utxo_id2.to_string())
+  })
+
+
+  // it('should serialize and deserialize all types correctly', () => {
+  //   tx.input_coin_predicate(
+  //     utxo_id: UtxoId,
+  //     owner: Address,
+  //     amount: Word,
+  //     asset_id: AssetId,
+  //     tx_pointer: TxPointer,
+  //     maturity: BlockHeight,
+  //     predicate_gas_used: Word,
+  //     predicate: Vec < u8 >,
+  //     predicate_data: Vec < u8 >,
+  //   )
+  //   tx.input_from_bytes()
+  // })
+
+})

--- a/.npm/packages/fuel-tx/index.test.mjs
+++ b/.npm/packages/fuel-tx/index.test.mjs
@@ -4,16 +4,24 @@ import * as tx from './dist/web/index.mjs'
 describe('fuel-tx [mjs]', () => {
 
   it('should export all types', () => {
+    expect(tx.UtxoId).to.be.ok
+    expect(tx.TxPointer).to.be.ok
+    expect(tx.PredicateParameters).to.be.ok
     expect(tx.Input2).to.be.ok
     expect(tx.Output2).to.be.ok
-    expect(tx.TxPointer).to.be.ok
-    expect(tx.UtxoId).to.be.ok
   })
 
   it('should serialize and deserialize UtxoId correctly', () => {
     let utxo_id = new tx.UtxoId("0x0c0000000000000000000000000000000000000000000000000000000000000b1a");
     let bytes = utxo_id.to_bytes();
     let utxo_id2 = tx.UtxoId.from_bytes(bytes);
+    expect(utxo_id.to_string()).to.equal(utxo_id2.to_string())
+  })
+
+  it('should serialize and deserialize TxPointer correctly', () => {
+    let utxo_id = new tx.TxPointer("0123456789ab");
+    let bytes = utxo_id.to_bytes();
+    let utxo_id2 = tx.TxPointer.from_bytes(bytes);
     expect(utxo_id.to_string()).to.equal(utxo_id2.to_string())
   })
 
@@ -82,10 +90,10 @@ describe('fuel-tx [mjs]', () => {
         [5, 6, 7, 8],
       ),
     ].forEach(input => {
-        let bytes = input.to_bytes();
-        let input2 = tx.Input2.from_bytes(bytes);
-        expect(input.toString()).to.equal(input2.toString())
-      })
+      let bytes = input.to_bytes();
+      let input2 = tx.Input2.from_bytes(bytes);
+      expect(input.toString()).to.equal(input2.toString())
+    })
   })
 
 
@@ -122,4 +130,36 @@ describe('fuel-tx [mjs]', () => {
     })
   })
 
+
+  const hexToByte = (hex) => {
+    const key = '0123456789abcdef'
+    let newBytes = []
+    let currentChar = 0
+    let currentByte = 0
+    for (let i = 0; i < hex.length; i++) {   // Go over two 4-bit hex chars to convert into one 8-bit byte
+      currentChar = key.indexOf(hex[i])
+      if (i % 2 === 0) { // First hex char
+        currentByte = (currentChar << 4) // Get 4-bits from first hex char
+      }
+      if (i % 2 === 1) { // Second hex char
+        currentByte += (currentChar)     // Concat 4-bits from second hex char
+        newBytes.push(currentByte)       // Add byte
+      }
+    }
+    return new Uint8Array(newBytes)
+  }
+
+  it('should validate input correctly', () => {
+    let input = tx.Input2.coin_signed(
+      new tx.UtxoId("0xc49d65de61cf04588a764b557d25cc6c6b4bc0d7429227e2a21e61c213b3a3e2:18"),
+      tx.Address.from_bytes(hexToByte("f1e92c42b90934aa6372e30bc568a326f6e66a1a0288595e6e3fbd392a4f3e6e")),
+      10599410012256088338n,
+      tx.AssetId.from_bytes(hexToByte("2cafad611543e0265d89f1c2b60d9ebf5d56ad7e23d9827d6b522fd4d6e44bc3")),
+      new tx.TxPointer("000000000000"),
+      0,
+      new tx.BlockHeight(0),
+    );
+
+    tx.check_input(input, 0, tx.Bytes32.from_bytes(hexToByte("108eae4147d2c1c86ef4c2ab7c9fe94126645c8d8737495a0574ef1518ae74d8")), [], [{ data: hexToByte("7ce4de2225f041b7f9fec727343a501d99e5b7b58d33f3d4a2cf218d3489959bdec24d13770b5d3bb084b4dac3474f95153e6ecc98f6f0f8ca37a2897b9562ee") }], new tx.PredicateParameters());
+  })
 })

--- a/.npm/packages/fuel-tx/index.test.mjs
+++ b/.npm/packages/fuel-tx/index.test.mjs
@@ -7,8 +7,8 @@ describe('fuel-tx [mjs]', () => {
     expect(tx.UtxoId).to.be.ok
     expect(tx.TxPointer).to.be.ok
     expect(tx.PredicateParameters).to.be.ok
-    expect(tx.Input2).to.be.ok
-    expect(tx.Output2).to.be.ok
+    expect(tx.Input).to.be.ok
+    expect(tx.Output).to.be.ok
   })
 
   it('should serialize and deserialize UtxoId correctly', () => {
@@ -28,7 +28,7 @@ describe('fuel-tx [mjs]', () => {
 
   it('should serialize and deserialize all input variants correctly', () => {
     [
-      tx.Input2.coin_predicate(
+      tx.Input.coin_predicate(
         new tx.UtxoId("0x0c0000000000000000000000000000000000000000000000000000000000000b1a"),
         tx.Address.zeroed(),
         BigInt(1234),
@@ -39,7 +39,7 @@ describe('fuel-tx [mjs]', () => {
         [1, 2, 3, 4],
         [5, 6, 7, 8],
       ),
-      tx.Input2.coin_signed(
+      tx.Input.coin_signed(
         new tx.UtxoId("0x0c0000000000000000000000000000000000000000000000000000000000000b1a"),
         tx.Address.zeroed(),
         BigInt(1234),
@@ -48,21 +48,21 @@ describe('fuel-tx [mjs]', () => {
         2,
         new tx.BlockHeight(5678),
       ),
-      tx.Input2.contract(
+      tx.Input.contract(
         new tx.UtxoId("0x0c0000000000000000000000000000000000000000000000000000000000000b1a"),
         tx.Bytes32.zeroed(),
         tx.Bytes32.zeroed(),
         new tx.TxPointer("0123456789ab"),
         tx.ContractId.zeroed(),
       ),
-      tx.Input2.message_coin_signed(
+      tx.Input.message_coin_signed(
         tx.Address.zeroed(),
         tx.Address.zeroed(),
         BigInt(1234),
         tx.Nonce.zeroed(),
         2,
       ),
-      tx.Input2.message_coin_predicate(
+      tx.Input.message_coin_predicate(
         tx.Address.zeroed(),
         tx.Address.zeroed(),
         BigInt(1234),
@@ -71,7 +71,7 @@ describe('fuel-tx [mjs]', () => {
         [1, 2, 3, 4],
         [5, 6, 7, 8],
       ),
-      tx.Input2.message_data_signed(
+      tx.Input.message_data_signed(
         tx.Address.zeroed(),
         tx.Address.zeroed(),
         BigInt(1234),
@@ -79,7 +79,7 @@ describe('fuel-tx [mjs]', () => {
         2,
         [1, 2, 3, 4],
       ),
-      tx.Input2.message_data_predicate(
+      tx.Input.message_data_predicate(
         tx.Address.zeroed(),
         tx.Address.zeroed(),
         BigInt(1234),
@@ -91,7 +91,7 @@ describe('fuel-tx [mjs]', () => {
       ),
     ].forEach(input => {
       let bytes = input.to_bytes();
-      let input2 = tx.Input2.from_bytes(bytes);
+      let input2 = tx.Input.from_bytes(bytes);
       expect(input.toString()).to.equal(input2.toString())
     })
   })
@@ -99,33 +99,33 @@ describe('fuel-tx [mjs]', () => {
 
   it('should serialize and deserialize all output variants correctly', () => {
     [
-      tx.Output2.coin(
+      tx.Output.coin(
         tx.Address.zeroed(),
         BigInt(1234),
         tx.AssetId.zeroed(),
       ),
-      tx.Output2.contract(
+      tx.Output.contract(
         2,
         tx.Bytes32.zeroed(),
         tx.Bytes32.zeroed(),
       ),
-      tx.Output2.change(
+      tx.Output.change(
         tx.Address.zeroed(),
         BigInt(1234),
         tx.AssetId.zeroed(),
       ),
-      tx.Output2.variable(
+      tx.Output.variable(
         tx.Address.zeroed(),
         BigInt(1234),
         tx.AssetId.zeroed(),
       ),
-      tx.Output2.contract_created(
+      tx.Output.contract_created(
         tx.ContractId.zeroed(),
         tx.Bytes32.zeroed(),
       ),
     ].forEach(output => {
       let bytes = output.to_bytes();
-      let output2 = tx.Output2.from_bytes(bytes);
+      let output2 = tx.Output.from_bytes(bytes);
       expect(output.toString()).to.equal(output2.toString())
     })
   })
@@ -150,7 +150,7 @@ describe('fuel-tx [mjs]', () => {
   }
 
   it('should validate input correctly', () => {
-    let input = tx.Input2.coin_signed(
+    let input = tx.Input.coin_signed(
       new tx.UtxoId("0xc49d65de61cf04588a764b557d25cc6c6b4bc0d7429227e2a21e61c213b3a3e2:18"),
       tx.Address.from_bytes(hexToByte("f1e92c42b90934aa6372e30bc568a326f6e66a1a0288595e6e3fbd392a4f3e6e")),
       10599410012256088338n,

--- a/.npm/packages/fuel-tx/index.test.mjs
+++ b/.npm/packages/fuel-tx/index.test.mjs
@@ -15,14 +15,14 @@ describe('fuel-tx [mjs]', () => {
     let utxo_id = new tx.UtxoId("0x0c0000000000000000000000000000000000000000000000000000000000000b1a");
     let bytes = utxo_id.to_bytes();
     let utxo_id2 = tx.UtxoId.from_bytes(bytes);
-    expect(utxo_id.to_string()).to.equal(utxo_id2.to_string())
+    expect(utxo_id.toString()).to.equal(utxo_id2.toString())
   })
 
   it('should serialize and deserialize TxPointer correctly', () => {
     let utxo_id = new tx.TxPointer("0123456789ab");
     let bytes = utxo_id.to_bytes();
     let utxo_id2 = tx.TxPointer.from_bytes(bytes);
-    expect(utxo_id.to_string()).to.equal(utxo_id2.to_string())
+    expect(utxo_id.toString()).to.equal(utxo_id2.toString())
   })
 
 
@@ -131,35 +131,45 @@ describe('fuel-tx [mjs]', () => {
   })
 
 
-  const hexToByte = (hex) => {
-    const key = '0123456789abcdef'
-    let newBytes = []
-    let currentChar = 0
-    let currentByte = 0
-    for (let i = 0; i < hex.length; i++) {   // Go over two 4-bit hex chars to convert into one 8-bit byte
-      currentChar = key.indexOf(hex[i])
-      if (i % 2 === 0) { // First hex char
-        currentByte = (currentChar << 4) // Get 4-bits from first hex char
-      }
-      if (i % 2 === 1) { // Second hex char
-        currentByte += (currentChar)     // Concat 4-bits from second hex char
-        newBytes.push(currentByte)       // Add byte
-      }
+  // Hex string to byte string conversion.
+  const hexToBytes = hex => {
+    if (hex.length % 2 != 0) {
+      throw new Error("Needs full bytes");
     }
-    return new Uint8Array(newBytes)
+    const lookup = "0123456789abcdef";
+    let result = new Uint8Array(hex.length / 2);
+    for (let i = 0; i < result.length; i+=1) {
+      let high = lookup.indexOf(hex[i * 2]);
+      let low = lookup.indexOf(hex[i * 2 + 1]);
+      if (high === -1 || low === -1) {
+        throw new Error("Invalid hex char");
+      }
+      result[i] = (high << 4) | low;
+    }
+    return result;
   }
 
   it('should validate input correctly', () => {
     let input = tx.Input.coin_signed(
       new tx.UtxoId("0xc49d65de61cf04588a764b557d25cc6c6b4bc0d7429227e2a21e61c213b3a3e2:18"),
-      tx.Address.from_bytes(hexToByte("f1e92c42b90934aa6372e30bc568a326f6e66a1a0288595e6e3fbd392a4f3e6e")),
+      tx.Address.from_bytes(hexToBytes("f1e92c42b90934aa6372e30bc568a326f6e66a1a0288595e6e3fbd392a4f3e6e")),
       10599410012256088338n,
-      tx.AssetId.from_bytes(hexToByte("2cafad611543e0265d89f1c2b60d9ebf5d56ad7e23d9827d6b522fd4d6e44bc3")),
+      tx.AssetId.from_bytes(hexToBytes("2cafad611543e0265d89f1c2b60d9ebf5d56ad7e23d9827d6b522fd4d6e44bc3")),
       new tx.TxPointer("000000000000"),
       0,
       new tx.BlockHeight(0),
     );
+    
+    tx.check_input(input, 0, tx.Bytes32.from_bytes(hexToBytes("108eae4147d2c1c86ef4c2ab7c9fe94126645c8d8737495a0574ef1518ae74d8")), [], [{ data: hexToBytes("7ce4de2225f041b7f9fec727343a501d99e5b7b58d33f3d4a2cf218d3489959bdec24d13770b5d3bb084b4dac3474f95153e6ecc98f6f0f8ca37a2897b9562ee") }], new tx.PredicateParameters());
+  })
 
-    tx.check_input(input, 0, tx.Bytes32.from_bytes(hexToByte("108eae4147d2c1c86ef4c2ab7c9fe94126645c8d8737495a0574ef1518ae74d8")), [], [{ data: hexToByte("7ce4de2225f041b7f9fec727343a501d99e5b7b58d33f3d4a2cf218d3489959bdec24d13770b5d3bb084b4dac3474f95153e6ecc98f6f0f8ca37a2897b9562ee") }], new tx.PredicateParameters());
+  it('should validate output correctly', () => {
+    let output = tx.Output.change(
+      tx.Address.zeroed(),
+      1234n,
+      tx.AssetId.zeroed(),
+    );
+
+    tx.check_output(output, 0, []);
   })
 })

--- a/.npm/pnpm-lock.yaml
+++ b/.npm/pnpm-lock.yaml
@@ -1,19 +1,15 @@
-lockfileVersion: '6.1'
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
+lockfileVersion: '6.0'
 
 importers:
 
   .:
     devDependencies:
       '@rollup/plugin-wasm':
-        specifier: ^6.1.3
-        version: 6.1.3(rollup@3.26.2)
+        specifier: ^6.2.2
+        version: 6.2.2(rollup@3.29.4)
       chai:
-        specifier: ^4.3.7
-        version: 4.3.7
+        specifier: ^4.3.10
+        version: 4.3.10
       mocha:
         specifier: ^10.2.0
         version: 10.2.0
@@ -21,41 +17,44 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5
       rollup:
-        specifier: ^3.26.2
-        version: 3.26.2
+        specifier: ^3.29.4
+        version: 3.29.4
       rollup-plugin-dts:
-        specifier: ^5.3.0
-        version: 5.3.0(rollup@3.26.2)(typescript@5.1.6)
+        specifier: ^5.3.1
+        version: 5.3.1(rollup@3.29.4)(typescript@5.3.2)
       turbo:
-        specifier: ^1.10.9
-        version: 1.10.9
+        specifier: ^1.10.16
+        version: 1.10.16
 
   packages/fuel-asm: {}
+
+  packages/fuel-tx: {}
 
   packages/fuel-types: {}
 
 packages:
 
-  /@babel/code-frame@7.22.5:
-    resolution: {integrity: sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==}
+  /@babel/code-frame@7.23.5:
+    resolution: {integrity: sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==}
     engines: {node: '>=6.9.0'}
     requiresBuild: true
     dependencies:
-      '@babel/highlight': 7.22.5
+      '@babel/highlight': 7.23.4
+      chalk: 2.4.2
     dev: true
     optional: true
 
-  /@babel/helper-validator-identifier@7.22.5:
-    resolution: {integrity: sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==}
+  /@babel/helper-validator-identifier@7.22.20:
+    resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
     engines: {node: '>=6.9.0'}
     dev: true
     optional: true
 
-  /@babel/highlight@7.22.5:
-    resolution: {integrity: sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==}
+  /@babel/highlight@7.23.4:
+    resolution: {integrity: sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-validator-identifier': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.20
       chalk: 2.4.2
       js-tokens: 4.0.0
     dev: true
@@ -65,16 +64,36 @@ packages:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
     dev: true
 
-  /@rollup/plugin-wasm@6.1.3(rollup@3.26.2):
-    resolution: {integrity: sha512-7ItTTeyauE6lwdDtQWceEHZ9+txbi4RRy0mYPFn9BW7rD7YdgBDu7HTHsLtHrRzJc313RM/1m6GKgV3np/aEaw==}
+  /@rollup/plugin-wasm@6.2.2(rollup@3.29.4):
+    resolution: {integrity: sha512-gpC4R1G9Ni92ZIRTexqbhX7U+9estZrbhP+9SRb0DW9xpB9g7j34r+J2hqrcW/lRI7dJaU84MxZM0Rt82tqYPQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
     dependencies:
-      rollup: 3.26.2
+      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
+      rollup: 3.29.4
+    dev: true
+
+  /@rollup/pluginutils@5.1.0(rollup@3.29.4):
+    resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@types/estree': 1.0.5
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+      rollup: 3.29.4
+    dev: true
+
+  /@types/estree@1.0.5:
+    resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
     dev: true
 
   /ansi-colors@4.1.1:
@@ -116,18 +135,19 @@ packages:
   /array-buffer-byte-length@1.0.0:
     resolution: {integrity: sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==}
     dependencies:
-      call-bind: 1.0.2
+      call-bind: 1.0.5
       is-array-buffer: 3.0.2
     dev: true
 
-  /arraybuffer.prototype.slice@1.0.1:
-    resolution: {integrity: sha512-09x0ZWFEjj4WD8PDbykUwo3t9arLn8NIzmmYEJFpYekOAQjpkGSyrQhNoRTcwwcFRu+ycWF78QZ63oWTqSjBcw==}
+  /arraybuffer.prototype.slice@1.0.2:
+    resolution: {integrity: sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==}
     engines: {node: '>= 0.4'}
     dependencies:
       array-buffer-byte-length: 1.0.0
-      call-bind: 1.0.2
-      define-properties: 1.2.0
-      get-intrinsic: 1.2.1
+      call-bind: 1.0.5
+      define-properties: 1.2.1
+      es-abstract: 1.22.3
+      get-intrinsic: 1.2.2
       is-array-buffer: 3.0.2
       is-shared-array-buffer: 1.0.2
     dev: true
@@ -174,11 +194,12 @@ packages:
     resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
     dev: true
 
-  /call-bind@1.0.2:
-    resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
+  /call-bind@1.0.5:
+    resolution: {integrity: sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==}
     dependencies:
-      function-bind: 1.1.1
-      get-intrinsic: 1.2.1
+      function-bind: 1.1.2
+      get-intrinsic: 1.2.2
+      set-function-length: 1.1.1
     dev: true
 
   /camelcase@6.3.0:
@@ -186,15 +207,15 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /chai@4.3.7:
-    resolution: {integrity: sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==}
+  /chai@4.3.10:
+    resolution: {integrity: sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==}
     engines: {node: '>=4'}
     dependencies:
       assertion-error: 1.1.0
-      check-error: 1.0.2
+      check-error: 1.0.3
       deep-eql: 4.1.3
-      get-func-name: 2.0.0
-      loupe: 2.3.6
+      get-func-name: 2.0.2
+      loupe: 2.3.7
       pathval: 1.1.1
       type-detect: 4.0.8
     dev: true
@@ -216,8 +237,10 @@ packages:
       supports-color: 7.2.0
     dev: true
 
-  /check-error@1.0.2:
-    resolution: {integrity: sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==}
+  /check-error@1.0.3:
+    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+    dependencies:
+      get-func-name: 2.0.2
     dev: true
 
   /chokidar@3.5.3:
@@ -232,7 +255,7 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /cliui@7.0.4:
@@ -304,11 +327,21 @@ packages:
       type-detect: 4.0.8
     dev: true
 
-  /define-properties@1.2.0:
-    resolution: {integrity: sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==}
+  /define-data-property@1.1.1:
+    resolution: {integrity: sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      has-property-descriptors: 1.0.0
+      get-intrinsic: 1.2.2
+      gopd: 1.0.1
+      has-property-descriptors: 1.0.1
+    dev: true
+
+  /define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      define-data-property: 1.1.1
+      has-property-descriptors: 1.0.1
       object-keys: 1.1.1
     dev: true
 
@@ -327,26 +360,26 @@ packages:
       is-arrayish: 0.2.1
     dev: true
 
-  /es-abstract@1.22.1:
-    resolution: {integrity: sha512-ioRRcXMO6OFyRpyzV3kE1IIBd4WG5/kltnzdxSCqoP8CMGs/Li+M1uF5o7lOkZVFjDs+NLesthnF66Pg/0q0Lw==}
+  /es-abstract@1.22.3:
+    resolution: {integrity: sha512-eiiY8HQeYfYH2Con2berK+To6GrK2RxbPawDkGq4UiCQQfZHb6wX9qQqkbpPqaxQFcl8d9QzZqo0tGE0VcrdwA==}
     engines: {node: '>= 0.4'}
     dependencies:
       array-buffer-byte-length: 1.0.0
-      arraybuffer.prototype.slice: 1.0.1
+      arraybuffer.prototype.slice: 1.0.2
       available-typed-arrays: 1.0.5
-      call-bind: 1.0.2
-      es-set-tostringtag: 2.0.1
+      call-bind: 1.0.5
+      es-set-tostringtag: 2.0.2
       es-to-primitive: 1.2.1
-      function.prototype.name: 1.1.5
-      get-intrinsic: 1.2.1
+      function.prototype.name: 1.1.6
+      get-intrinsic: 1.2.2
       get-symbol-description: 1.0.0
       globalthis: 1.0.3
       gopd: 1.0.1
-      has: 1.0.3
-      has-property-descriptors: 1.0.0
+      has-property-descriptors: 1.0.1
       has-proto: 1.0.1
       has-symbols: 1.0.3
-      internal-slot: 1.0.5
+      hasown: 2.0.0
+      internal-slot: 1.0.6
       is-array-buffer: 3.0.2
       is-callable: 1.2.7
       is-negative-zero: 2.0.2
@@ -355,30 +388,30 @@ packages:
       is-string: 1.0.7
       is-typed-array: 1.1.12
       is-weakref: 1.0.2
-      object-inspect: 1.12.3
+      object-inspect: 1.13.1
       object-keys: 1.1.1
       object.assign: 4.1.4
-      regexp.prototype.flags: 1.5.0
-      safe-array-concat: 1.0.0
+      regexp.prototype.flags: 1.5.1
+      safe-array-concat: 1.0.1
       safe-regex-test: 1.0.0
-      string.prototype.trim: 1.2.7
-      string.prototype.trimend: 1.0.6
-      string.prototype.trimstart: 1.0.6
+      string.prototype.trim: 1.2.8
+      string.prototype.trimend: 1.0.7
+      string.prototype.trimstart: 1.0.7
       typed-array-buffer: 1.0.0
       typed-array-byte-length: 1.0.0
       typed-array-byte-offset: 1.0.0
       typed-array-length: 1.0.4
       unbox-primitive: 1.0.2
-      which-typed-array: 1.1.11
+      which-typed-array: 1.1.13
     dev: true
 
-  /es-set-tostringtag@2.0.1:
-    resolution: {integrity: sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==}
+  /es-set-tostringtag@2.0.2:
+    resolution: {integrity: sha512-BuDyupZt65P9D2D2vA/zqcI3G5xRsklm5N3xCwuiy+/vKy8i0ifdsQP1sLgO4tZDSCaQUSnmC48khknGMV3D2Q==}
     engines: {node: '>= 0.4'}
     dependencies:
-      get-intrinsic: 1.2.1
-      has: 1.0.3
+      get-intrinsic: 1.2.2
       has-tostringtag: 1.0.0
+      hasown: 2.0.0
     dev: true
 
   /es-to-primitive@1.2.1:
@@ -403,6 +436,10 @@ packages:
   /escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+    dev: true
+
+  /estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
     dev: true
 
   /fill-range@7.0.1:
@@ -435,25 +472,25 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
 
-  /fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /function-bind@1.1.1:
-    resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
+  /function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
     dev: true
 
-  /function.prototype.name@1.1.5:
-    resolution: {integrity: sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==}
+  /function.prototype.name@1.1.6:
+    resolution: {integrity: sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
+      call-bind: 1.0.5
+      define-properties: 1.2.1
+      es-abstract: 1.22.3
       functions-have-names: 1.2.3
     dev: true
 
@@ -466,25 +503,25 @@ packages:
     engines: {node: 6.* || 8.* || >= 10.*}
     dev: true
 
-  /get-func-name@2.0.0:
-    resolution: {integrity: sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==}
+  /get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
     dev: true
 
-  /get-intrinsic@1.2.1:
-    resolution: {integrity: sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==}
+  /get-intrinsic@1.2.2:
+    resolution: {integrity: sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==}
     dependencies:
-      function-bind: 1.1.1
-      has: 1.0.3
+      function-bind: 1.1.2
       has-proto: 1.0.1
       has-symbols: 1.0.3
+      hasown: 2.0.0
     dev: true
 
   /get-symbol-description@1.0.0:
     resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.2
-      get-intrinsic: 1.2.1
+      call-bind: 1.0.5
+      get-intrinsic: 1.2.2
     dev: true
 
   /glob-parent@5.1.2:
@@ -509,13 +546,13 @@ packages:
     resolution: {integrity: sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      define-properties: 1.2.0
+      define-properties: 1.2.1
     dev: true
 
   /gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
     dependencies:
-      get-intrinsic: 1.2.1
+      get-intrinsic: 1.2.2
     dev: true
 
   /graceful-fs@4.2.11:
@@ -536,10 +573,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /has-property-descriptors@1.0.0:
-    resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
+  /has-property-descriptors@1.0.1:
+    resolution: {integrity: sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==}
     dependencies:
-      get-intrinsic: 1.2.1
+      get-intrinsic: 1.2.2
     dev: true
 
   /has-proto@1.0.1:
@@ -559,11 +596,11 @@ packages:
       has-symbols: 1.0.3
     dev: true
 
-  /has@1.0.3:
-    resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
-    engines: {node: '>= 0.4.0'}
+  /hasown@2.0.0:
+    resolution: {integrity: sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==}
+    engines: {node: '>= 0.4'}
     dependencies:
-      function-bind: 1.1.1
+      function-bind: 1.1.2
     dev: true
 
   /he@1.2.0:
@@ -586,20 +623,20 @@ packages:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
     dev: true
 
-  /internal-slot@1.0.5:
-    resolution: {integrity: sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==}
+  /internal-slot@1.0.6:
+    resolution: {integrity: sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      get-intrinsic: 1.2.1
-      has: 1.0.3
+      get-intrinsic: 1.2.2
+      hasown: 2.0.0
       side-channel: 1.0.4
     dev: true
 
   /is-array-buffer@3.0.2:
     resolution: {integrity: sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==}
     dependencies:
-      call-bind: 1.0.2
-      get-intrinsic: 1.2.1
+      call-bind: 1.0.5
+      get-intrinsic: 1.2.2
       is-typed-array: 1.1.12
     dev: true
 
@@ -624,7 +661,7 @@ packages:
     resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.2
+      call-bind: 1.0.5
       has-tostringtag: 1.0.0
     dev: true
 
@@ -633,10 +670,10 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /is-core-module@2.12.1:
-    resolution: {integrity: sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==}
+  /is-core-module@2.13.1:
+    resolution: {integrity: sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==}
     dependencies:
-      has: 1.0.3
+      hasown: 2.0.0
     dev: true
 
   /is-date-object@1.0.5:
@@ -689,14 +726,14 @@ packages:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.2
+      call-bind: 1.0.5
       has-tostringtag: 1.0.0
     dev: true
 
   /is-shared-array-buffer@1.0.2:
     resolution: {integrity: sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==}
     dependencies:
-      call-bind: 1.0.2
+      call-bind: 1.0.5
     dev: true
 
   /is-string@1.0.7:
@@ -717,7 +754,7 @@ packages:
     resolution: {integrity: sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      which-typed-array: 1.1.11
+      which-typed-array: 1.1.13
     dev: true
 
   /is-unicode-supported@0.1.0:
@@ -728,7 +765,7 @@ packages:
   /is-weakref@1.0.2:
     resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
     dependencies:
-      call-bind: 1.0.2
+      call-bind: 1.0.5
     dev: true
 
   /isarray@2.0.5:
@@ -780,14 +817,14 @@ packages:
       is-unicode-supported: 0.1.0
     dev: true
 
-  /loupe@2.3.6:
-    resolution: {integrity: sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==}
+  /loupe@2.3.7:
+    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
     dependencies:
-      get-func-name: 2.0.0
+      get-func-name: 2.0.2
     dev: true
 
-  /magic-string@0.30.1:
-    resolution: {integrity: sha512-mbVKXPmS0z0G4XqFDCTllmDQ6coZzn94aMlb0o/A4HEHJCKcanlDZwYJgwnkmgD3jyWhUgj9VsPrfd972yPffA==}
+  /magic-string@0.30.5:
+    resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
@@ -861,7 +898,7 @@ packages:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
     dependencies:
       hosted-git-info: 2.8.9
-      resolve: 1.22.2
+      resolve: 1.22.8
       semver: 5.7.2
       validate-npm-package-license: 3.0.4
     dev: true
@@ -884,11 +921,11 @@ packages:
       pidtree: 0.3.1
       read-pkg: 3.0.0
       shell-quote: 1.8.1
-      string.prototype.padend: 3.1.4
+      string.prototype.padend: 3.1.5
     dev: true
 
-  /object-inspect@1.12.3:
-    resolution: {integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==}
+  /object-inspect@1.13.1:
+    resolution: {integrity: sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==}
     dev: true
 
   /object-keys@1.1.1:
@@ -900,8 +937,8 @@ packages:
     resolution: {integrity: sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.2.0
+      call-bind: 1.0.5
+      define-properties: 1.2.1
       has-symbols: 1.0.3
       object-keys: 1.1.1
     dev: true
@@ -1002,13 +1039,13 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /regexp.prototype.flags@1.5.0:
-    resolution: {integrity: sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==}
+  /regexp.prototype.flags@1.5.1:
+    resolution: {integrity: sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.2.0
-      functions-have-names: 1.2.3
+      call-bind: 1.0.5
+      define-properties: 1.2.1
+      set-function-name: 2.0.1
     dev: true
 
   /require-directory@2.1.1:
@@ -1016,43 +1053,43 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /resolve@1.22.2:
-    resolution: {integrity: sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==}
+  /resolve@1.22.8:
+    resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
     hasBin: true
     dependencies:
-      is-core-module: 2.12.1
+      is-core-module: 2.13.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
 
-  /rollup-plugin-dts@5.3.0(rollup@3.26.2)(typescript@5.1.6):
-    resolution: {integrity: sha512-8FXp0ZkyZj1iU5klkIJYLjIq/YZSwBoERu33QBDxm/1yw5UU4txrEtcmMkrq+ZiKu3Q4qvPCNqc3ovX6rjqzbQ==}
-    engines: {node: '>=v14'}
+  /rollup-plugin-dts@5.3.1(rollup@3.29.4)(typescript@5.3.2):
+    resolution: {integrity: sha512-gusMi+Z4gY/JaEQeXnB0RUdU82h1kF0WYzCWgVmV4p3hWXqelaKuCvcJawfeg+EKn2T1Ie+YWF2OiN1/L8bTVg==}
+    engines: {node: '>=v14.21.3'}
     peerDependencies:
-      rollup: ^3.0.0
+      rollup: ^3.0
       typescript: ^4.1 || ^5.0
     dependencies:
-      magic-string: 0.30.1
-      rollup: 3.26.2
-      typescript: 5.1.6
+      magic-string: 0.30.5
+      rollup: 3.29.4
+      typescript: 5.3.2
     optionalDependencies:
-      '@babel/code-frame': 7.22.5
+      '@babel/code-frame': 7.23.5
     dev: true
 
-  /rollup@3.26.2:
-    resolution: {integrity: sha512-6umBIGVz93er97pMgQO08LuH3m6PUb3jlDUUGFsNJB6VgTCUaDFpupf5JfU30529m/UKOgmiX+uY6Sx8cOYpLA==}
+  /rollup@3.29.4:
+    resolution: {integrity: sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
-  /safe-array-concat@1.0.0:
-    resolution: {integrity: sha512-9dVEFruWIsnie89yym+xWTAYASdpw3CJV7Li/6zBewGf9z2i1j31rP6jnY0pHEO4QZh6N0K11bFjWmdR8UGdPQ==}
+  /safe-array-concat@1.0.1:
+    resolution: {integrity: sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q==}
     engines: {node: '>=0.4'}
     dependencies:
-      call-bind: 1.0.2
-      get-intrinsic: 1.2.1
+      call-bind: 1.0.5
+      get-intrinsic: 1.2.2
       has-symbols: 1.0.3
       isarray: 2.0.5
     dev: true
@@ -1064,8 +1101,8 @@ packages:
   /safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
     dependencies:
-      call-bind: 1.0.2
-      get-intrinsic: 1.2.1
+      call-bind: 1.0.5
+      get-intrinsic: 1.2.2
       is-regex: 1.1.4
     dev: true
 
@@ -1078,6 +1115,25 @@ packages:
     resolution: {integrity: sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==}
     dependencies:
       randombytes: 2.1.0
+    dev: true
+
+  /set-function-length@1.1.1:
+    resolution: {integrity: sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      define-data-property: 1.1.1
+      get-intrinsic: 1.2.2
+      gopd: 1.0.1
+      has-property-descriptors: 1.0.1
+    dev: true
+
+  /set-function-name@2.0.1:
+    resolution: {integrity: sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      define-data-property: 1.1.1
+      functions-have-names: 1.2.3
+      has-property-descriptors: 1.0.1
     dev: true
 
   /shebang-command@1.2.0:
@@ -1099,16 +1155,16 @@ packages:
   /side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
     dependencies:
-      call-bind: 1.0.2
-      get-intrinsic: 1.2.1
-      object-inspect: 1.12.3
+      call-bind: 1.0.5
+      get-intrinsic: 1.2.2
+      object-inspect: 1.13.1
     dev: true
 
   /spdx-correct@3.2.0:
     resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
     dependencies:
       spdx-expression-parse: 3.0.1
-      spdx-license-ids: 3.0.13
+      spdx-license-ids: 3.0.16
     dev: true
 
   /spdx-exceptions@2.3.0:
@@ -1119,11 +1175,11 @@ packages:
     resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
     dependencies:
       spdx-exceptions: 2.3.0
-      spdx-license-ids: 3.0.13
+      spdx-license-ids: 3.0.16
     dev: true
 
-  /spdx-license-ids@3.0.13:
-    resolution: {integrity: sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==}
+  /spdx-license-ids@3.0.16:
+    resolution: {integrity: sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==}
     dev: true
 
   /string-width@4.2.3:
@@ -1135,38 +1191,38 @@ packages:
       strip-ansi: 6.0.1
     dev: true
 
-  /string.prototype.padend@3.1.4:
-    resolution: {integrity: sha512-67otBXoksdjsnXXRUq+KMVTdlVRZ2af422Y0aTyTjVaoQkGr3mxl2Bc5emi7dOQ3OGVVQQskmLEWwFXwommpNw==}
+  /string.prototype.padend@3.1.5:
+    resolution: {integrity: sha512-DOB27b/2UTTD+4myKUFh+/fXWcu/UDyASIXfg+7VzoCNNGOfWvoyU/x5pvVHr++ztyt/oSYI1BcWBBG/hmlNjA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
+      call-bind: 1.0.5
+      define-properties: 1.2.1
+      es-abstract: 1.22.3
     dev: true
 
-  /string.prototype.trim@1.2.7:
-    resolution: {integrity: sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==}
+  /string.prototype.trim@1.2.8:
+    resolution: {integrity: sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
+      call-bind: 1.0.5
+      define-properties: 1.2.1
+      es-abstract: 1.22.3
     dev: true
 
-  /string.prototype.trimend@1.0.6:
-    resolution: {integrity: sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==}
+  /string.prototype.trimend@1.0.7:
+    resolution: {integrity: sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==}
     dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
+      call-bind: 1.0.5
+      define-properties: 1.2.1
+      es-abstract: 1.22.3
     dev: true
 
-  /string.prototype.trimstart@1.0.6:
-    resolution: {integrity: sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==}
+  /string.prototype.trimstart@1.0.7:
+    resolution: {integrity: sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==}
     dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
+      call-bind: 1.0.5
+      define-properties: 1.2.1
+      es-abstract: 1.22.3
     dev: true
 
   /strip-ansi@6.0.1:
@@ -1219,65 +1275,64 @@ packages:
       is-number: 7.0.0
     dev: true
 
-  /turbo-darwin-64@1.10.9:
-    resolution: {integrity: sha512-Avz3wsYYb8/vjyHPVRFbNbowIiaF33vcBRklIUkPchTLvZekrT5x3ltQBCflyoi2zJV9g08hK4xXTGuCxeVvPA==}
+  /turbo-darwin-64@1.10.16:
+    resolution: {integrity: sha512-+Jk91FNcp9e9NCLYlvDDlp2HwEDp14F9N42IoW3dmHI5ZkGSXzalbhVcrx3DOox3QfiNUHxzWg4d7CnVNCuuMg==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-darwin-arm64@1.10.9:
-    resolution: {integrity: sha512-HyggdSPc/v2HuYrJF75smhIlurn8bY2cWpZYCjOL5Pj2DpLyhBs+nk+JirZl7XQiaUEVFj6eTbsejXyDP2Ritw==}
+  /turbo-darwin-arm64@1.10.16:
+    resolution: {integrity: sha512-jqGpFZipIivkRp/i+jnL8npX0VssE6IAVNKtu573LXtssZdV/S+fRGYA16tI46xJGxSAivrZ/IcgZrV6Jk80bw==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-64@1.10.9:
-    resolution: {integrity: sha512-qvdEgJKzDjOYY8o/HlnSwD+TIXiAML+3l6wUG4Ojuh/6cIhemLMRaHmEG+LygRW7GRw3dDv3hpp9OtiKmyxFdQ==}
+  /turbo-linux-64@1.10.16:
+    resolution: {integrity: sha512-PpqEZHwLoizQ6sTUvmImcRmACyRk9EWLXGlqceogPZsJ1jTRK3sfcF9fC2W56zkSIzuLEP07k5kl+ZxJd8JMcg==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-arm64@1.10.9:
-    resolution: {integrity: sha512-gva8H3CS8F6HlXL6YTDJAPrvPXVjBCxdd4DKABghjAxdknV5mZV1WWwMuGf0Z2W8qtmNG1XS0Dt2Wrb1ERFnLw==}
+  /turbo-linux-arm64@1.10.16:
+    resolution: {integrity: sha512-TMjFYz8to1QE0fKVXCIvG/4giyfnmqcQIwjdNfJvKjBxn22PpbjeuFuQ5kNXshUTRaTJihFbuuCcb5OYFNx4uw==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-64@1.10.9:
-    resolution: {integrity: sha512-OZ+bkSBJIkyl4JBDk8FX2/bOqtrElfXQV/KQ8/ibddB8Clzn/owx9FS1eXGdvttRZ9IJWzPrdFv+k4vbWQfE7w==}
+  /turbo-windows-64@1.10.16:
+    resolution: {integrity: sha512-+jsf68krs0N66FfC4/zZvioUap/Tq3sPFumnMV+EBo8jFdqs4yehd6+MxIwYTjSQLIcpH8KoNMB0gQYhJRLZzw==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-arm64@1.10.9:
-    resolution: {integrity: sha512-WhhhioGaePkGdGOIlrOB8LF8400FJUAQcVf8yCTvjzDB+OWn3dJQ3nalFjxH0PlZ17l6TPGt1WvWQiDVXUE4pw==}
+  /turbo-windows-arm64@1.10.16:
+    resolution: {integrity: sha512-sKm3hcMM1bl0B3PLG4ifidicOGfoJmOEacM5JtgBkYM48ncMHjkHfFY7HrJHZHUnXM4l05RQTpLFoOl/uIo2HQ==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo@1.10.9:
-    resolution: {integrity: sha512-s1ZRRD89NelCYHty1SpV1Elpv2LRrktgcddbZm9oTq1RPNpJFSrrEOAJhNz/w0fxTSjSN1Ey3TWZghjUjgKuzg==}
+  /turbo@1.10.16:
+    resolution: {integrity: sha512-2CEaK4FIuSZiP83iFa9GqMTQhroW2QryckVqUydmg4tx78baftTOS0O+oDAhvo9r9Nit4xUEtC1RAHoqs6ZEtg==}
     hasBin: true
-    requiresBuild: true
     optionalDependencies:
-      turbo-darwin-64: 1.10.9
-      turbo-darwin-arm64: 1.10.9
-      turbo-linux-64: 1.10.9
-      turbo-linux-arm64: 1.10.9
-      turbo-windows-64: 1.10.9
-      turbo-windows-arm64: 1.10.9
+      turbo-darwin-64: 1.10.16
+      turbo-darwin-arm64: 1.10.16
+      turbo-linux-64: 1.10.16
+      turbo-linux-arm64: 1.10.16
+      turbo-windows-64: 1.10.16
+      turbo-windows-arm64: 1.10.16
     dev: true
 
   /type-detect@4.0.8:
@@ -1289,8 +1344,8 @@ packages:
     resolution: {integrity: sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.2
-      get-intrinsic: 1.2.1
+      call-bind: 1.0.5
+      get-intrinsic: 1.2.2
       is-typed-array: 1.1.12
     dev: true
 
@@ -1298,7 +1353,7 @@ packages:
     resolution: {integrity: sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.2
+      call-bind: 1.0.5
       for-each: 0.3.3
       has-proto: 1.0.1
       is-typed-array: 1.1.12
@@ -1309,7 +1364,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       available-typed-arrays: 1.0.5
-      call-bind: 1.0.2
+      call-bind: 1.0.5
       for-each: 0.3.3
       has-proto: 1.0.1
       is-typed-array: 1.1.12
@@ -1318,13 +1373,13 @@ packages:
   /typed-array-length@1.0.4:
     resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}
     dependencies:
-      call-bind: 1.0.2
+      call-bind: 1.0.5
       for-each: 0.3.3
       is-typed-array: 1.1.12
     dev: true
 
-  /typescript@5.1.6:
-    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
+  /typescript@5.3.2:
+    resolution: {integrity: sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true
@@ -1332,7 +1387,7 @@ packages:
   /unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
     dependencies:
-      call-bind: 1.0.2
+      call-bind: 1.0.5
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
@@ -1355,12 +1410,12 @@ packages:
       is-symbol: 1.0.4
     dev: true
 
-  /which-typed-array@1.1.11:
-    resolution: {integrity: sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==}
+  /which-typed-array@1.1.13:
+    resolution: {integrity: sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==}
     engines: {node: '>= 0.4'}
     dependencies:
       available-typed-arrays: 1.0.5
-      call-bind: 1.0.2
+      call-bind: 1.0.5
       for-each: 0.3.3
       gopd: 1.0.1
       has-tostringtag: 1.0.0
@@ -1427,3 +1482,7 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- [#645](https://github.com/FuelLabs/fuel-vm/pull/645): Add wasm support for `fuel-tx` crate.
+
 ## [Version 0.43.1]
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,10 @@ bitflags = "2"
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"
 
-[profile.release]
+[profile.web-release] # For minimal wasm binaries, use this profile
+inherits = "release"
+opt-level = "z"
+codegen-units = 1
 lto = true
-opt-level = 'z'
+strip = true
+panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,7 @@ fuel-vm = { version = "0.43.0", path = "fuel-vm", default-features = false }
 bitflags = "2"
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"
+
+[profile.release]
+lto = true
+opt-level = 'z'

--- a/fuel-asm/Cargo.toml
+++ b/fuel-asm/Cargo.toml
@@ -16,7 +16,7 @@ bitflags = { workspace = true }
 fuel-types = { workspace = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 strum = { version = "0.24", default-features = false, features = ["derive"] }
-wasm-bindgen = { version = "0.2.87", optional = true }
+wasm-bindgen = { version = "0.2.88", optional = true }
 
 [dev-dependencies]
 bincode = { workspace = true }

--- a/fuel-tx/Cargo.toml
+++ b/fuel-tx/Cargo.toml
@@ -14,6 +14,7 @@ description = "FuelVM transaction."
 bitflags = { workspace = true }
 derivative = { version = "2.2.0", default-features = false, features = ["use_core"], optional = true }
 derive_more = { version = "0.99", default-features = false, features = ["display"] }
+duplicate = "1.0"
 fuel-asm = { workspace = true, default-features = false }
 fuel-crypto = { workspace = true, default-features = false }
 fuel-merkle = { workspace = true, default-features = false, optional = true }

--- a/fuel-tx/Cargo.toml
+++ b/fuel-tx/Cargo.toml
@@ -28,6 +28,7 @@ strum = { version = "0.24", default-features = false, optional = true }
 strum_macros = { version = "0.24", optional = true }
 wasm-bindgen = { version = "0.2.88", optional = true }
 serde-wasm-bindgen = { version = "0.6", optional = true }
+wee_alloc = { version = "0.4.5", optional = true }
 
 [dev-dependencies]
 bincode = { workspace = true }
@@ -46,7 +47,7 @@ rstest = "0.15"
 default = ["fuel-asm/default", "fuel-crypto/default", "fuel-merkle/default", "fuel-types/default", "std"]
 builder = ["alloc", "internals"]
 internals = []
-typescript = ["alloc", "wasm-bindgen", "serde", "serde-wasm-bindgen", "getrandom/js", "fuel-types/typescript"]
+typescript = ["alloc", "wee_alloc", "wasm-bindgen", "serde", "serde-wasm-bindgen", "getrandom/js", "fuel-types/typescript"]
 random = ["fuel-crypto/random", "fuel-types/random", "rand"]
 std = ["alloc", "fuel-asm/std", "fuel-crypto/std", "fuel-merkle/std", "fuel-types/std", "itertools/default", "rand?/default", "serde?/default", "hex/std"]
 alloc = ["hashbrown", "fuel-types/alloc", "itertools/use_alloc", "derivative", "fuel-merkle", "strum", "strum_macros"]

--- a/fuel-tx/Cargo.toml
+++ b/fuel-tx/Cargo.toml
@@ -21,13 +21,14 @@ fuel-types = { workspace = true, default-features = false }
 getrandom = { version = "0.2", optional = true }
 hashbrown = { version = "0.14", optional = true }
 itertools = { version = "0.10", default-features = false, optional = true }
+js-sys = { version = "0.3", optional = true }
 rand = { version = "0.8", default-features = false, features = ["std_rng"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"], optional = true }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"], optional = true }
+serde-wasm-bindgen = { version = "0.6", optional = true }
 strum = { version = "0.24", default-features = false, optional = true }
 strum_macros = { version = "0.24", optional = true }
 wasm-bindgen = { version = "0.2.88", optional = true }
-serde-wasm-bindgen = { version = "0.6", optional = true }
 wee_alloc = { version = "0.4.5", optional = true }
 
 [dev-dependencies]
@@ -47,7 +48,7 @@ rstest = "0.15"
 default = ["fuel-asm/default", "fuel-crypto/default", "fuel-merkle/default", "fuel-types/default", "std"]
 builder = ["alloc", "internals"]
 internals = []
-typescript = ["alloc", "wee_alloc", "wasm-bindgen", "serde", "serde-wasm-bindgen", "getrandom/js", "fuel-types/typescript"]
+typescript = ["alloc", "wee_alloc", "js-sys", "wasm-bindgen", "serde", "serde-wasm-bindgen", "getrandom/js", "fuel-types/typescript"]
 random = ["fuel-crypto/random", "fuel-types/random", "rand"]
 std = ["alloc", "fuel-asm/std", "fuel-crypto/std", "fuel-merkle/std", "fuel-types/std", "itertools/default", "rand?/default", "serde?/default", "hex/std"]
 alloc = ["hashbrown", "fuel-types/alloc", "itertools/use_alloc", "derivative", "fuel-merkle", "strum", "strum_macros"]

--- a/fuel-tx/Cargo.toml
+++ b/fuel-tx/Cargo.toml
@@ -19,7 +19,6 @@ fuel-asm = { workspace = true, default-features = false }
 fuel-crypto = { workspace = true, default-features = false }
 fuel-merkle = { workspace = true, default-features = false, optional = true }
 fuel-types = { workspace = true, default-features = false }
-getrandom = { version = "0.2", optional = true }
 hashbrown = { version = "0.14", optional = true }
 itertools = { version = "0.10", default-features = false, optional = true }
 js-sys = { version = "0.3", optional = true }
@@ -49,7 +48,7 @@ serde_json = { version = "1.0" }
 default = ["fuel-asm/default", "fuel-crypto/default", "fuel-merkle/default", "fuel-types/default", "std"]
 builder = ["alloc", "internals"]
 internals = []
-typescript = ["alloc", "js-sys", "wasm-bindgen", "serde", "serde-wasm-bindgen", "getrandom/js", "fuel-types/typescript"]
+typescript = ["alloc", "js-sys", "wasm-bindgen", "serde", "serde-wasm-bindgen", "fuel-types/typescript"]
 random = ["fuel-crypto/random", "fuel-types/random", "rand"]
 std = ["alloc", "fuel-asm/std", "fuel-crypto/std", "fuel-merkle/std", "fuel-types/std", "itertools/default", "rand?/default", "serde?/default", "hex/std"]
 alloc = ["hashbrown", "fuel-types/alloc", "itertools/use_alloc", "derivative", "fuel-merkle", "strum", "strum_macros"]

--- a/fuel-tx/Cargo.toml
+++ b/fuel-tx/Cargo.toml
@@ -24,8 +24,8 @@ itertools = { version = "0.10", default-features = false, optional = true }
 js-sys = { version = "0.3", optional = true }
 rand = { version = "0.8", default-features = false, features = ["std_rng"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"], optional = true }
-serde_json = { version = "1.0", default-features = false, features = ["alloc"], optional = true }
 serde-wasm-bindgen = { version = "0.6", optional = true }
+serde_json = { version = "1.0", default-features = false, features = ["alloc"], optional = true }
 strum = { version = "0.24", default-features = false, optional = true }
 strum_macros = { version = "0.24", optional = true }
 wasm-bindgen = { version = "0.2.88", optional = true }

--- a/fuel-tx/Cargo.toml
+++ b/fuel-tx/Cargo.toml
@@ -18,6 +18,7 @@ fuel-asm = { workspace = true, default-features = false }
 fuel-crypto = { workspace = true, default-features = false }
 fuel-merkle = { workspace = true, default-features = false, optional = true }
 fuel-types = { workspace = true, default-features = false }
+getrandom = { version = "0.2", optional = true }
 hashbrown = { version = "0.14", optional = true }
 itertools = { version = "0.10", default-features = false, optional = true }
 rand = { version = "0.8", default-features = false, features = ["std_rng"], optional = true }
@@ -25,6 +26,8 @@ serde = { version = "1.0", default-features = false, features = ["alloc", "deriv
 serde_json = { version = "1.0", default-features = false, features = ["alloc"], optional = true }
 strum = { version = "0.24", default-features = false, optional = true }
 strum_macros = { version = "0.24", optional = true }
+wasm-bindgen = { version = "0.2.88", optional = true }
+serde-wasm-bindgen = { version = "0.6", optional = true }
 
 [dev-dependencies]
 bincode = { workspace = true }
@@ -43,6 +46,7 @@ rstest = "0.15"
 default = ["fuel-asm/default", "fuel-crypto/default", "fuel-merkle/default", "fuel-types/default", "std"]
 builder = ["alloc", "internals"]
 internals = []
+typescript = ["alloc", "wasm-bindgen", "serde", "serde-wasm-bindgen", "getrandom/js", "fuel-types/typescript"]
 random = ["fuel-crypto/random", "fuel-types/random", "rand"]
 std = ["alloc", "fuel-asm/std", "fuel-crypto/std", "fuel-merkle/std", "fuel-types/std", "itertools/default", "rand?/default", "serde?/default", "hex/std"]
 alloc = ["hashbrown", "fuel-types/alloc", "itertools/use_alloc", "derivative", "fuel-merkle", "strum", "strum_macros"]

--- a/fuel-tx/Cargo.toml
+++ b/fuel-tx/Cargo.toml
@@ -29,7 +29,6 @@ serde_json = { version = "1.0", default-features = false, features = ["alloc"], 
 strum = { version = "0.24", default-features = false, optional = true }
 strum_macros = { version = "0.24", optional = true }
 wasm-bindgen = { version = "0.2.88", optional = true }
-wee_alloc = { version = "0.4.5", optional = true }
 
 [dev-dependencies]
 bincode = { workspace = true }
@@ -49,7 +48,7 @@ serde_json = { version = "1.0" }
 default = ["fuel-asm/default", "fuel-crypto/default", "fuel-merkle/default", "fuel-types/default", "std"]
 builder = ["alloc", "internals"]
 internals = []
-typescript = ["alloc", "wee_alloc", "js-sys", "wasm-bindgen", "serde", "serde-wasm-bindgen", "getrandom/js", "fuel-types/typescript"]
+typescript = ["alloc", "js-sys", "wasm-bindgen", "serde", "serde-wasm-bindgen", "getrandom/js", "fuel-types/typescript"]
 random = ["fuel-crypto/random", "fuel-types/random", "rand"]
 std = ["alloc", "fuel-asm/std", "fuel-crypto/std", "fuel-merkle/std", "fuel-types/std", "itertools/default", "rand?/default", "serde?/default", "hex/std"]
 alloc = ["hashbrown", "fuel-types/alloc", "itertools/use_alloc", "derivative", "fuel-merkle", "strum", "strum_macros"]

--- a/fuel-tx/Cargo.toml
+++ b/fuel-tx/Cargo.toml
@@ -14,7 +14,6 @@ description = "FuelVM transaction."
 bitflags = { workspace = true }
 derivative = { version = "2.2.0", default-features = false, features = ["use_core"], optional = true }
 derive_more = { version = "0.99", default-features = false, features = ["display"] }
-duplicate = "1.0"
 fuel-asm = { workspace = true, default-features = false }
 fuel-crypto = { workspace = true, default-features = false }
 fuel-merkle = { workspace = true, default-features = false, optional = true }

--- a/fuel-tx/src/lib.rs
+++ b/fuel-tx/src/lib.rs
@@ -137,7 +137,3 @@ impl ContractIdExt for ContractId {
         self.asset_id(&Bytes32::zeroed())
     }
 }
-
-
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;

--- a/fuel-tx/src/lib.rs
+++ b/fuel-tx/src/lib.rs
@@ -14,6 +14,9 @@
 #[cfg(feature = "typescript")]
 use getrandom as _; // This is a dependency only to enable features
 
+#[cfg(not(feature = "typescript"))]
+use duplicate as _; // This is only used with typescript feature
+
 #[cfg(feature = "alloc")]
 extern crate alloc;
 extern crate core;

--- a/fuel-tx/src/lib.rs
+++ b/fuel-tx/src/lib.rs
@@ -11,9 +11,6 @@
 
 // TODO: Add docs
 
-#[cfg(feature = "typescript")]
-use getrandom as _; // This is a dependency only to enable features
-
 #[cfg(not(feature = "typescript"))]
 use duplicate as _; // This is only used with typescript feature
 

--- a/fuel-tx/src/lib.rs
+++ b/fuel-tx/src/lib.rs
@@ -11,9 +11,6 @@
 
 // TODO: Add docs
 
-#[cfg(not(feature = "typescript"))]
-use duplicate as _; // This is only used with typescript feature
-
 #[cfg(feature = "alloc")]
 extern crate alloc;
 extern crate core;

--- a/fuel-tx/src/lib.rs
+++ b/fuel-tx/src/lib.rs
@@ -6,7 +6,7 @@
 #![allow(clippy::wrong_self_convention)]
 #![deny(clippy::cast_possible_truncation)]
 #![deny(clippy::string_slice)]
-#![deny(unused_crate_dependencies)]
+// #![deny(unused_crate_dependencies)]
 #![deny(unsafe_code)]
 
 // TODO: Add docs

--- a/fuel-tx/src/lib.rs
+++ b/fuel-tx/src/lib.rs
@@ -6,10 +6,13 @@
 #![allow(clippy::wrong_self_convention)]
 #![deny(clippy::cast_possible_truncation)]
 #![deny(clippy::string_slice)]
-// #![deny(unused_crate_dependencies)]
+#![deny(unused_crate_dependencies)]
 #![deny(unsafe_code)]
 
 // TODO: Add docs
+
+#[cfg(feature = "typescript")]
+use getrandom as _; // This is a dependency only to enable features
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/fuel-tx/src/lib.rs
+++ b/fuel-tx/src/lib.rs
@@ -137,3 +137,7 @@ impl ContractIdExt for ContractId {
         self.asset_id(&Bytes32::zeroed())
     }
 }
+
+
+#[global_allocator]
+static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;

--- a/fuel-tx/src/transaction.rs
+++ b/fuel-tx/src/transaction.rs
@@ -28,8 +28,14 @@ use fuel_types::{
     Salt,
     Word,
 };
-use input::*;
-use output::*;
+use input::{
+    typescript as input_ts,
+    *,
+};
+use output::{
+    typescript as output_ts,
+    *,
+};
 
 use alloc::vec::{
     IntoIter,

--- a/fuel-tx/src/transaction.rs
+++ b/fuel-tx/src/transaction.rs
@@ -28,13 +28,14 @@ use fuel_types::{
     Salt,
     Word,
 };
-use input::{
-    typescript as input_ts,
-    *,
-};
-use output::{
-    typescript as output_ts,
-    *,
+
+use input::*;
+use output::*;
+
+#[cfg(feature = "typescript")]
+use self::{
+    input::typescript as input_ts,
+    output::typescript as output_ts,
 };
 
 use alloc::vec::{

--- a/fuel-tx/src/transaction.rs
+++ b/fuel-tx/src/transaction.rs
@@ -931,47 +931,49 @@ pub mod typescript {
         }
     }
 
-    #[duplicate::duplicate_item(
-        Type;
-        [ Script ];
-        [ Create ];
-        [ Mint ];
-    )]
-    #[wasm_bindgen]
-    impl Type {
-        #[wasm_bindgen(js_name = as_tx)]
-        pub fn typescript_wrap_tx(self) -> Transaction {
-            Transaction(Box::new(crate::Transaction::Type(self)))
-        }
+    macro_rules! ts_methods {
+        ($t:ty, $tx:expr) => {
+            #[wasm_bindgen]
+            impl $t {
+                #[wasm_bindgen(js_name = as_tx)]
+                pub fn typescript_wrap_tx(self) -> Transaction {
+                    Transaction(Box::new($tx(self)))
+                }
 
-        #[wasm_bindgen(constructor)]
-        pub fn typescript_new() -> Type {
-            Type::default()
-        }
+                #[wasm_bindgen(constructor)]
+                pub fn typescript_new() -> $t {
+                    <$t>::default()
+                }
 
-        #[cfg(feature = "serde")]
-        #[wasm_bindgen(js_name = toJSON)]
-        pub fn to_json(&self) -> String {
-            serde_json::to_string(&self).expect("unable to json format")
-        }
+                #[cfg(feature = "serde")]
+                #[wasm_bindgen(js_name = toJSON)]
+                pub fn to_json(&self) -> String {
+                    serde_json::to_string(&self).expect("unable to json format")
+                }
 
-        #[wasm_bindgen(js_name = toString)]
-        pub fn typescript_to_string(&self) -> String {
-            format!("{:?}", self)
-        }
+                #[wasm_bindgen(js_name = toString)]
+                pub fn typescript_to_string(&self) -> String {
+                    format!("{:?}", self)
+                }
 
-        #[wasm_bindgen(js_name = to_bytes)]
-        pub fn typescript_to_bytes(&self) -> Vec<u8> {
-            use fuel_types::canonical::Serialize;
-            <Self as Serialize>::to_bytes(self)
-        }
+                #[wasm_bindgen(js_name = to_bytes)]
+                pub fn typescript_to_bytes(&self) -> Vec<u8> {
+                    use fuel_types::canonical::Serialize;
+                    <Self as Serialize>::to_bytes(self)
+                }
 
-        #[wasm_bindgen(js_name = from_bytes)]
-        pub fn typescript_from_bytes(value: &[u8]) -> Option<Type> {
-            use fuel_types::canonical::Deserialize;
-            <Self as Deserialize>::from_bytes(value).ok()
-        }
+                #[wasm_bindgen(js_name = from_bytes)]
+                pub fn typescript_from_bytes(value: &[u8]) -> Option<$t> {
+                    use fuel_types::canonical::Deserialize;
+                    <Self as Deserialize>::from_bytes(value).ok()
+                }
+            }
+        };
     }
+
+    ts_methods!(Script, crate::Transaction::Script);
+    ts_methods!(Create, crate::Transaction::Create);
+    ts_methods!(Mint, crate::Transaction::Mint);
 }
 
 #[cfg(test)]

--- a/fuel-tx/src/transaction.rs
+++ b/fuel-tx/src/transaction.rs
@@ -864,11 +864,11 @@ pub mod typescript {
         }
 
         #[wasm_bindgen(js_name = from_bytes)]
-        pub fn typescript_from_bytes(value: &[u8]) -> Option<Transaction> {
+        pub fn typescript_from_bytes(value: &[u8]) -> Result<Transaction, js_sys::Error> {
             use fuel_types::canonical::Deserialize;
             crate::Transaction::from_bytes(value)
                 .map(|v| Transaction(Box::new(v)))
-                .ok()
+                .map_err(|e| js_sys::Error::new(&format!("{:?}", e)))
         }
 
         #[wasm_bindgen]
@@ -963,9 +963,10 @@ pub mod typescript {
                 }
 
                 #[wasm_bindgen(js_name = from_bytes)]
-                pub fn typescript_from_bytes(value: &[u8]) -> Option<$t> {
+                pub fn typescript_from_bytes(value: &[u8]) -> Result<$t, js_sys::Error> {
                     use fuel_types::canonical::Deserialize;
-                    <Self as Deserialize>::from_bytes(value).ok()
+                    <Self as Deserialize>::from_bytes(value)
+                        .map_err(|e| js_sys::Error::new(&format!("{:?}", e)))
                 }
             }
         };

--- a/fuel-tx/src/transaction/consensus_parameters.rs
+++ b/fuel-tx/src/transaction/consensus_parameters.rs
@@ -168,6 +168,7 @@ impl Default for FeeParameters {
 
 /// Consensus configurable parameters used for verifying transactions
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "typescript", wasm_bindgen::prelude::wasm_bindgen)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(default))]
 pub struct PredicateParameters {

--- a/fuel-tx/src/transaction/consensus_parameters.rs
+++ b/fuel-tx/src/transaction/consensus_parameters.rs
@@ -168,7 +168,7 @@ impl Default for FeeParameters {
 
 /// Consensus configurable parameters used for verifying transactions
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-// #[cfg_attr(feature = "typescript", wasm_bindgen::prelude::wasm_bindgen)]
+#[cfg_attr(feature = "typescript", wasm_bindgen::prelude::wasm_bindgen)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(default))]
 pub struct PredicateParameters {

--- a/fuel-tx/src/transaction/consensus_parameters.rs
+++ b/fuel-tx/src/transaction/consensus_parameters.rs
@@ -369,6 +369,21 @@ impl Default for ContractParameters {
     }
 }
 
+#[cfg(feature = "typescript")]
+mod typescript {
+    use wasm_bindgen::prelude::*;
+
+    use super::PredicateParameters;
+
+    #[wasm_bindgen]
+    impl PredicateParameters {
+        #[wasm_bindgen(constructor)]
+        pub fn typescript_new() -> Self {
+            Self::DEFAULT
+        }
+    }
+}
+
 /// Arbitrary default consensus parameters. While best-efforts are made to adjust these to
 /// reasonable settings, they may not be useful for every network instantiation.
 #[deprecated(since = "0.12.2", note = "use `ConsensusParameters` instead.")]

--- a/fuel-tx/src/transaction/consensus_parameters.rs
+++ b/fuel-tx/src/transaction/consensus_parameters.rs
@@ -168,7 +168,7 @@ impl Default for FeeParameters {
 
 /// Consensus configurable parameters used for verifying transactions
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "typescript", wasm_bindgen::prelude::wasm_bindgen)]
+// #[cfg_attr(feature = "typescript", wasm_bindgen::prelude::wasm_bindgen)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(default))]
 pub struct PredicateParameters {

--- a/fuel-tx/src/transaction/policies.rs
+++ b/fuel-tx/src/transaction/policies.rs
@@ -82,6 +82,7 @@ pub const POLICIES_NUMBER: usize = PoliciesBits::all().bits().count_ones() as us
 /// Container for managing policies.
 #[derive(Clone, Copy, Default, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "typescript", wasm_bindgen::prelude::wasm_bindgen)]
 pub struct Policies {
     /// A bitmask that indicates what policies are set.
     bits: PoliciesBits,
@@ -268,6 +269,49 @@ impl Distribution<Policies> for Standard {
         }
 
         policies
+    }
+}
+
+#[cfg(feature = "typescript")]
+pub mod typescript {
+    use wasm_bindgen::prelude::*;
+
+    use crate::transaction::Policies;
+    use alloc::{
+        format,
+        string::String,
+        vec::Vec,
+    };
+
+    #[wasm_bindgen]
+    impl Policies {
+        #[wasm_bindgen(constructor)]
+        pub fn typescript_new() -> Policies {
+            Policies::default()
+        }
+
+        #[cfg(feature = "serde")]
+        #[wasm_bindgen(js_name = toJSON)]
+        pub fn to_json(&self) -> String {
+            serde_json::to_string(&self).expect("unable to json format")
+        }
+
+        #[wasm_bindgen(js_name = toString)]
+        pub fn typescript_to_string(&self) -> String {
+            format!("{:?}", self)
+        }
+
+        #[wasm_bindgen(js_name = to_bytes)]
+        pub fn typescript_to_bytes(&self) -> Vec<u8> {
+            use fuel_types::canonical::Serialize;
+            <Self as Serialize>::to_bytes(self)
+        }
+
+        #[wasm_bindgen(js_name = from_bytes)]
+        pub fn typescript_from_bytes(value: &[u8]) -> Option<Policies> {
+            use fuel_types::canonical::Deserialize;
+            <Self as Deserialize>::from_bytes(value).ok()
+        }
     }
 }
 

--- a/fuel-tx/src/transaction/policies.rs
+++ b/fuel-tx/src/transaction/policies.rs
@@ -308,9 +308,10 @@ pub mod typescript {
         }
 
         #[wasm_bindgen(js_name = from_bytes)]
-        pub fn typescript_from_bytes(value: &[u8]) -> Option<Policies> {
+        pub fn typescript_from_bytes(value: &[u8]) -> Result<Policies, js_sys::Error> {
             use fuel_types::canonical::Deserialize;
-            <Self as Deserialize>::from_bytes(value).ok()
+            <Self as Deserialize>::from_bytes(value)
+                .map_err(|e| js_sys::Error::new(&format!("{:?}", e)))
         }
     }
 }

--- a/fuel-tx/src/transaction/types/create.rs
+++ b/fuel-tx/src/transaction/types/create.rs
@@ -108,6 +108,7 @@ impl CreateMetadata {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
 #[canonical(prefix = TransactionRepr::Create)]
+#[cfg_attr(feature = "typescript", wasm_bindgen::prelude::wasm_bindgen)]
 #[derivative(Eq, PartialEq, Hash)]
 pub struct Create {
     pub(crate) bytecode_length: Word,

--- a/fuel-tx/src/transaction/types/input.rs
+++ b/fuel-tx/src/transaction/types/input.rs
@@ -935,6 +935,7 @@ pub mod typescript {
             .map(|v| Input2(Box::new(v)))
             .ok()
     }
+
     #[wasm_bindgen::prelude::wasm_bindgen]
     pub fn input_coin_predicate(
         utxo_id: UtxoId,

--- a/fuel-tx/src/transaction/types/input.rs
+++ b/fuel-tx/src/transaction/types/input.rs
@@ -935,7 +935,7 @@ pub mod typescript {
         }
 
         #[wasm_bindgen(js_name = toString)]
-        pub fn to_string(&self) -> String {
+        pub fn typescript_to_string(&self) -> String {
             format!("{:?}", self.0)
         }
 

--- a/fuel-tx/src/transaction/types/input.rs
+++ b/fuel-tx/src/transaction/types/input.rs
@@ -898,6 +898,8 @@ mod snapshot_tests;
 
 #[cfg(feature = "typescript")]
 pub mod typescript {
+    use wasm_bindgen::prelude::*;
+
     use super::*;
 
     use crate::{
@@ -914,190 +916,206 @@ pub mod typescript {
 
     use alloc::{
         boxed::Box,
+        format,
+        string::String,
         vec::Vec,
     };
 
     #[derive(Clone, Eq, Hash, PartialEq)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[wasm_bindgen::prelude::wasm_bindgen]
+    #[wasm_bindgen]
     pub struct Input2(#[wasm_bindgen(skip)] pub Box<crate::Input>);
 
-    #[wasm_bindgen::prelude::wasm_bindgen]
-    pub fn input_to_bytes(input: &Input2) -> Vec<u8> {
-        use fuel_types::canonical::Serialize;
-        input.0.to_bytes()
-    }
+    #[wasm_bindgen]
+    impl Input2 {
+        #[cfg(feature = "serde")]
+        #[wasm_bindgen(js_name = toJSON)]
+        pub fn to_json(&self) -> String {
+            serde_json::to_string(&self.0).expect("unable to json format")
+        }
 
-    #[wasm_bindgen::prelude::wasm_bindgen]
-    pub fn input_from_bytes(input: &[u8]) -> Option<Input2> {
-        use fuel_types::canonical::Deserialize;
-        crate::Input::from_bytes(input)
-            .map(|v| Input2(Box::new(v)))
-            .ok()
-    }
+        #[wasm_bindgen(js_name = toString)]
+        pub fn to_string(&self) -> String {
+            format!("{:?}", self.0)
+        }
 
-    #[wasm_bindgen::prelude::wasm_bindgen]
-    pub fn input_coin_predicate(
-        utxo_id: UtxoId,
-        owner: Address,
-        amount: Word,
-        asset_id: AssetId,
-        tx_pointer: TxPointer,
-        maturity: BlockHeight,
-        predicate_gas_used: Word,
-        predicate: Vec<u8>,
-        predicate_data: Vec<u8>,
-    ) -> Input2 {
-        Input2(Box::new(crate::Input::CoinPredicate(CoinPredicate {
-            utxo_id,
-            owner,
-            amount,
-            asset_id,
-            tx_pointer,
-            witness_index: Empty::new(),
-            maturity,
-            predicate_gas_used,
-            predicate,
-            predicate_data,
-        })))
-    }
+        #[wasm_bindgen]
+        pub fn to_bytes(&self) -> Vec<u8> {
+            use fuel_types::canonical::Serialize;
+            self.0.to_bytes()
+        }
 
-    #[wasm_bindgen::prelude::wasm_bindgen]
-    pub fn input_coin_signed(
-        utxo_id: UtxoId,
-        owner: Address,
-        amount: Word,
-        asset_id: AssetId,
-        tx_pointer: TxPointer,
-        witness_index: u8,
-        maturity: BlockHeight,
-    ) -> Input2 {
-        Input2(Box::new(crate::Input::CoinSigned(CoinSigned {
-            utxo_id,
-            owner,
-            amount,
-            asset_id,
-            tx_pointer,
-            witness_index,
-            maturity,
-            predicate_gas_used: Empty::new(),
-            predicate: Empty::new(),
-            predicate_data: Empty::new(),
-        })))
-    }
+        #[wasm_bindgen]
+        pub fn from_bytes(input: &[u8]) -> Option<Input2> {
+            use fuel_types::canonical::Deserialize;
+            crate::Input::from_bytes(input)
+                .map(|v| Input2(Box::new(v)))
+                .ok()
+        }
 
-    #[wasm_bindgen::prelude::wasm_bindgen]
-    pub fn input_contract(
-        utxo_id: UtxoId,
-        balance_root: Bytes32,
-        state_root: Bytes32,
-        tx_pointer: TxPointer,
-        contract_id: ContractId,
-    ) -> Input2 {
-        Input2(Box::new(crate::Input::Contract(Contract {
-            utxo_id,
-            balance_root,
-            state_root,
-            tx_pointer,
-            contract_id,
-        })))
-    }
-
-    #[wasm_bindgen::prelude::wasm_bindgen]
-    pub fn input_message_coin_signed(
-        sender: Address,
-        recipient: Address,
-        amount: Word,
-        nonce: Nonce,
-        witness_index: u8,
-    ) -> Input2 {
-        Input2(Box::new(crate::Input::MessageCoinSigned(
-            MessageCoinSigned {
-                sender,
-                recipient,
+        #[wasm_bindgen]
+        pub fn coin_predicate(
+            utxo_id: UtxoId,
+            owner: Address,
+            amount: Word,
+            asset_id: AssetId,
+            tx_pointer: TxPointer,
+            maturity: BlockHeight,
+            predicate_gas_used: Word,
+            predicate: Vec<u8>,
+            predicate_data: Vec<u8>,
+        ) -> Input2 {
+            Input2(Box::new(crate::Input::CoinPredicate(CoinPredicate {
+                utxo_id,
+                owner,
                 amount,
-                nonce,
-                witness_index,
-                predicate_gas_used: Empty::new(),
-                data: Empty::new(),
-                predicate: Empty::new(),
-                predicate_data: Empty::new(),
-            },
-        )))
-    }
-
-    #[wasm_bindgen::prelude::wasm_bindgen]
-    pub fn input_message_coin_predicate(
-        sender: Address,
-        recipient: Address,
-        amount: Word,
-        nonce: Nonce,
-        predicate_gas_used: Word,
-        predicate: Vec<u8>,
-        predicate_data: Vec<u8>,
-    ) -> Input2 {
-        Input2(Box::new(crate::Input::MessageCoinPredicate(
-            MessageCoinPredicate {
-                sender,
-                recipient,
-                amount,
-                nonce,
+                asset_id,
+                tx_pointer,
                 witness_index: Empty::new(),
+                maturity,
                 predicate_gas_used,
-                data: Empty::new(),
                 predicate,
                 predicate_data,
-            },
-        )))
-    }
+            })))
+        }
 
-    #[wasm_bindgen::prelude::wasm_bindgen]
-    pub fn input_message_data_signed(
-        sender: Address,
-        recipient: Address,
-        amount: Word,
-        nonce: Nonce,
-        witness_index: u8,
-        data: Vec<u8>,
-    ) -> Input2 {
-        Input2(Box::new(crate::Input::MessageDataSigned(
-            MessageDataSigned {
-                sender,
-                recipient,
+        #[wasm_bindgen]
+        pub fn coin_signed(
+            utxo_id: UtxoId,
+            owner: Address,
+            amount: Word,
+            asset_id: AssetId,
+            tx_pointer: TxPointer,
+            witness_index: u8,
+            maturity: BlockHeight,
+        ) -> Input2 {
+            Input2(Box::new(crate::Input::CoinSigned(CoinSigned {
+                utxo_id,
+                owner,
                 amount,
-                nonce,
+                asset_id,
+                tx_pointer,
                 witness_index,
-                data,
+                maturity,
+                predicate_gas_used: Empty::new(),
                 predicate: Empty::new(),
                 predicate_data: Empty::new(),
-                predicate_gas_used: Empty::new(),
-            },
-        )))
-    }
+            })))
+        }
 
-    #[wasm_bindgen::prelude::wasm_bindgen]
-    pub fn input_message_data_predicate(
-        sender: Address,
-        recipient: Address,
-        amount: Word,
-        nonce: Nonce,
-        predicate_gas_used: Word,
-        data: Vec<u8>,
-        predicate: Vec<u8>,
-        predicate_data: Vec<u8>,
-    ) -> Input2 {
-        Input2(Box::new(crate::Input::MessageDataPredicate(
-            MessageDataPredicate {
-                sender,
-                recipient,
-                amount,
-                nonce,
-                witness_index: Empty::new(),
-                predicate_gas_used,
-                data,
-                predicate,
-                predicate_data,
-            },
-        )))
+        #[wasm_bindgen]
+        pub fn contract(
+            utxo_id: UtxoId,
+            balance_root: Bytes32,
+            state_root: Bytes32,
+            tx_pointer: TxPointer,
+            contract_id: ContractId,
+        ) -> Input2 {
+            Input2(Box::new(crate::Input::Contract(Contract {
+                utxo_id,
+                balance_root,
+                state_root,
+                tx_pointer,
+                contract_id,
+            })))
+        }
+
+        #[wasm_bindgen]
+        pub fn message_coin_signed(
+            sender: Address,
+            recipient: Address,
+            amount: Word,
+            nonce: Nonce,
+            witness_index: u8,
+        ) -> Input2 {
+            Input2(Box::new(crate::Input::MessageCoinSigned(
+                MessageCoinSigned {
+                    sender,
+                    recipient,
+                    amount,
+                    nonce,
+                    witness_index,
+                    predicate_gas_used: Empty::new(),
+                    data: Empty::new(),
+                    predicate: Empty::new(),
+                    predicate_data: Empty::new(),
+                },
+            )))
+        }
+
+        #[wasm_bindgen]
+        pub fn message_coin_predicate(
+            sender: Address,
+            recipient: Address,
+            amount: Word,
+            nonce: Nonce,
+            predicate_gas_used: Word,
+            predicate: Vec<u8>,
+            predicate_data: Vec<u8>,
+        ) -> Input2 {
+            Input2(Box::new(crate::Input::MessageCoinPredicate(
+                MessageCoinPredicate {
+                    sender,
+                    recipient,
+                    amount,
+                    nonce,
+                    witness_index: Empty::new(),
+                    predicate_gas_used,
+                    data: Empty::new(),
+                    predicate,
+                    predicate_data,
+                },
+            )))
+        }
+
+        #[wasm_bindgen]
+        pub fn message_data_signed(
+            sender: Address,
+            recipient: Address,
+            amount: Word,
+            nonce: Nonce,
+            witness_index: u8,
+            data: Vec<u8>,
+        ) -> Input2 {
+            Input2(Box::new(crate::Input::MessageDataSigned(
+                MessageDataSigned {
+                    sender,
+                    recipient,
+                    amount,
+                    nonce,
+                    witness_index,
+                    data,
+                    predicate: Empty::new(),
+                    predicate_data: Empty::new(),
+                    predicate_gas_used: Empty::new(),
+                },
+            )))
+        }
+
+        #[wasm_bindgen]
+        pub fn message_data_predicate(
+            sender: Address,
+            recipient: Address,
+            amount: Word,
+            nonce: Nonce,
+            predicate_gas_used: Word,
+            data: Vec<u8>,
+            predicate: Vec<u8>,
+            predicate_data: Vec<u8>,
+        ) -> Input2 {
+            Input2(Box::new(crate::Input::MessageDataPredicate(
+                MessageDataPredicate {
+                    sender,
+                    recipient,
+                    amount,
+                    nonce,
+                    witness_index: Empty::new(),
+                    predicate_gas_used,
+                    data,
+                    predicate,
+                    predicate_data,
+                },
+            )))
+        }
     }
 }

--- a/fuel-tx/src/transaction/types/input.rs
+++ b/fuel-tx/src/transaction/types/input.rs
@@ -946,11 +946,11 @@ pub mod typescript {
         }
 
         #[wasm_bindgen(js_name = from_bytes)]
-        pub fn typescript_from_bytes(value: &[u8]) -> Option<Input> {
+        pub fn typescript_from_bytes(value: &[u8]) -> Result<Input, js_sys::Error> {
             use fuel_types::canonical::Deserialize;
             crate::Input::from_bytes(value)
                 .map(|v| Input(Box::new(v)))
-                .ok()
+                .map_err(|e| js_sys::Error::new(&format!("{:?}", e)))
         }
 
         #[wasm_bindgen]

--- a/fuel-tx/src/transaction/types/input.rs
+++ b/fuel-tx/src/transaction/types/input.rs
@@ -924,10 +924,10 @@ pub mod typescript {
     #[derive(Clone, Eq, Hash, PartialEq)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[wasm_bindgen]
-    pub struct Input2(#[wasm_bindgen(skip)] pub Box<crate::Input>);
+    pub struct Input(#[wasm_bindgen(skip)] pub Box<crate::Input>);
 
     #[wasm_bindgen]
-    impl Input2 {
+    impl Input {
         #[cfg(feature = "serde")]
         #[wasm_bindgen(js_name = toJSON)]
         pub fn to_json(&self) -> String {
@@ -946,10 +946,10 @@ pub mod typescript {
         }
 
         #[wasm_bindgen]
-        pub fn from_bytes(input: &[u8]) -> Option<Input2> {
+        pub fn from_bytes(input: &[u8]) -> Option<Input> {
             use fuel_types::canonical::Deserialize;
             crate::Input::from_bytes(input)
-                .map(|v| Input2(Box::new(v)))
+                .map(|v| Input(Box::new(v)))
                 .ok()
         }
 
@@ -964,8 +964,8 @@ pub mod typescript {
             predicate_gas_used: Word,
             predicate: Vec<u8>,
             predicate_data: Vec<u8>,
-        ) -> Input2 {
-            Input2(Box::new(crate::Input::CoinPredicate(CoinPredicate {
+        ) -> Input {
+            Input(Box::new(crate::Input::CoinPredicate(CoinPredicate {
                 utxo_id,
                 owner,
                 amount,
@@ -988,8 +988,8 @@ pub mod typescript {
             tx_pointer: TxPointer,
             witness_index: u8,
             maturity: BlockHeight,
-        ) -> Input2 {
-            Input2(Box::new(crate::Input::CoinSigned(CoinSigned {
+        ) -> Input {
+            Input(Box::new(crate::Input::CoinSigned(CoinSigned {
                 utxo_id,
                 owner,
                 amount,
@@ -1010,8 +1010,8 @@ pub mod typescript {
             state_root: Bytes32,
             tx_pointer: TxPointer,
             contract_id: ContractId,
-        ) -> Input2 {
-            Input2(Box::new(crate::Input::Contract(Contract {
+        ) -> Input {
+            Input(Box::new(crate::Input::Contract(Contract {
                 utxo_id,
                 balance_root,
                 state_root,
@@ -1027,8 +1027,8 @@ pub mod typescript {
             amount: Word,
             nonce: Nonce,
             witness_index: u8,
-        ) -> Input2 {
-            Input2(Box::new(crate::Input::MessageCoinSigned(
+        ) -> Input {
+            Input(Box::new(crate::Input::MessageCoinSigned(
                 MessageCoinSigned {
                     sender,
                     recipient,
@@ -1052,8 +1052,8 @@ pub mod typescript {
             predicate_gas_used: Word,
             predicate: Vec<u8>,
             predicate_data: Vec<u8>,
-        ) -> Input2 {
-            Input2(Box::new(crate::Input::MessageCoinPredicate(
+        ) -> Input {
+            Input(Box::new(crate::Input::MessageCoinPredicate(
                 MessageCoinPredicate {
                     sender,
                     recipient,
@@ -1076,8 +1076,8 @@ pub mod typescript {
             nonce: Nonce,
             witness_index: u8,
             data: Vec<u8>,
-        ) -> Input2 {
-            Input2(Box::new(crate::Input::MessageDataSigned(
+        ) -> Input {
+            Input(Box::new(crate::Input::MessageDataSigned(
                 MessageDataSigned {
                     sender,
                     recipient,
@@ -1102,8 +1102,8 @@ pub mod typescript {
             data: Vec<u8>,
             predicate: Vec<u8>,
             predicate_data: Vec<u8>,
-        ) -> Input2 {
-            Input2(Box::new(crate::Input::MessageDataPredicate(
+        ) -> Input {
+            Input(Box::new(crate::Input::MessageDataPredicate(
                 MessageDataPredicate {
                     sender,
                     recipient,

--- a/fuel-tx/src/transaction/types/input.rs
+++ b/fuel-tx/src/transaction/types/input.rs
@@ -939,16 +939,16 @@ pub mod typescript {
             format!("{:?}", self.0)
         }
 
-        #[wasm_bindgen]
-        pub fn to_bytes(&self) -> Vec<u8> {
+        #[wasm_bindgen(js_name = to_bytes)]
+        pub fn typescript_to_bytes(&self) -> Vec<u8> {
             use fuel_types::canonical::Serialize;
             self.0.to_bytes()
         }
 
-        #[wasm_bindgen]
-        pub fn from_bytes(input: &[u8]) -> Option<Input> {
+        #[wasm_bindgen(js_name = from_bytes)]
+        pub fn typescript_from_bytes(value: &[u8]) -> Option<Input> {
             use fuel_types::canonical::Deserialize;
-            crate::Input::from_bytes(input)
+            crate::Input::from_bytes(value)
                 .map(|v| Input(Box::new(v)))
                 .ok()
         }

--- a/fuel-tx/src/transaction/types/input.rs
+++ b/fuel-tx/src/transaction/types/input.rs
@@ -895,3 +895,208 @@ impl Deserialize for Input {
 
 #[cfg(all(test, feature = "std"))]
 mod snapshot_tests;
+
+#[cfg(feature = "typescript")]
+pub mod typescript {
+    use super::*;
+
+    use crate::{
+        TxPointer,
+        UtxoId,
+    };
+    use fuel_types::{
+        Address,
+        AssetId,
+        BlockHeight,
+        Bytes32,
+        Word,
+    };
+
+    use alloc::{
+        boxed::Box,
+        vec::Vec,
+    };
+
+    #[derive(Clone, Eq, Hash, PartialEq)]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[wasm_bindgen::prelude::wasm_bindgen]
+    pub struct Input2(#[wasm_bindgen(skip)] pub Box<crate::Input>);
+
+    #[wasm_bindgen::prelude::wasm_bindgen]
+    pub fn input_to_bytes(input: &Input2) -> Vec<u8> {
+        use fuel_types::canonical::Serialize;
+        input.0.to_bytes()
+    }
+
+    #[wasm_bindgen::prelude::wasm_bindgen]
+    pub fn input_from_bytes(input: &[u8]) -> Option<Input2> {
+        use fuel_types::canonical::Deserialize;
+        crate::Input::from_bytes(input)
+            .map(|v| Input2(Box::new(v)))
+            .ok()
+    }
+    #[wasm_bindgen::prelude::wasm_bindgen]
+    pub fn input_coin_predicate(
+        utxo_id: UtxoId,
+        owner: Address,
+        amount: Word,
+        asset_id: AssetId,
+        tx_pointer: TxPointer,
+        maturity: BlockHeight,
+        predicate_gas_used: Word,
+        predicate: Vec<u8>,
+        predicate_data: Vec<u8>,
+    ) -> Input2 {
+        Input2(Box::new(crate::Input::CoinPredicate(CoinPredicate {
+            utxo_id,
+            owner,
+            amount,
+            asset_id,
+            tx_pointer,
+            witness_index: Empty::new(),
+            maturity,
+            predicate_gas_used,
+            predicate,
+            predicate_data,
+        })))
+    }
+
+    #[wasm_bindgen::prelude::wasm_bindgen]
+    pub fn input_coin_signed(
+        utxo_id: UtxoId,
+        owner: Address,
+        amount: Word,
+        asset_id: AssetId,
+        tx_pointer: TxPointer,
+        witness_index: u8,
+        maturity: BlockHeight,
+    ) -> Input2 {
+        Input2(Box::new(crate::Input::CoinSigned(CoinSigned {
+            utxo_id,
+            owner,
+            amount,
+            asset_id,
+            tx_pointer,
+            witness_index,
+            maturity,
+            predicate_gas_used: Empty::new(),
+            predicate: Empty::new(),
+            predicate_data: Empty::new(),
+        })))
+    }
+
+    #[wasm_bindgen::prelude::wasm_bindgen]
+    pub fn input_contract(
+        utxo_id: UtxoId,
+        balance_root: Bytes32,
+        state_root: Bytes32,
+        tx_pointer: TxPointer,
+        contract_id: ContractId,
+    ) -> Input2 {
+        Input2(Box::new(crate::Input::Contract(Contract {
+            utxo_id,
+            balance_root,
+            state_root,
+            tx_pointer,
+            contract_id,
+        })))
+    }
+
+    #[wasm_bindgen::prelude::wasm_bindgen]
+    pub fn input_message_coin_signed(
+        sender: Address,
+        recipient: Address,
+        amount: Word,
+        nonce: Nonce,
+        witness_index: u8,
+    ) -> Input2 {
+        Input2(Box::new(crate::Input::MessageCoinSigned(
+            MessageCoinSigned {
+                sender,
+                recipient,
+                amount,
+                nonce,
+                witness_index,
+                predicate_gas_used: Empty::new(),
+                data: Empty::new(),
+                predicate: Empty::new(),
+                predicate_data: Empty::new(),
+            },
+        )))
+    }
+
+    #[wasm_bindgen::prelude::wasm_bindgen]
+    pub fn input_message_coin_predicate(
+        sender: Address,
+        recipient: Address,
+        amount: Word,
+        nonce: Nonce,
+        predicate_gas_used: Word,
+        predicate: Vec<u8>,
+        predicate_data: Vec<u8>,
+    ) -> Input2 {
+        Input2(Box::new(crate::Input::MessageCoinPredicate(
+            MessageCoinPredicate {
+                sender,
+                recipient,
+                amount,
+                nonce,
+                witness_index: Empty::new(),
+                predicate_gas_used,
+                data: Empty::new(),
+                predicate,
+                predicate_data,
+            },
+        )))
+    }
+
+    #[wasm_bindgen::prelude::wasm_bindgen]
+    pub fn input_message_data_signed(
+        sender: Address,
+        recipient: Address,
+        amount: Word,
+        nonce: Nonce,
+        witness_index: u8,
+        data: Vec<u8>,
+    ) -> Input2 {
+        Input2(Box::new(crate::Input::MessageDataSigned(
+            MessageDataSigned {
+                sender,
+                recipient,
+                amount,
+                nonce,
+                witness_index,
+                data,
+                predicate: Empty::new(),
+                predicate_data: Empty::new(),
+                predicate_gas_used: Empty::new(),
+            },
+        )))
+    }
+
+    #[wasm_bindgen::prelude::wasm_bindgen]
+    pub fn input_message_data_predicate(
+        sender: Address,
+        recipient: Address,
+        amount: Word,
+        nonce: Nonce,
+        predicate_gas_used: Word,
+        data: Vec<u8>,
+        predicate: Vec<u8>,
+        predicate_data: Vec<u8>,
+    ) -> Input2 {
+        Input2(Box::new(crate::Input::MessageDataPredicate(
+            MessageDataPredicate {
+                sender,
+                recipient,
+                amount,
+                nonce,
+                witness_index: Empty::new(),
+                predicate_gas_used,
+                data,
+                predicate,
+                predicate_data,
+            },
+        )))
+    }
+}

--- a/fuel-tx/src/transaction/types/input/contract.rs
+++ b/fuel-tx/src/transaction/types/input/contract.rs
@@ -15,6 +15,7 @@ use fuel_types::{
 #[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
+#[cfg_attr(feature = "typescript", wasm_bindgen::prelude::wasm_bindgen(js_name = InputContract))]
 pub struct Contract {
     pub utxo_id: UtxoId,
     pub balance_root: Bytes32,
@@ -52,6 +53,42 @@ impl Distribution<Contract> for Standard {
             state_root: rng.gen(),
             tx_pointer: rng.gen(),
             contract_id: rng.gen(),
+        }
+    }
+}
+
+#[cfg(feature = "typescript")]
+pub mod typescript {
+    use wasm_bindgen::prelude::*;
+
+    use super::*;
+
+    use crate::{
+        TxPointer,
+        UtxoId,
+    };
+    use fuel_types::{
+        Bytes32,
+        ContractId,
+    };
+
+    #[wasm_bindgen(js_class = InputContract)]
+    impl Contract {
+        #[wasm_bindgen(constructor)]
+        pub fn typescript_new(
+            utxo_id: UtxoId,
+            balance_root: Bytes32,
+            state_root: Bytes32,
+            tx_pointer: TxPointer,
+            contract_id: ContractId,
+        ) -> Self {
+            Self {
+                utxo_id,
+                balance_root,
+                state_root,
+                tx_pointer,
+                contract_id,
+            }
         }
     }
 }

--- a/fuel-tx/src/transaction/types/mint.rs
+++ b/fuel-tx/src/transaction/types/mint.rs
@@ -51,6 +51,7 @@ impl MintMetadata {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
 #[canonical(prefix = TransactionRepr::Mint)]
+#[cfg_attr(feature = "typescript", wasm_bindgen::prelude::wasm_bindgen)]
 #[derivative(Eq, PartialEq, Hash)]
 pub struct Mint {
     /// The location of the transaction in the block.

--- a/fuel-tx/src/transaction/types/output.rs
+++ b/fuel-tx/src/transaction/types/output.rs
@@ -242,3 +242,78 @@ impl Output {
         self.prepare_sign()
     }
 }
+
+#[cfg(feature = "typescript")]
+pub mod typescript {
+    use super::*;
+
+    use fuel_types::{
+        Address,
+        AssetId,
+        Bytes32,
+        Word,
+    };
+
+    use alloc::{
+        boxed::Box,
+        vec::Vec,
+    };
+
+    #[derive(Clone, Eq, Hash, PartialEq)]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[wasm_bindgen::prelude::wasm_bindgen]
+    pub struct Output2(#[wasm_bindgen(skip)] pub Box<crate::Output>);
+
+    #[wasm_bindgen::prelude::wasm_bindgen]
+    pub fn output_to_bytes(input: &Output2) -> Vec<u8> {
+        use fuel_types::canonical::Serialize;
+        input.0.to_bytes()
+    }
+
+    #[wasm_bindgen::prelude::wasm_bindgen]
+    pub fn output_from_bytes(input: &[u8]) -> Option<Output2> {
+        use fuel_types::canonical::Deserialize;
+        crate::Output::from_bytes(input)
+            .map(|v| Output2(Box::new(v)))
+            .ok()
+    }
+
+    #[wasm_bindgen::prelude::wasm_bindgen]
+    pub fn output_coin(to: Address, amount: Word, asset_id: AssetId) -> Output2 {
+        Output2(Box::new(crate::Output::coin(to, amount, asset_id)))
+    }
+
+    #[wasm_bindgen::prelude::wasm_bindgen]
+    pub fn output_contract(
+        input_index: u8,
+        balance_root: Bytes32,
+        state_root: Bytes32,
+    ) -> Output2 {
+        Output2(Box::new(crate::Output::contract(
+            input_index,
+            balance_root,
+            state_root,
+        )))
+    }
+
+    #[wasm_bindgen::prelude::wasm_bindgen]
+    pub fn output_change(to: Address, amount: Word, asset_id: AssetId) -> Output2 {
+        Output2(Box::new(crate::Output::change(to, amount, asset_id)))
+    }
+
+    #[wasm_bindgen::prelude::wasm_bindgen]
+    pub fn output_variable(to: Address, amount: Word, asset_id: AssetId) -> Output2 {
+        Output2(Box::new(crate::Output::variable(to, amount, asset_id)))
+    }
+
+    #[wasm_bindgen::prelude::wasm_bindgen]
+    pub fn output_contract_created(
+        contract_id: ContractId,
+        state_root: Bytes32,
+    ) -> Output2 {
+        Output2(Box::new(crate::Output::contract_created(
+            contract_id,
+            state_root,
+        )))
+    }
+}

--- a/fuel-tx/src/transaction/types/output.rs
+++ b/fuel-tx/src/transaction/types/output.rs
@@ -277,7 +277,7 @@ pub mod typescript {
         }
 
         #[wasm_bindgen(js_name = toString)]
-        pub fn to_string(&self) -> String {
+        pub fn typescript_to_string(&self) -> String {
             format!("{:?}", self.0)
         }
 

--- a/fuel-tx/src/transaction/types/output.rs
+++ b/fuel-tx/src/transaction/types/output.rs
@@ -288,11 +288,11 @@ pub mod typescript {
         }
 
         #[wasm_bindgen(js_name = from_bytes)]
-        pub fn typescript_from_bytes(value: &[u8]) -> Option<Output> {
+        pub fn typescript_from_bytes(value: &[u8]) -> Result<Output, js_sys::Error> {
             use fuel_types::canonical::Deserialize;
             crate::Output::from_bytes(value)
                 .map(|v| Output(Box::new(v)))
-                .ok()
+                .map_err(|e| js_sys::Error::new(&format!("{:?}", e)))
         }
 
         #[wasm_bindgen]

--- a/fuel-tx/src/transaction/types/output.rs
+++ b/fuel-tx/src/transaction/types/output.rs
@@ -281,16 +281,16 @@ pub mod typescript {
             format!("{:?}", self.0)
         }
 
-        #[wasm_bindgen]
-        pub fn to_bytes(&self) -> Vec<u8> {
+        #[wasm_bindgen(js_name = to_bytes)]
+        pub fn typescript_to_bytes(&self) -> Vec<u8> {
             use fuel_types::canonical::Serialize;
             self.0.to_bytes()
         }
 
-        #[wasm_bindgen]
-        pub fn from_bytes(output: &[u8]) -> Option<Output> {
+        #[wasm_bindgen(js_name = from_bytes)]
+        pub fn typescript_from_bytes(value: &[u8]) -> Option<Output> {
             use fuel_types::canonical::Deserialize;
-            crate::Output::from_bytes(output)
+            crate::Output::from_bytes(value)
                 .map(|v| Output(Box::new(v)))
                 .ok()
         }

--- a/fuel-tx/src/transaction/types/output.rs
+++ b/fuel-tx/src/transaction/types/output.rs
@@ -266,10 +266,10 @@ pub mod typescript {
     #[derive(Clone, Eq, Hash, PartialEq)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[wasm_bindgen]
-    pub struct Output2(#[wasm_bindgen(skip)] pub Box<crate::Output>);
+    pub struct Output(#[wasm_bindgen(skip)] pub Box<crate::Output>);
 
     #[wasm_bindgen]
-    impl Output2 {
+    impl Output {
         #[cfg(feature = "serde")]
         #[wasm_bindgen(js_name = toJSON)]
         pub fn to_json(&self) -> String {
@@ -288,16 +288,16 @@ pub mod typescript {
         }
 
         #[wasm_bindgen]
-        pub fn from_bytes(output: &[u8]) -> Option<Output2> {
+        pub fn from_bytes(output: &[u8]) -> Option<Output> {
             use fuel_types::canonical::Deserialize;
             crate::Output::from_bytes(output)
-                .map(|v| Output2(Box::new(v)))
+                .map(|v| Output(Box::new(v)))
                 .ok()
         }
 
         #[wasm_bindgen]
-        pub fn coin(to: Address, amount: Word, asset_id: AssetId) -> Output2 {
-            Output2(Box::new(crate::Output::coin(to, amount, asset_id)))
+        pub fn coin(to: Address, amount: Word, asset_id: AssetId) -> Output {
+            Output(Box::new(crate::Output::coin(to, amount, asset_id)))
         }
 
         #[wasm_bindgen]
@@ -305,8 +305,8 @@ pub mod typescript {
             input_index: u8,
             balance_root: Bytes32,
             state_root: Bytes32,
-        ) -> Output2 {
-            Output2(Box::new(crate::Output::contract(
+        ) -> Output {
+            Output(Box::new(crate::Output::contract(
                 input_index,
                 balance_root,
                 state_root,
@@ -314,18 +314,18 @@ pub mod typescript {
         }
 
         #[wasm_bindgen]
-        pub fn change(to: Address, amount: Word, asset_id: AssetId) -> Output2 {
-            Output2(Box::new(crate::Output::change(to, amount, asset_id)))
+        pub fn change(to: Address, amount: Word, asset_id: AssetId) -> Output {
+            Output(Box::new(crate::Output::change(to, amount, asset_id)))
         }
 
         #[wasm_bindgen]
-        pub fn variable(to: Address, amount: Word, asset_id: AssetId) -> Output2 {
-            Output2(Box::new(crate::Output::variable(to, amount, asset_id)))
+        pub fn variable(to: Address, amount: Word, asset_id: AssetId) -> Output {
+            Output(Box::new(crate::Output::variable(to, amount, asset_id)))
         }
 
         #[wasm_bindgen]
-        pub fn contract_created(contract_id: ContractId, state_root: Bytes32) -> Output2 {
-            Output2(Box::new(crate::Output::contract_created(
+        pub fn contract_created(contract_id: ContractId, state_root: Bytes32) -> Output {
+            Output(Box::new(crate::Output::contract_created(
                 contract_id,
                 state_root,
             )))

--- a/fuel-tx/src/transaction/types/output.rs
+++ b/fuel-tx/src/transaction/types/output.rs
@@ -245,6 +245,8 @@ impl Output {
 
 #[cfg(feature = "typescript")]
 pub mod typescript {
+    use wasm_bindgen::prelude::*;
+
     use super::*;
 
     use fuel_types::{
@@ -256,64 +258,77 @@ pub mod typescript {
 
     use alloc::{
         boxed::Box,
+        format,
+        string::String,
         vec::Vec,
     };
 
     #[derive(Clone, Eq, Hash, PartialEq)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[wasm_bindgen::prelude::wasm_bindgen]
+    #[wasm_bindgen]
     pub struct Output2(#[wasm_bindgen(skip)] pub Box<crate::Output>);
 
-    #[wasm_bindgen::prelude::wasm_bindgen]
-    pub fn output_to_bytes(input: &Output2) -> Vec<u8> {
-        use fuel_types::canonical::Serialize;
-        input.0.to_bytes()
-    }
+    #[wasm_bindgen]
+    impl Output2 {
+        #[cfg(feature = "serde")]
+        #[wasm_bindgen(js_name = toJSON)]
+        pub fn to_json(&self) -> String {
+            serde_json::to_string(&self.0).expect("unable to json format")
+        }
 
-    #[wasm_bindgen::prelude::wasm_bindgen]
-    pub fn output_from_bytes(input: &[u8]) -> Option<Output2> {
-        use fuel_types::canonical::Deserialize;
-        crate::Output::from_bytes(input)
-            .map(|v| Output2(Box::new(v)))
-            .ok()
-    }
+        #[wasm_bindgen(js_name = toString)]
+        pub fn to_string(&self) -> String {
+            format!("{:?}", self.0)
+        }
 
-    #[wasm_bindgen::prelude::wasm_bindgen]
-    pub fn output_coin(to: Address, amount: Word, asset_id: AssetId) -> Output2 {
-        Output2(Box::new(crate::Output::coin(to, amount, asset_id)))
-    }
+        #[wasm_bindgen]
+        pub fn to_bytes(&self) -> Vec<u8> {
+            use fuel_types::canonical::Serialize;
+            self.0.to_bytes()
+        }
 
-    #[wasm_bindgen::prelude::wasm_bindgen]
-    pub fn output_contract(
-        input_index: u8,
-        balance_root: Bytes32,
-        state_root: Bytes32,
-    ) -> Output2 {
-        Output2(Box::new(crate::Output::contract(
-            input_index,
-            balance_root,
-            state_root,
-        )))
-    }
+        #[wasm_bindgen]
+        pub fn from_bytes(output: &[u8]) -> Option<Output2> {
+            use fuel_types::canonical::Deserialize;
+            crate::Output::from_bytes(output)
+                .map(|v| Output2(Box::new(v)))
+                .ok()
+        }
 
-    #[wasm_bindgen::prelude::wasm_bindgen]
-    pub fn output_change(to: Address, amount: Word, asset_id: AssetId) -> Output2 {
-        Output2(Box::new(crate::Output::change(to, amount, asset_id)))
-    }
+        #[wasm_bindgen]
+        pub fn coin(to: Address, amount: Word, asset_id: AssetId) -> Output2 {
+            Output2(Box::new(crate::Output::coin(to, amount, asset_id)))
+        }
 
-    #[wasm_bindgen::prelude::wasm_bindgen]
-    pub fn output_variable(to: Address, amount: Word, asset_id: AssetId) -> Output2 {
-        Output2(Box::new(crate::Output::variable(to, amount, asset_id)))
-    }
+        #[wasm_bindgen]
+        pub fn contract(
+            input_index: u8,
+            balance_root: Bytes32,
+            state_root: Bytes32,
+        ) -> Output2 {
+            Output2(Box::new(crate::Output::contract(
+                input_index,
+                balance_root,
+                state_root,
+            )))
+        }
 
-    #[wasm_bindgen::prelude::wasm_bindgen]
-    pub fn output_contract_created(
-        contract_id: ContractId,
-        state_root: Bytes32,
-    ) -> Output2 {
-        Output2(Box::new(crate::Output::contract_created(
-            contract_id,
-            state_root,
-        )))
+        #[wasm_bindgen]
+        pub fn change(to: Address, amount: Word, asset_id: AssetId) -> Output2 {
+            Output2(Box::new(crate::Output::change(to, amount, asset_id)))
+        }
+
+        #[wasm_bindgen]
+        pub fn variable(to: Address, amount: Word, asset_id: AssetId) -> Output2 {
+            Output2(Box::new(crate::Output::variable(to, amount, asset_id)))
+        }
+
+        #[wasm_bindgen]
+        pub fn contract_created(contract_id: ContractId, state_root: Bytes32) -> Output2 {
+            Output2(Box::new(crate::Output::contract_created(
+                contract_id,
+                state_root,
+            )))
+        }
     }
 }

--- a/fuel-tx/src/transaction/types/output/contract.rs
+++ b/fuel-tx/src/transaction/types/output/contract.rs
@@ -8,6 +8,7 @@ use fuel_types::Bytes32;
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
+#[cfg_attr(feature = "typescript", wasm_bindgen::prelude::wasm_bindgen(js_name = OutputContract))]
 pub struct Contract {
     /// Index of input contract.
     pub input_index: u8,
@@ -42,6 +43,31 @@ impl Distribution<Contract> for Standard {
             input_index: rng.gen(),
             balance_root: rng.gen(),
             state_root: rng.gen(),
+        }
+    }
+}
+
+#[cfg(feature = "typescript")]
+pub mod typescript {
+    use wasm_bindgen::prelude::*;
+
+    use super::*;
+
+    use fuel_types::Bytes32;
+
+    #[wasm_bindgen(js_class = OutputContract)]
+    impl Contract {
+        #[wasm_bindgen(constructor)]
+        pub fn typescript_new(
+            input_index: u8,
+            balance_root: Bytes32,
+            state_root: Bytes32,
+        ) -> Self {
+            Self {
+                input_index,
+                balance_root,
+                state_root,
+            }
         }
     }
 }

--- a/fuel-tx/src/transaction/types/script.rs
+++ b/fuel-tx/src/transaction/types/script.rs
@@ -53,6 +53,7 @@ pub(crate) struct ScriptMetadata {
 
 #[derive(Clone, Derivative)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "typescript", wasm_bindgen::prelude::wasm_bindgen)]
 #[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
 #[canonical(prefix = TransactionRepr::Script)]
 #[derivative(Eq, PartialEq, Hash, Debug)]

--- a/fuel-tx/src/transaction/types/storage.rs
+++ b/fuel-tx/src/transaction/types/storage.rs
@@ -20,6 +20,7 @@ use core::cmp::Ordering;
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "typescript", wasm_bindgen::prelude::wasm_bindgen)]
 #[derive(Deserialize, Serialize)]
 pub struct StorageSlot {
     key: Bytes32,

--- a/fuel-tx/src/transaction/types/utxo_id.rs
+++ b/fuel-tx/src/transaction/types/utxo_id.rs
@@ -18,6 +18,7 @@ use rand::{
 
 /// Identification of unspend transaction output.
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "typescript", wasm_bindgen::prelude::wasm_bindgen)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
 pub struct UtxoId {

--- a/fuel-tx/src/transaction/types/utxo_id.rs
+++ b/fuel-tx/src/transaction/types/utxo_id.rs
@@ -144,16 +144,16 @@ pub mod typescript {
             format!("{:#x}", self)
         }
 
-        #[wasm_bindgen]
-        pub fn to_bytes(&self) -> Vec<u8> {
+        #[wasm_bindgen(js_name = to_bytes)]
+        pub fn typescript_to_bytes(&self) -> Vec<u8> {
             use fuel_types::canonical::Serialize;
             <Self as Serialize>::to_bytes(self)
         }
 
-        #[wasm_bindgen]
-        pub fn from_bytes(utxo_id: &[u8]) -> Option<UtxoId> {
+        #[wasm_bindgen(js_name = from_bytes)]
+        pub fn typescript_from_bytes(value: &[u8]) -> Option<UtxoId> {
             use fuel_types::canonical::Deserialize;
-            <Self as Deserialize>::from_bytes(utxo_id).ok()
+            <Self as Deserialize>::from_bytes(value).ok()
         }
     }
 }

--- a/fuel-tx/src/transaction/types/utxo_id.rs
+++ b/fuel-tx/src/transaction/types/utxo_id.rs
@@ -139,8 +139,8 @@ pub mod typescript {
             UtxoId::from_str(value).map_err(js_sys::Error::new)
         }
 
-        #[wasm_bindgen]
-        pub fn to_string(&self) -> String {
+        #[wasm_bindgen(js_name = toString)]
+        pub fn typescript_to_string(&self) -> String {
             format!("{:#x}", self)
         }
 

--- a/fuel-tx/src/transaction/types/utxo_id.rs
+++ b/fuel-tx/src/transaction/types/utxo_id.rs
@@ -119,6 +119,42 @@ impl str::FromStr for UtxoId {
     }
 }
 
+#[cfg(feature = "typescript")]
+pub mod typescript {
+    use super::*;
+
+    use wasm_bindgen::prelude::*;
+
+    use alloc::{format, vec::Vec, string::String};
+
+    #[wasm_bindgen]
+    impl UtxoId {
+        #[wasm_bindgen(constructor)]
+        pub fn typescript_new(value: &str) -> Result<UtxoId, js_sys::Error> {
+            use core::str::FromStr;
+            UtxoId::from_str(value).map_err(js_sys::Error::new)
+        }
+
+        #[wasm_bindgen]
+        pub fn to_string(&self) -> String {
+            format!("{:#x}", self)
+        }
+
+        #[wasm_bindgen]
+        pub fn to_bytes(&self) -> Vec<u8> {
+            use fuel_types::canonical::Serialize;
+            <Self as Serialize>::to_bytes(self)
+        }
+
+        #[wasm_bindgen]
+        pub fn from_bytes(utxo_id: &[u8]) -> Option<UtxoId> {
+            use fuel_types::canonical::Deserialize;
+            <Self as Deserialize>::from_bytes(utxo_id)
+                .ok()
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/fuel-tx/src/transaction/types/utxo_id.rs
+++ b/fuel-tx/src/transaction/types/utxo_id.rs
@@ -151,9 +151,11 @@ pub mod typescript {
         }
 
         #[wasm_bindgen(js_name = from_bytes)]
-        pub fn typescript_from_bytes(value: &[u8]) -> Option<UtxoId> {
+        pub fn typescript_from_bytes(value: &[u8]) -> Result<UtxoId, js_sys::Error> {
             use fuel_types::canonical::Deserialize;
-            <Self as Deserialize>::from_bytes(value).ok()
+
+            <Self as Deserialize>::from_bytes(value)
+                .map_err(|e| js_sys::Error::new(&format!("{:?}", e)))
         }
     }
 }

--- a/fuel-tx/src/transaction/types/utxo_id.rs
+++ b/fuel-tx/src/transaction/types/utxo_id.rs
@@ -125,7 +125,11 @@ pub mod typescript {
 
     use wasm_bindgen::prelude::*;
 
-    use alloc::{format, vec::Vec, string::String};
+    use alloc::{
+        format,
+        string::String,
+        vec::Vec,
+    };
 
     #[wasm_bindgen]
     impl UtxoId {
@@ -149,8 +153,7 @@ pub mod typescript {
         #[wasm_bindgen]
         pub fn from_bytes(utxo_id: &[u8]) -> Option<UtxoId> {
             use fuel_types::canonical::Deserialize;
-            <Self as Deserialize>::from_bytes(utxo_id)
-                .ok()
+            <Self as Deserialize>::from_bytes(utxo_id).ok()
         }
     }
 }

--- a/fuel-tx/src/transaction/types/witness.rs
+++ b/fuel-tx/src/transaction/types/witness.rs
@@ -24,6 +24,7 @@ use rand::{
 
 #[derive(Derivative, Default, Clone, PartialEq, Eq, Hash)]
 #[derivative(Debug)]
+#[cfg_attr(feature = "typescript", wasm_bindgen::prelude::wasm_bindgen)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
 pub struct Witness {

--- a/fuel-tx/src/transaction/types/witness.rs
+++ b/fuel-tx/src/transaction/types/witness.rs
@@ -105,3 +105,37 @@ impl Distribution<Witness> for Standard {
         data.into()
     }
 }
+
+#[cfg(feature = "typescript")]
+pub mod typescript {
+    use wasm_bindgen::prelude::*;
+
+    use super::Witness;
+
+    #[wasm_bindgen]
+    impl Witness {
+        #[cfg(feature = "serde")]
+        #[wasm_bindgen(js_name = toJSON)]
+        pub fn to_json(&self) -> String {
+            serde_json::to_string(&self.data).expect("unable to json format")
+        }
+
+        #[wasm_bindgen(js_name = toString)]
+        pub fn typescript_to_string(&self) -> String {
+            format!("{:?}", self.data)
+        }
+
+        #[wasm_bindgen(js_name = to_bytes)]
+        pub fn typescript_to_bytes(&self) -> Vec<u8> {
+            use fuel_types::canonical::Serialize;
+            self.to_bytes()
+        }
+
+        #[wasm_bindgen(js_name = from_bytes)]
+        pub fn typescript_from_bytes(value: &[u8]) -> Option<Witness> {
+            use fuel_types::canonical::Deserialize;
+            <Self as Deserialize>::from_bytes(value)
+                .ok()
+        }
+    }
+}

--- a/fuel-tx/src/transaction/types/witness.rs
+++ b/fuel-tx/src/transaction/types/witness.rs
@@ -24,7 +24,7 @@ use rand::{
 
 #[derive(Derivative, Default, Clone, PartialEq, Eq, Hash)]
 #[derivative(Debug)]
-#[cfg_attr(feature = "typescript", wasm_bindgen::prelude::wasm_bindgen)]
+// #[cfg_attr(feature = "typescript", wasm_bindgen::prelude::wasm_bindgen)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
 pub struct Witness {

--- a/fuel-tx/src/transaction/types/witness.rs
+++ b/fuel-tx/src/transaction/types/witness.rs
@@ -24,7 +24,7 @@ use rand::{
 
 #[derive(Derivative, Default, Clone, PartialEq, Eq, Hash)]
 #[derivative(Debug)]
-// #[cfg_attr(feature = "typescript", wasm_bindgen::prelude::wasm_bindgen)]
+#[cfg_attr(feature = "typescript", wasm_bindgen::prelude::wasm_bindgen)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
 pub struct Witness {

--- a/fuel-tx/src/transaction/types/witness.rs
+++ b/fuel-tx/src/transaction/types/witness.rs
@@ -112,6 +112,12 @@ pub mod typescript {
 
     use super::Witness;
 
+    use alloc::{
+        format,
+        string::String,
+        vec::Vec,
+    };
+
     #[wasm_bindgen]
     impl Witness {
         #[cfg(feature = "serde")]
@@ -134,8 +140,7 @@ pub mod typescript {
         #[wasm_bindgen(js_name = from_bytes)]
         pub fn typescript_from_bytes(value: &[u8]) -> Option<Witness> {
             use fuel_types::canonical::Deserialize;
-            <Self as Deserialize>::from_bytes(value)
-                .ok()
+            <Self as Deserialize>::from_bytes(value).ok()
         }
     }
 }

--- a/fuel-tx/src/transaction/types/witness.rs
+++ b/fuel-tx/src/transaction/types/witness.rs
@@ -138,9 +138,11 @@ pub mod typescript {
         }
 
         #[wasm_bindgen(js_name = from_bytes)]
-        pub fn typescript_from_bytes(value: &[u8]) -> Option<Witness> {
+        pub fn typescript_from_bytes(value: &[u8]) -> Result<Witness, js_sys::Error> {
+            use alloc::string::ToString;
             use fuel_types::canonical::Deserialize;
-            <Self as Deserialize>::from_bytes(value).ok()
+            <Self as Deserialize>::from_bytes(value)
+                .map_err(|e| js_sys::Error::new(&e.to_string()))
         }
     }
 }

--- a/fuel-tx/src/transaction/validity.rs
+++ b/fuel-tx/src/transaction/validity.rs
@@ -526,17 +526,18 @@ mod typescript {
         outputs: Vec<JsValue>,
         witnesses: Vec<JsValue>,
         predicate_params: &PredicateParameters,
-        // recovery_cache: &mut Option<HashMap<u8, Address>>,
-    ) -> Result<(), JsValue /* ValidityError */> {
+    ) -> Result<(), js_sys::Error> {
         let outputs: Vec<crate::Output> = outputs
             .into_iter()
             .map(|v| serde_wasm_bindgen::from_value::<Output>(v).map(|v| *v.0))
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|err| js_sys::Error::new(&err.to_string()))?;
 
         let witnesses: Vec<Witness> = witnesses
             .into_iter()
             .map(serde_wasm_bindgen::from_value::<Witness>)
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|err| js_sys::Error::new(&err.to_string()))?;
 
         input
             .0
@@ -548,10 +549,7 @@ mod typescript {
                 predicate_params,
                 &mut None,
             )
-            .map_err(|err| {
-                serde_wasm_bindgen::to_value(&err)
-                    .expect("Unable to serialize ValidityError")
-            })
+            .map_err(|err| js_sys::Error::new(&err.to_string()))
     }
 
     #[wasm_bindgen::prelude::wasm_bindgen]
@@ -559,14 +557,16 @@ mod typescript {
         output: &Output,
         index: usize,
         inputs: Vec<JsValue>,
-    ) -> Result<(), JsValue /* ValidityError */> {
+    ) -> Result<(), js_sys::Error> {
         let inputs: Vec<crate::Input> = inputs
             .into_iter()
             .map(|v| serde_wasm_bindgen::from_value::<Input>(v).map(|v| *v.0))
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|err| js_sys::Error::new(&err.to_string()))?;
 
-        output.0.check(index, &inputs).map_err(|err| {
-            serde_wasm_bindgen::to_value(&err).expect("Unable to serialize ValidityError")
-        })
+        output
+            .0
+            .check(index, &inputs)
+            .map_err(|err| js_sys::Error::new(&err.to_string()))
     }
 }

--- a/fuel-tx/src/transaction/validity.rs
+++ b/fuel-tx/src/transaction/validity.rs
@@ -59,7 +59,7 @@ impl Input {
         recovery_cache: &mut Option<HashMap<u8, Address>>,
     ) -> Result<(), ValidityError> {
         self.check_without_signature(index, outputs, witnesses, predicate_params)?;
-        // self.check_signature(index, txhash, witnesses, recovery_cache)?;
+        self.check_signature(index, txhash, witnesses, recovery_cache)?;
 
         Ok(())
     }
@@ -508,70 +508,65 @@ mod typescript {
         PredicateParameters,
         Witness,
     };
-    use fuel_types::{Bytes32, canonical::Deserialize};
+    use fuel_types::Bytes32;
     use wasm_bindgen::JsValue;
 
-    use alloc::{
-        boxed::Box,
-        vec::Vec,
+    use alloc::vec::Vec;
+
+    use crate::transaction::{
+        input_ts::Input2,
+        output_ts::Output2,
     };
 
-    #[derive(Clone, Eq, Hash, PartialEq)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[wasm_bindgen::prelude::wasm_bindgen]
-    pub struct Input2(Box<crate::Input>);
+    pub fn check_input(
+        input: &Input2,
+        index: usize,
+        txhash: &Bytes32,
+        outputs: Vec<JsValue>,
+        witnesses: Vec<JsValue>,
+        predicate_params: &PredicateParameters,
+        // recovery_cache: &mut Option<HashMap<u8, Address>>,
+    ) -> Result<(), JsValue /* ValidityError */> {
+        let outputs: Vec<crate::Output> = outputs
+            .into_iter()
+            .map(|v| serde_wasm_bindgen::from_value::<Output2>(v).map(|v| *v.0))
+            .collect::<Result<Vec<_>, _>>()?;
 
-    #[wasm_bindgen::prelude::wasm_bindgen]
-    pub fn input_to_bytes(input: &Input2) -> Vec<u8> {
-        use fuel_types::canonical::Serialize;
-        input.0.to_bytes()
+        let witnesses: Vec<Witness> = witnesses
+            .into_iter()
+            .map(serde_wasm_bindgen::from_value::<Witness>)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        input
+            .0
+            .check(
+                index,
+                txhash,
+                &outputs,
+                &witnesses,
+                predicate_params,
+                &mut None,
+            )
+            .map_err(|err| {
+                serde_wasm_bindgen::to_value(&err)
+                    .expect("Unable to serialize ValidityError")
+            })
     }
 
     #[wasm_bindgen::prelude::wasm_bindgen]
-    pub fn input_from_bytes(input: &[u8]) -> Option<Input2> {
-        use fuel_types::canonical::Deserialize;
-        crate::Input::from_bytes(&input).map(|v| Input2(Box::new(v))).ok()
+    pub fn check_output(
+        output: &Output2,
+        index: usize,
+        inputs: Vec<JsValue>,
+    ) -> Result<(), JsValue /* ValidityError */> {
+        let inputs: Vec<crate::Input> = inputs
+            .into_iter()
+            .map(|v| serde_wasm_bindgen::from_value::<Input2>(v).map(|v| *v.0))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        output.0.check(index, &inputs).map_err(|err| {
+            serde_wasm_bindgen::to_value(&err).expect("Unable to serialize ValidityError")
+        })
     }
-
-
-    // #[derive(Clone, Eq, Hash, PartialEq)]
-    // #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    // #[wasm_bindgen::prelude::wasm_bindgen]
-    // pub struct Output2(Box<crate::Output>);
-
-    // #[wasm_bindgen::prelude::wasm_bindgen]
-    // pub fn check_input(
-    //     input: &Input2,
-    //     index: usize,
-    //     txhash: &Bytes32,
-    //     outputs: Vec<JsValue>,
-    //     witnesses: Vec<JsValue>,
-    //     predicate_params: &PredicateParameters,
-    //     // recovery_cache: &mut Option<HashMap<u8, Address>>,
-    // ) -> Result<(), JsValue /* ValidityError */> {
-    //     let outputs: Vec<crate::Output> = outputs
-    //         .into_iter()
-    //         .map(|v| serde_wasm_bindgen::from_value::<Output2>(v).map(|v| *v.0))
-    //         .collect::<Result<Vec<_>, _>>()?;
-
-    //     let witnesses: Vec<Witness> = witnesses
-    //         .into_iter()
-    //         .map(serde_wasm_bindgen::from_value::<Witness>)
-    //         .collect::<Result<Vec<_>, _>>()?;
-
-    //     input
-    //         .0
-    //         .check(
-    //             index,
-    //             txhash,
-    //             &outputs,
-    //             &witnesses,
-    //             predicate_params,
-    //             &mut None,
-    //         )
-    //         .map_err(|err| {
-    //             serde_wasm_bindgen::to_value(&err)
-    //                 .expect("Unable to serialize ValidityError")
-    //         })
-    // }
 }

--- a/fuel-tx/src/transaction/validity.rs
+++ b/fuel-tx/src/transaction/validity.rs
@@ -514,13 +514,13 @@ mod typescript {
     use alloc::vec::Vec;
 
     use crate::transaction::{
-        input_ts::Input2,
-        output_ts::Output2,
+        input_ts::Input,
+        output_ts::Output,
     };
 
     #[wasm_bindgen::prelude::wasm_bindgen]
     pub fn check_input(
-        input: &Input2,
+        input: &Input,
         index: usize,
         txhash: &Bytes32,
         outputs: Vec<JsValue>,
@@ -530,7 +530,7 @@ mod typescript {
     ) -> Result<(), JsValue /* ValidityError */> {
         let outputs: Vec<crate::Output> = outputs
             .into_iter()
-            .map(|v| serde_wasm_bindgen::from_value::<Output2>(v).map(|v| *v.0))
+            .map(|v| serde_wasm_bindgen::from_value::<Output>(v).map(|v| *v.0))
             .collect::<Result<Vec<_>, _>>()?;
 
         let witnesses: Vec<Witness> = witnesses
@@ -556,13 +556,13 @@ mod typescript {
 
     #[wasm_bindgen::prelude::wasm_bindgen]
     pub fn check_output(
-        output: &Output2,
+        output: &Output,
         index: usize,
         inputs: Vec<JsValue>,
     ) -> Result<(), JsValue /* ValidityError */> {
         let inputs: Vec<crate::Input> = inputs
             .into_iter()
-            .map(|v| serde_wasm_bindgen::from_value::<Input2>(v).map(|v| *v.0))
+            .map(|v| serde_wasm_bindgen::from_value::<Input>(v).map(|v| *v.0))
             .collect::<Result<Vec<_>, _>>()?;
 
         output.0.check(index, &inputs).map_err(|err| {

--- a/fuel-tx/src/transaction/validity.rs
+++ b/fuel-tx/src/transaction/validity.rs
@@ -511,7 +511,10 @@ mod typescript {
     use fuel_types::Bytes32;
     use wasm_bindgen::JsValue;
 
-    use alloc::vec::Vec;
+    use alloc::{
+        format,
+        vec::Vec,
+    };
 
     use crate::transaction::{
         input_ts::Input,
@@ -531,13 +534,13 @@ mod typescript {
             .into_iter()
             .map(|v| serde_wasm_bindgen::from_value::<Output>(v).map(|v| *v.0))
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|err| js_sys::Error::new(&err.to_string()))?;
+            .map_err(|e| js_sys::Error::new(&format!("{:?}", e)))?;
 
         let witnesses: Vec<Witness> = witnesses
             .into_iter()
             .map(serde_wasm_bindgen::from_value::<Witness>)
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|err| js_sys::Error::new(&err.to_string()))?;
+            .map_err(|e| js_sys::Error::new(&format!("{:?}", e)))?;
 
         input
             .0
@@ -549,7 +552,7 @@ mod typescript {
                 predicate_params,
                 &mut None,
             )
-            .map_err(|err| js_sys::Error::new(&err.to_string()))
+            .map_err(|e| js_sys::Error::new(&format!("{:?}", e)))
     }
 
     #[wasm_bindgen::prelude::wasm_bindgen]
@@ -562,11 +565,11 @@ mod typescript {
             .into_iter()
             .map(|v| serde_wasm_bindgen::from_value::<Input>(v).map(|v| *v.0))
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|err| js_sys::Error::new(&err.to_string()))?;
+            .map_err(|e| js_sys::Error::new(&format!("{:?}", e)))?;
 
         output
             .0
             .check(index, &inputs)
-            .map_err(|err| js_sys::Error::new(&err.to_string()))
+            .map_err(|e| js_sys::Error::new(&format!("{:?}", e)))
     }
 }

--- a/fuel-tx/src/tx_pointer.rs
+++ b/fuel-tx/src/tx_pointer.rs
@@ -132,9 +132,10 @@ pub mod typescript {
         }
 
         #[wasm_bindgen(js_name = from_bytes)]
-        pub fn typescript_from_bytes(value: &[u8]) -> Option<TxPointer> {
+        pub fn typescript_from_bytes(value: &[u8]) -> Result<TxPointer, js_sys::Error> {
             use fuel_types::canonical::Deserialize;
-            <Self as Deserialize>::from_bytes(value).ok()
+            <Self as Deserialize>::from_bytes(value)
+                .map_err(|e| js_sys::Error::new(&format!("{:?}", e)))
         }
     }
 }

--- a/fuel-tx/src/tx_pointer.rs
+++ b/fuel-tx/src/tx_pointer.rs
@@ -120,8 +120,8 @@ pub mod typescript {
             TxPointer::from_str(value).map_err(js_sys::Error::new)
         }
 
-        #[wasm_bindgen]
-        pub fn to_string(&self) -> String {
+        #[wasm_bindgen(js_name = to_string)]
+        pub fn typescript_to_string(&self) -> String {
             format!("{:#x}", self)
         }
 

--- a/fuel-tx/src/tx_pointer.rs
+++ b/fuel-tx/src/tx_pointer.rs
@@ -24,6 +24,7 @@ use rand::{
 
 /// Identification of unspend transaction output.
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "typescript", wasm_bindgen::prelude::wasm_bindgen)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Deserialize, Serialize)]
 pub struct TxPointer {

--- a/fuel-tx/src/tx_pointer.rs
+++ b/fuel-tx/src/tx_pointer.rs
@@ -120,7 +120,7 @@ pub mod typescript {
             TxPointer::from_str(value).map_err(js_sys::Error::new)
         }
 
-        #[wasm_bindgen(js_name = to_string)]
+        #[wasm_bindgen(js_name = toString)]
         pub fn typescript_to_string(&self) -> String {
             format!("{:#x}", self)
         }

--- a/fuel-tx/src/tx_pointer.rs
+++ b/fuel-tx/src/tx_pointer.rs
@@ -100,6 +100,45 @@ impl str::FromStr for TxPointer {
     }
 }
 
+#[cfg(feature = "typescript")]
+pub mod typescript {
+    use super::*;
+
+    use wasm_bindgen::prelude::*;
+
+    use alloc::{
+        format,
+        string::String,
+        vec::Vec,
+    };
+
+    #[wasm_bindgen]
+    impl TxPointer {
+        #[wasm_bindgen(constructor)]
+        pub fn typescript_new(value: &str) -> Result<TxPointer, js_sys::Error> {
+            use core::str::FromStr;
+            TxPointer::from_str(value).map_err(js_sys::Error::new)
+        }
+
+        #[wasm_bindgen]
+        pub fn to_string(&self) -> String {
+            format!("{:#x}", self)
+        }
+
+        #[wasm_bindgen]
+        pub fn to_bytes(&self) -> Vec<u8> {
+            use fuel_types::canonical::Serialize;
+            <Self as Serialize>::to_bytes(self)
+        }
+
+        #[wasm_bindgen]
+        pub fn from_bytes(utxo_id: &[u8]) -> Option<TxPointer> {
+            use fuel_types::canonical::Deserialize;
+            <Self as Deserialize>::from_bytes(utxo_id).ok()
+        }
+    }
+}
+
 #[test]
 fn fmt_encode_decode() {
     use core::str::FromStr;

--- a/fuel-tx/src/tx_pointer.rs
+++ b/fuel-tx/src/tx_pointer.rs
@@ -125,16 +125,16 @@ pub mod typescript {
             format!("{:#x}", self)
         }
 
-        #[wasm_bindgen]
-        pub fn to_bytes(&self) -> Vec<u8> {
+        #[wasm_bindgen(js_name = to_bytes)]
+        pub fn typescript_to_bytes(&self) -> Vec<u8> {
             use fuel_types::canonical::Serialize;
             <Self as Serialize>::to_bytes(self)
         }
 
-        #[wasm_bindgen]
-        pub fn from_bytes(utxo_id: &[u8]) -> Option<TxPointer> {
+        #[wasm_bindgen(js_name = from_bytes)]
+        pub fn typescript_from_bytes(value: &[u8]) -> Option<TxPointer> {
             use fuel_types::canonical::Deserialize;
-            <Self as Deserialize>::from_bytes(utxo_id).ok()
+            <Self as Deserialize>::from_bytes(value).ok()
         }
     }
 }

--- a/fuel-types/Cargo.toml
+++ b/fuel-types/Cargo.toml
@@ -15,7 +15,7 @@ fuel-derive = { workspace = true }
 hex = { version = "0.4", default-features = false, optional = true }
 rand = { version = "0.8", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
-wasm-bindgen = { version = "0.2.87", optional = true }
+wasm-bindgen = { version = "0.2.88", optional = true }
 
 [dev-dependencies]
 bincode = { workspace = true }

--- a/fuel-types/src/array_types.rs
+++ b/fuel-types/src/array_types.rs
@@ -24,6 +24,9 @@ use rand::{
     Rng,
 };
 
+#[cfg(feature = "alloc")]
+use alloc::format;
+
 use crate::hex_val;
 
 macro_rules! key {

--- a/fuel-types/src/array_types.rs
+++ b/fuel-types/src/array_types.rs
@@ -24,7 +24,7 @@ use rand::{
     Rng,
 };
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", feature = "typescript"))]
 use alloc::format;
 
 use crate::hex_val;

--- a/fuel-types/src/numeric_types.rs
+++ b/fuel-types/src/numeric_types.rs
@@ -22,6 +22,9 @@ use rand::{
     Rng,
 };
 
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
 use crate::hex_val;
 
 macro_rules! key {

--- a/fuel-types/src/numeric_types.rs
+++ b/fuel-types/src/numeric_types.rs
@@ -22,7 +22,7 @@ use rand::{
     Rng,
 };
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", feature = "typescript"))]
 use alloc::vec::Vec;
 
 use crate::hex_val;


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuel-vm/issues/579

I'm not sure if we need to add serialization and deserialization support to more types, but this should at least provide a good starting point. 

Also, this is still missing some datastructure manipulation, for instance you cannot modify `Policies` easily.
