### PR TITLE
Relese 0.45.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Version 0.45.0]
 
+### Changed
 #### Breaking
 
 - [#668](https://github.com/FuelLabs/fuel-vm/pull/668): Remove `non_exhaustive` from versionable types for security reasons

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.45.0]
+
 #### Breaking
 
 - [#668](https://github.com/FuelLabs/fuel-vm/pull/668): Remove `non_exhaustive` from versionable types for security reasons

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,17 +18,17 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.44.0"
+version = "0.45.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.44.0", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.44.0", path = "fuel-crypto", default-features = false }
-fuel-derive = { version = "0.44.0", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.44.0", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.44.0", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.44.0", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.44.0", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.44.0", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.45.0", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.45.0", path = "fuel-crypto", default-features = false }
+fuel-derive = { version = "0.45.0", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.45.0", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.45.0", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.45.0", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.45.0", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.45.0", path = "fuel-vm", default-features = false }
 bitflags = "2"
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
## Version v0.45.0

### Changed

#### Breaking

- [#668](https://github.com/FuelLabs/fuel-vm/pull/668): Remove `non_exhaustive` from versionable types for security reasons

## What's Changed
* Remove non-exhaustive attribute for versionable types by @MitchTurner in https://github.com/FuelLabs/fuel-vm/pull/668


**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.44.0...v0.45.0