### PR TITLE
Omit extra byte from types like AssetId when serialized with postcard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 #### Breaking
 
 - [#654](https://github.com/FuelLabs/fuel-vm/pull/654): Make public types versionable by making non-exhaustive.
+- [#658](https://github.com/FuelLabs/fuel-vm/pull/658): Make `key!`-generated types like `Address`, `AssetId`, `ContractId` and `Bytes32` consume one less byte when serialized with a binary serde serializer like postcard.
 
 ## [Version 0.43.2]
 


### PR DESCRIPTION
For some reason unknown to me, types generated using the `key!` macro were including an extra length byte in front of them when serialized in serde binary formats. This PR removes the leading byte. (The reason was me, although I'm going to blame serde docs here).