### PR TITLE
Release `0.47.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.47.0]
+
 ### Added
 
 - [#686](https://github.com/FuelLabs/fuel-vm/pull/686): Implement `serde` for `InterpreterError`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,17 +18,17 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.46.0"
+version = "0.47.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.46.0", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.46.0", path = "fuel-crypto", default-features = false }
-fuel-derive = { version = "0.46.0", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.46.0", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.46.0", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.46.0", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.46.0", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.46.0", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.47.0", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.47.0", path = "fuel-crypto", default-features = false }
+fuel-derive = { version = "0.47.0", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.47.0", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.47.0", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.47.0", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.47.0", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.47.0", path = "fuel-vm", default-features = false }
 bitflags = "2"
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
## Version v0.47.0

### Added

- [#686](https://github.com/FuelLabs/fuel-vm/pull/686): Implement `serde` for `InterpreterError`.

### Changed

#### Breaking

- [#685](https://github.com/FuelLabs/fuel-vm/pull/685):
  The `MaxFee` is a mandatory policy to set. The `MaxFee` policy is used to check that the transaction is valid. 
  Added a new stage for the `Checked` transaction - `Ready`. This type can be constructed with the 
  `gas_price` before being transacted by the `Interpreter`.
- [#671](https://github.com/FuelLabs/fuel-vm/pull/671): Support dynamically sized values in the ContractsState table by using a vector data type (`Vec<u8>`).
- [#682](https://github.com/FuelLabs/fuel-vm/pull/682): Include `Tip` policy in fee calculation
- [#683](https://github.com/FuelLabs/fuel-vm/pull/683): Simplify `InterpreterStorage` by removing dependency on `MerkleRootStorage` and removing `merkle_` prefix from method names.
- [#678](https://github.com/FuelLabs/fuel-vm/pull/678): Zero malleable fields before execution. Remove some now-obsolete GTF getters. Don't update `tx.receiptsRoot` after pushing receipts, and do it after execution instead.
- [#672](https://github.com/FuelLabs/fuel-vm/pull/672): Remove `GasPrice` policy
- [#672](https://github.com/FuelLabs/fuel-vm/pull/672): Add `gas_price` field to transaction execution
- [#684](https://github.com/FuelLabs/fuel-vm/pull/684): Remove `maturity` field from `Input` coin types. Also remove related `GTF` getter.
- [#675](https://github.com/FuelLabs/fuel-vm/pull/675): Add `GTF` access for `asset_id` and `to` fields for `Change` outputs.

## What's Changed
* Update fee calculation logic to accept price by @MitchTurner in https://github.com/FuelLabs/fuel-vm/pull/672
* chore: Simplify `InterpreterStorage` by @bvrooman in https://github.com/FuelLabs/fuel-vm/pull/683
* Remove maturity from input coin by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/684
* Zero malleable fields before execution by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/678
* Include tip in fee by @MitchTurner in https://github.com/FuelLabs/fuel-vm/pull/682
* feat: Use Vec of Bytes for Contract State by @bvrooman in https://github.com/FuelLabs/fuel-vm/pull/671
* Implement `serde` for `InterpreterError` by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/686
* Add access to {asset_id,to,amount} fields for Variable and Change outputs by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/675
* Use max fee policy to charge user by @MitchTurner in https://github.com/FuelLabs/fuel-vm/pull/685

**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.46.0...v0.47.0