### PR TITLE
Update CI Rust version to 1.75

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.73.0
-  NIGHTLY_RUST_VERSION: nightly-2023-10-29
+  RUST_VERSION: 1.75.0
+  NIGHTLY_RUST_VERSION: nightly-2024-02-07
 
 jobs:
   check-changelog:


### PR DESCRIPTION
Upgrades the version of Rust used in CI to 1.75 to address a compiler error for `clap` during CI: `package clap v4.5.0 cannot be built because it requires rustc 1.74 or newer, while the currently active rustc version is 1.73.0`