### PR TITLE
Bump version to `v0.46.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.46.0]
+
 ### Changed
 #### Breaking
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,17 +18,17 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.45.0"
+version = "0.46.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.45.0", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.45.0", path = "fuel-crypto", default-features = false }
-fuel-derive = { version = "0.45.0", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.45.0", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.45.0", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.45.0", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.45.0", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.45.0", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.46.0", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.46.0", path = "fuel-crypto", default-features = false }
+fuel-derive = { version = "0.46.0", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.46.0", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.46.0", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.46.0", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.46.0", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.46.0", path = "fuel-vm", default-features = false }
 bitflags = "2"
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
## Version v0.46.0

### Changed
#### Breaking

- [#679](https://github.com/FuelLabs/fuel-vm/pull/679): Require less restricted constraint on `MerkleRootStorage` trait. Now it requires `StorageInspect` instead of the `StorageMutate`.
- [#1632](https://github.com/FuelLabs/fuel-core/pull/1632): Removed `ContractsInfo` table. Contract salts and roots are no longer stored in on-chain data.
- [#1632](https://github.com/FuelLabs/fuel-core/pull/1632): Opcode `CROO` now calculates the given contract's root on demand. `CROO` has therefore been changed to a `DependentCost` gas cost.

## What's Changed
* Update CI Rust version to 1.75 by @bvrooman in https://github.com/FuelLabs/fuel-vm/pull/674
* feat: Remove ContractsInfo by @bvrooman in https://github.com/FuelLabs/fuel-vm/pull/673
* Add gasprice to mint tx by @MitchTurner in https://github.com/FuelLabs/fuel-vm/pull/676
* Require less restricted constraint on `MerkleRootStorage` trait by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/679


**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.45.0...v0.46.0