### PR TITLE
Versioning of `ConsensusParameters` and `GasCosts`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 #### Breaking
 
+- [#701](https://github.com/FuelLabs/fuel-vm/pull/701): Wrapped `ConsensusParameters` and `GasCosts` into an enum to support versioning. Moved `block_gas_limit` from `fuel_core_chain_config::ChainConfig` to `ConsensusPataremeters`. Reduced default `MAX_SIZE` to be [110kb](https://github.com/FuelLabs/fuel-core/pull/1761) and `MAX_CONTRACT_SIZE` to be [100kb](https://github.com/FuelLabs/fuel-core/pull/1761).
 - [#692](https://github.com/FuelLabs/fuel-vm/pull/692): Add GTF getters for tx size and address.
 - [#698](https://github.com/FuelLabs/fuel-vm/pull/698): Store input, output and witness limits to u16, while keeping the values limited to 255.
 

--- a/fuel-tx/src/builder.rs
+++ b/fuel-tx/src/builder.rs
@@ -228,7 +228,7 @@ impl<Tx> TransactionBuilder<Tx> {
     }
 
     pub fn with_tx_params(&mut self, tx_params: TxParameters) -> &mut Self {
-        self.params.tx_params = tx_params;
+        self.params.set_tx_params(tx_params);
         self
     }
 
@@ -236,12 +236,12 @@ impl<Tx> TransactionBuilder<Tx> {
         &mut self,
         predicate_params: PredicateParameters,
     ) -> &mut Self {
-        self.params.predicate_params = predicate_params;
+        self.params.set_predicate_params(predicate_params);
         self
     }
 
     pub fn with_script_params(&mut self, script_params: ScriptParameters) -> &mut Self {
-        self.params.script_params = script_params;
+        self.params.set_script_params(script_params);
         self
     }
 
@@ -249,22 +249,32 @@ impl<Tx> TransactionBuilder<Tx> {
         &mut self,
         contract_params: ContractParameters,
     ) -> &mut Self {
-        self.params.contract_params = contract_params;
+        self.params.set_contract_params(contract_params);
         self
     }
 
     pub fn with_fee_params(&mut self, fee_params: FeeParameters) -> &mut Self {
-        self.params.fee_params = fee_params;
+        self.params.set_fee_params(fee_params);
         self
     }
 
-    pub fn with_base_asset_id(&mut self, base_asset_id: AssetId) -> &mut Self {
-        self.params.base_asset_id = base_asset_id;
+    pub fn with_chain_id(&mut self, chain_id: ChainId) -> &mut Self {
+        self.params.set_chain_id(chain_id);
         self
     }
 
     pub fn with_gas_costs(&mut self, gas_costs: GasCosts) -> &mut Self {
-        self.params.gas_costs = gas_costs;
+        self.params.set_gas_costs(gas_costs);
+        self
+    }
+
+    pub fn with_base_asset_id(&mut self, base_asset_id: AssetId) -> &mut Self {
+        self.params.set_base_asset_id(base_asset_id);
+        self
+    }
+
+    pub fn with_block_gas_limit(&mut self, block_gas_limit: u64) -> &mut Self {
+        self.params.set_block_gas_limit(block_gas_limit);
         self
     }
 }
@@ -285,11 +295,6 @@ impl<Tx: Buildable> TransactionBuilder<Tx> {
     {
         self.tx.set_script_gas_limit(gas_limit);
 
-        self
-    }
-
-    pub fn with_chain_id(&mut self, chain_id: ChainId) -> &mut Self {
-        self.params.chain_id = chain_id;
         self
     }
 
@@ -405,7 +410,7 @@ impl<Tx: Buildable> TransactionBuilder<Tx> {
         let witness_len = u16::try_from(self.witnesses().len())
             .expect("The number of witnesses can't exceed `u16::MAX`");
 
-        if u32::from(witness_len) > self.params.tx_params.max_witnesses {
+        if u32::from(witness_len) > self.params.tx_params().max_witnesses {
             panic!("Max witnesses exceeded");
         }
 

--- a/fuel-tx/src/lib.rs
+++ b/fuel-tx/src/lib.rs
@@ -107,10 +107,6 @@ pub use transaction::{
 };
 
 #[cfg(feature = "alloc")]
-#[allow(deprecated)]
-pub use transaction::consensus_parameters::default_parameters;
-
-#[cfg(feature = "alloc")]
 pub use contract::Contract;
 
 /// Trait extends the functionality of the `ContractId` type.

--- a/fuel-tx/src/tests/valid_cases.rs
+++ b/fuel-tx/src/tests/valid_cases.rs
@@ -38,6 +38,7 @@ pub fn test_params() -> ConsensusParameters {
         CHAIN_ID,
         Default::default(),
         Default::default(),
+        Default::default(),
     )
 }
 

--- a/fuel-tx/src/tests/valid_cases/transaction.rs
+++ b/fuel-tx/src/tests/valid_cases/transaction.rs
@@ -1006,7 +1006,9 @@ fn script__check__transaction_at_maximum_size_is_valid() {
     let block_height = 100.into();
     let mut params = test_params();
     let max_size = 1024usize;
-    params.tx_params.max_size = max_size as u64;
+    let mut tx_params = *params.tx_params();
+    tx_params.max_size = max_size as u64;
+    params.set_tx_params(tx_params);
 
     let base_size = {
         let tx = TransactionBuilder::script(vec![], vec![])
@@ -1038,7 +1040,9 @@ fn script__check__transaction_exceeding_maximum_size_is_invalid() {
     let block_height = 100.into();
     let mut params = test_params();
     let max_size = 1024usize;
-    params.tx_params.max_size = max_size as u64;
+    let mut tx_params = *params.tx_params();
+    tx_params.max_size = max_size as u64;
+    params.set_tx_params(tx_params);
 
     let base_size = {
         let tx = TransactionBuilder::script(vec![], vec![])

--- a/fuel-tx/src/transaction/consensus_parameters.rs
+++ b/fuel-tx/src/transaction/consensus_parameters.rs
@@ -15,21 +15,14 @@ pub use gas::{
 };
 
 const MAX_GAS: u64 = 100_000_000;
-const MAX_SIZE: u64 = 17 * 1024 * 1024;
+const MAX_SIZE: u64 = 110 * 1024;
 
-/// A collection of parameters for convenience
+/// A versioned set of consensus parameters.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(default))]
-pub struct ConsensusParameters {
-    pub tx_params: TxParameters,
-    pub predicate_params: PredicateParameters,
-    pub script_params: ScriptParameters,
-    pub contract_params: ContractParameters,
-    pub fee_params: FeeParameters,
-    pub chain_id: ChainId,
-    pub gas_costs: GasCosts,
-    pub base_asset_id: AssetId,
+pub enum ConsensusParameters {
+    /// Version 1 of the consensus parameters
+    V1(ConsensusParametersV1),
 }
 
 impl Default for ConsensusParameters {
@@ -41,6 +34,188 @@ impl Default for ConsensusParameters {
 impl ConsensusParameters {
     /// Constructor for the `ConsensusParameters` with Standard values.
     pub fn standard() -> Self {
+        ConsensusParametersV1::standard().into()
+    }
+
+    /// Constructor for the `ConsensusParameters` with Standard values around `ChainId`.
+    pub fn standard_with_id(chain_id: ChainId) -> Self {
+        ConsensusParametersV1::standard_with_id(chain_id).into()
+    }
+
+    /// Constructor for the `ConsensusParameters`
+    pub const fn new(
+        tx_params: TxParameters,
+        predicate_params: PredicateParameters,
+        script_params: ScriptParameters,
+        contract_params: ContractParameters,
+        fee_params: FeeParameters,
+        chain_id: ChainId,
+        gas_costs: GasCosts,
+        base_asset_id: AssetId,
+        block_gas_limit: u64,
+    ) -> Self {
+        Self::V1(ConsensusParametersV1 {
+            tx_params,
+            predicate_params,
+            script_params,
+            contract_params,
+            fee_params,
+            chain_id,
+            gas_costs,
+            base_asset_id,
+            block_gas_limit,
+        })
+    }
+
+    /// Get the transaction parameters
+    pub fn tx_params(&self) -> &TxParameters {
+        match self {
+            Self::V1(params) => &params.tx_params,
+        }
+    }
+
+    /// Get the predicate parameters
+    pub fn predicate_params(&self) -> &PredicateParameters {
+        match self {
+            Self::V1(params) => &params.predicate_params,
+        }
+    }
+
+    /// Get the script parameters
+    pub fn script_params(&self) -> &ScriptParameters {
+        match self {
+            Self::V1(params) => &params.script_params,
+        }
+    }
+
+    /// Get the contract parameters
+    pub fn contract_params(&self) -> &ContractParameters {
+        match self {
+            Self::V1(params) => &params.contract_params,
+        }
+    }
+
+    /// Get the fee parameters
+    pub fn fee_params(&self) -> &FeeParameters {
+        match self {
+            Self::V1(params) => &params.fee_params,
+        }
+    }
+
+    /// Get the chain ID
+    pub fn chain_id(&self) -> ChainId {
+        match self {
+            Self::V1(params) => params.chain_id,
+        }
+    }
+
+    /// Get the gas costs
+    pub fn gas_costs(&self) -> &GasCosts {
+        match self {
+            Self::V1(params) => &params.gas_costs,
+        }
+    }
+
+    /// Get the base asset ID
+    pub fn base_asset_id(&self) -> &AssetId {
+        match self {
+            Self::V1(params) => &params.base_asset_id,
+        }
+    }
+
+    /// Get the block gas limit
+    pub fn block_gas_limit(&self) -> u64 {
+        match self {
+            Self::V1(params) => params.block_gas_limit,
+        }
+    }
+}
+
+#[cfg(feature = "builder")]
+impl ConsensusParameters {
+    /// Set the transaction parameters.
+    pub fn set_tx_params(&mut self, tx_params: TxParameters) {
+        match self {
+            Self::V1(params) => params.tx_params = tx_params,
+        }
+    }
+
+    /// Set the predicate parameters.
+    pub fn set_predicate_params(&mut self, predicate_params: PredicateParameters) {
+        match self {
+            Self::V1(params) => params.predicate_params = predicate_params,
+        }
+    }
+
+    /// Set the script parameters.
+    pub fn set_script_params(&mut self, script_params: ScriptParameters) {
+        match self {
+            Self::V1(params) => params.script_params = script_params,
+        }
+    }
+
+    /// Set the contract parameters.
+    pub fn set_contract_params(&mut self, contract_params: ContractParameters) {
+        match self {
+            Self::V1(params) => params.contract_params = contract_params,
+        }
+    }
+
+    /// Set the fee parameters.
+    pub fn set_fee_params(&mut self, fee_params: FeeParameters) {
+        match self {
+            Self::V1(params) => params.fee_params = fee_params,
+        }
+    }
+
+    /// Set the chain ID.
+    pub fn set_chain_id(&mut self, chain_id: ChainId) {
+        match self {
+            Self::V1(params) => params.chain_id = chain_id,
+        }
+    }
+
+    /// Set the gas costs.
+    pub fn set_gas_costs(&mut self, gas_costs: GasCosts) {
+        match self {
+            Self::V1(params) => params.gas_costs = gas_costs,
+        }
+    }
+
+    /// Set the base asset ID.
+    pub fn set_base_asset_id(&mut self, base_asset_id: AssetId) {
+        match self {
+            Self::V1(params) => params.base_asset_id = base_asset_id,
+        }
+    }
+
+    /// Set the block gas limit.
+    pub fn set_block_gas_limit(&mut self, block_gas_limit: u64) {
+        match self {
+            Self::V1(params) => params.block_gas_limit = block_gas_limit,
+        }
+    }
+}
+
+/// A collection of parameters for convenience
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
+pub struct ConsensusParametersV1 {
+    pub tx_params: TxParameters,
+    pub predicate_params: PredicateParameters,
+    pub script_params: ScriptParameters,
+    pub contract_params: ContractParameters,
+    pub fee_params: FeeParameters,
+    pub chain_id: ChainId,
+    pub gas_costs: GasCosts,
+    pub base_asset_id: AssetId,
+    pub block_gas_limit: u64,
+}
+
+impl ConsensusParametersV1 {
+    /// Constructor for the `ConsensusParameters` with Standard values.
+    pub fn standard() -> Self {
         Self {
             tx_params: TxParameters::DEFAULT,
             predicate_params: PredicateParameters::DEFAULT,
@@ -50,6 +225,7 @@ impl ConsensusParameters {
             chain_id: ChainId::default(),
             gas_costs: GasCosts::default(),
             base_asset_id: Default::default(),
+            block_gas_limit: TxParameters::DEFAULT.max_gas_per_tx,
         }
     }
 
@@ -64,69 +240,20 @@ impl ConsensusParameters {
             chain_id,
             gas_costs: GasCosts::default(),
             base_asset_id: Default::default(),
+            block_gas_limit: TxParameters::DEFAULT.max_gas_per_tx,
         }
     }
+}
 
-    /// Constructor for the `ConsensusParameters`
-    pub const fn new(
-        tx_params: TxParameters,
-        predicate_params: PredicateParameters,
-        script_params: ScriptParameters,
-        contract_params: ContractParameters,
-        fee_params: FeeParameters,
-        chain_id: ChainId,
-        gas_costs: GasCosts,
-        base_asset_id: AssetId,
-    ) -> Self {
-        Self {
-            tx_params,
-            predicate_params,
-            script_params,
-            contract_params,
-            fee_params,
-            chain_id,
-            gas_costs,
-            base_asset_id,
-        }
+impl Default for ConsensusParametersV1 {
+    fn default() -> Self {
+        Self::standard()
     }
+}
 
-    /// Get the transaction parameters
-    pub fn tx_params(&self) -> &TxParameters {
-        &self.tx_params
-    }
-
-    /// Get the predicate parameters
-    pub fn predicate_params(&self) -> &PredicateParameters {
-        &self.predicate_params
-    }
-
-    /// Get the script parameters
-    pub fn script_params(&self) -> &ScriptParameters {
-        &self.script_params
-    }
-
-    /// Get the contract parameters
-    pub fn contract_params(&self) -> &ContractParameters {
-        &self.contract_params
-    }
-
-    /// Get the fee parameters
-    pub fn fee_params(&self) -> &FeeParameters {
-        &self.fee_params
-    }
-
-    pub fn base_asset_id(&self) -> &AssetId {
-        &self.base_asset_id
-    }
-
-    /// Get the chain ID
-    pub fn chain_id(&self) -> ChainId {
-        self.chain_id
-    }
-
-    /// Get the gas costs
-    pub fn gas_costs(&self) -> &GasCosts {
-        &self.gas_costs
+impl From<ConsensusParametersV1> for ConsensusParameters {
+    fn from(params: ConsensusParametersV1) -> Self {
+        Self::V1(params)
     }
 }
 
@@ -346,7 +473,7 @@ pub struct ContractParameters {
 impl ContractParameters {
     /// Default consensus parameters with settings suggested in fuel-specs
     pub const DEFAULT: Self = Self {
-        contract_max_size: 16 * 1024 * 1024,
+        contract_max_size: 100 * 1024,
         max_storage_slots: 255,
     };
 
@@ -382,46 +509,4 @@ mod typescript {
             Self::DEFAULT
         }
     }
-}
-
-/// Arbitrary default consensus parameters. While best-efforts are made to adjust these to
-/// reasonable settings, they may not be useful for every network instantiation.
-#[deprecated(since = "0.12.2", note = "use `ConsensusParameters` instead.")]
-pub mod default_parameters {
-    use crate::{
-        transaction::consensus_parameters::{
-            PredicateParameters,
-            ScriptParameters,
-            TxParameters,
-        },
-        ContractParameters,
-        FeeParameters,
-    };
-    use fuel_types::ChainId;
-
-    pub const CONTRACT_MAX_SIZE: u64 = ContractParameters::DEFAULT.contract_max_size;
-    pub const MAX_INPUTS: u16 = TxParameters::DEFAULT.max_inputs;
-    pub const MAX_OUTPUTS: u16 = TxParameters::DEFAULT.max_outputs;
-    pub const MAX_WITNESSES: u32 = TxParameters::DEFAULT.max_witnesses;
-    pub const MAX_GAS_PER_TX: u64 = TxParameters::DEFAULT.max_gas_per_tx;
-
-    pub const MAX_SCRIPT_LENGTH: u64 = ScriptParameters::DEFAULT.max_script_length;
-    pub const MAX_SCRIPT_DATA_LENGTH: u64 =
-        ScriptParameters::DEFAULT.max_script_data_length;
-
-    pub const MAX_STORAGE_SLOTS: u64 = ContractParameters::DEFAULT.max_storage_slots;
-
-    pub const MAX_PREDICATE_LENGTH: u64 =
-        PredicateParameters::DEFAULT.max_predicate_length;
-    pub const MAX_PREDICATE_DATA_LENGTH: u64 =
-        PredicateParameters::DEFAULT.max_predicate_data_length;
-    pub const MAX_MESSAGE_DATA_LENGTH: u64 =
-        PredicateParameters::DEFAULT.max_message_data_length;
-
-    pub const MAX_GAS_PER_PREDICATE: u64 =
-        PredicateParameters::DEFAULT.max_gas_per_predicate;
-    pub const GAS_PRICE_FACTOR: u64 = FeeParameters::DEFAULT.gas_price_factor;
-    pub const GAS_PER_BYTE: u64 = FeeParameters::DEFAULT.gas_per_byte;
-
-    pub const CHAIN_ID: ChainId = ChainId::new(0);
 }

--- a/fuel-tx/src/transaction/consensus_parameters/gas.rs
+++ b/fuel-tx/src/transaction/consensus_parameters/gas.rs
@@ -198,12 +198,682 @@ impl Default for GasCostsValues {
     }
 }
 
+/// The versioned gas costs for every op.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum GasCostsValues {
+    /// Version 1 of the gas costs.
+    V1(GasCostsValuesV1),
+}
+
+#[allow(missing_docs)]
+impl GasCostsValues {
+    pub fn add(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.add,
+        }
+    }
+
+    pub fn addi(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.addi,
+        }
+    }
+
+    pub fn aloc(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.aloc,
+        }
+    }
+
+    pub fn and(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.and,
+        }
+    }
+
+    pub fn andi(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.andi,
+        }
+    }
+
+    pub fn bal(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.bal,
+        }
+    }
+
+    pub fn bhei(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.bhei,
+        }
+    }
+
+    pub fn bhsh(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.bhsh,
+        }
+    }
+
+    pub fn burn(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.burn,
+        }
+    }
+
+    pub fn cb(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.cb,
+        }
+    }
+
+    pub fn cfei(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.cfei,
+        }
+    }
+
+    pub fn cfsi(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.cfsi,
+        }
+    }
+
+    pub fn div(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.div,
+        }
+    }
+
+    pub fn divi(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.divi,
+        }
+    }
+
+    pub fn eck1(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.eck1,
+        }
+    }
+
+    pub fn ecr1(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.ecr1,
+        }
+    }
+
+    pub fn ed19(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.ed19,
+        }
+    }
+
+    pub fn eq_(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.eq,
+        }
+    }
+
+    pub fn exp(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.exp,
+        }
+    }
+
+    pub fn expi(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.expi,
+        }
+    }
+
+    pub fn flag(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.flag,
+        }
+    }
+
+    pub fn gm(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.gm,
+        }
+    }
+
+    pub fn gt(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.gt,
+        }
+    }
+
+    pub fn gtf(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.gtf,
+        }
+    }
+
+    pub fn ji(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.ji,
+        }
+    }
+
+    pub fn jmp(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.jmp,
+        }
+    }
+
+    pub fn jne(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.jne,
+        }
+    }
+
+    pub fn jnei(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.jnei,
+        }
+    }
+
+    pub fn jnzi(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.jnzi,
+        }
+    }
+
+    pub fn jmpf(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.jmpf,
+        }
+    }
+
+    pub fn jmpb(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.jmpb,
+        }
+    }
+
+    pub fn jnzf(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.jnzf,
+        }
+    }
+
+    pub fn jnzb(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.jnzb,
+        }
+    }
+
+    pub fn jnef(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.jnef,
+        }
+    }
+
+    pub fn jneb(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.jneb,
+        }
+    }
+
+    pub fn lb(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.lb,
+        }
+    }
+
+    pub fn log(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.log,
+        }
+    }
+
+    pub fn lt(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.lt,
+        }
+    }
+
+    pub fn lw(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.lw,
+        }
+    }
+
+    pub fn mint(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.mint,
+        }
+    }
+
+    pub fn mlog(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.mlog,
+        }
+    }
+
+    pub fn mod_op(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.mod_op,
+        }
+    }
+
+    pub fn modi(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.modi,
+        }
+    }
+
+    pub fn move_op(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.move_op,
+        }
+    }
+
+    pub fn movi(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.movi,
+        }
+    }
+
+    pub fn mroo(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.mroo,
+        }
+    }
+
+    pub fn mul(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.mul,
+        }
+    }
+
+    pub fn muli(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.muli,
+        }
+    }
+
+    pub fn mldv(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.mldv,
+        }
+    }
+
+    pub fn noop(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.noop,
+        }
+    }
+
+    pub fn not(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.not,
+        }
+    }
+
+    pub fn or(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.or,
+        }
+    }
+
+    pub fn ori(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.ori,
+        }
+    }
+
+    pub fn poph(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.poph,
+        }
+    }
+
+    pub fn popl(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.popl,
+        }
+    }
+
+    pub fn pshh(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.pshh,
+        }
+    }
+
+    pub fn pshl(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.pshl,
+        }
+    }
+
+    pub fn ret(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.ret,
+        }
+    }
+
+    pub fn rvrt(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.rvrt,
+        }
+    }
+
+    pub fn sb(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.sb,
+        }
+    }
+
+    pub fn sll(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.sll,
+        }
+    }
+
+    pub fn slli(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.slli,
+        }
+    }
+
+    pub fn srl(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.srl,
+        }
+    }
+
+    pub fn srli(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.srli,
+        }
+    }
+
+    pub fn srw(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.srw,
+        }
+    }
+
+    pub fn sub(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.sub,
+        }
+    }
+
+    pub fn subi(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.subi,
+        }
+    }
+
+    pub fn sw(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.sw,
+        }
+    }
+
+    pub fn sww(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.sww,
+        }
+    }
+
+    pub fn time(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.time,
+        }
+    }
+
+    pub fn tr(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.tr,
+        }
+    }
+
+    pub fn tro(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.tro,
+        }
+    }
+
+    pub fn wdcm(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.wdcm,
+        }
+    }
+
+    pub fn wqcm(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.wqcm,
+        }
+    }
+
+    pub fn wdop(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.wdop,
+        }
+    }
+
+    pub fn wqop(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.wqop,
+        }
+    }
+
+    pub fn wdml(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.wdml,
+        }
+    }
+
+    pub fn wqml(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.wqml,
+        }
+    }
+
+    pub fn wddv(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.wddv,
+        }
+    }
+
+    pub fn wqdv(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.wqdv,
+        }
+    }
+
+    pub fn wdmd(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.wdmd,
+        }
+    }
+
+    pub fn wqmd(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.wqmd,
+        }
+    }
+
+    pub fn wdam(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.wdam,
+        }
+    }
+
+    pub fn wqam(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.wqam,
+        }
+    }
+
+    pub fn wdmm(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.wdmm,
+        }
+    }
+
+    pub fn wqmm(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.wqmm,
+        }
+    }
+
+    pub fn xor(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.xor,
+        }
+    }
+
+    pub fn xori(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.xori,
+        }
+    }
+
+    pub fn call(&self) -> DependentCost {
+        match self {
+            GasCostsValues::V1(v1) => v1.call,
+        }
+    }
+
+    pub fn ccp(&self) -> DependentCost {
+        match self {
+            GasCostsValues::V1(v1) => v1.ccp,
+        }
+    }
+
+    pub fn croo(&self) -> DependentCost {
+        match self {
+            GasCostsValues::V1(v1) => v1.croo,
+        }
+    }
+
+    pub fn csiz(&self) -> DependentCost {
+        match self {
+            GasCostsValues::V1(v1) => v1.csiz,
+        }
+    }
+
+    pub fn k256(&self) -> DependentCost {
+        match self {
+            GasCostsValues::V1(v1) => v1.k256,
+        }
+    }
+
+    pub fn ldc(&self) -> DependentCost {
+        match self {
+            GasCostsValues::V1(v1) => v1.ldc,
+        }
+    }
+
+    pub fn logd(&self) -> DependentCost {
+        match self {
+            GasCostsValues::V1(v1) => v1.logd,
+        }
+    }
+
+    pub fn mcl(&self) -> DependentCost {
+        match self {
+            GasCostsValues::V1(v1) => v1.mcl,
+        }
+    }
+
+    pub fn mcli(&self) -> DependentCost {
+        match self {
+            GasCostsValues::V1(v1) => v1.mcli,
+        }
+    }
+
+    pub fn mcp(&self) -> DependentCost {
+        match self {
+            GasCostsValues::V1(v1) => v1.mcp,
+        }
+    }
+
+    pub fn mcpi(&self) -> DependentCost {
+        match self {
+            GasCostsValues::V1(v1) => v1.mcpi,
+        }
+    }
+
+    pub fn meq(&self) -> DependentCost {
+        match self {
+            GasCostsValues::V1(v1) => v1.meq,
+        }
+    }
+
+    pub fn retd(&self) -> DependentCost {
+        match self {
+            GasCostsValues::V1(v1) => v1.retd,
+        }
+    }
+
+    pub fn s256(&self) -> DependentCost {
+        match self {
+            GasCostsValues::V1(v1) => v1.s256,
+        }
+    }
+
+    pub fn scwq(&self) -> DependentCost {
+        match self {
+            GasCostsValues::V1(v1) => v1.scwq,
+        }
+    }
+
+    pub fn smo(&self) -> DependentCost {
+        match self {
+            GasCostsValues::V1(v1) => v1.smo,
+        }
+    }
+
+    pub fn srwq(&self) -> DependentCost {
+        match self {
+            GasCostsValues::V1(v1) => v1.srwq,
+        }
+    }
+
+    pub fn swwq(&self) -> DependentCost {
+        match self {
+            GasCostsValues::V1(v1) => v1.swwq,
+        }
+    }
+
+    pub fn contract_root(&self) -> DependentCost {
+        match self {
+            GasCostsValues::V1(v1) => v1.contract_root,
+        }
+    }
+
+    pub fn state_root(&self) -> DependentCost {
+        match self {
+            GasCostsValues::V1(v1) => v1.state_root,
+        }
+    }
+
+    pub fn new_storage_per_byte(&self) -> Word {
+        match self {
+            GasCostsValues::V1(v1) => v1.new_storage_per_byte,
+        }
+    }
+
+    pub fn vm_initialization(&self) -> DependentCost {
+        match self {
+            GasCostsValues::V1(v1) => v1.vm_initialization,
+        }
+    }
+}
+
 /// Gas costs for every op.
 #[allow(missing_docs)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(default = "GasCostsValues::unit"))]
-pub struct GasCostsValues {
+pub struct GasCostsValuesV1 {
     pub add: Word,
     pub addi: Word,
     pub aloc: Word,
@@ -367,7 +1037,7 @@ impl GasCosts {
 impl GasCostsValues {
     /// Create costs that are all set to zero.
     pub fn free() -> Self {
-        Self {
+        GasCostsValuesV1 {
             add: 0,
             addi: 0,
             aloc: 0,
@@ -481,11 +1151,12 @@ impl GasCostsValues {
             new_storage_per_byte: 0,
             vm_initialization: DependentCost::free(),
         }
+        .into()
     }
 
     /// Create costs that are all set to one.
     pub fn unit() -> Self {
-        Self {
+        GasCostsValuesV1 {
             add: 1,
             addi: 1,
             aloc: 1,
@@ -599,6 +1270,7 @@ impl GasCostsValues {
             new_storage_per_byte: 1,
             vm_initialization: DependentCost::unit(),
         }
+        .into()
     }
 }
 
@@ -694,6 +1366,12 @@ impl From<GasCostsValues> for GasCosts {
 impl From<GasCosts> for GasCostsValues {
     fn from(i: GasCosts) -> Self {
         (*i.0).clone()
+    }
+}
+
+impl From<GasCostsValuesV1> for GasCostsValues {
+    fn from(i: GasCostsValuesV1) -> Self {
+        GasCostsValues::V1(i)
     }
 }
 

--- a/fuel-tx/src/transaction/consensus_parameters/gas/default_gas_costs.rs
+++ b/fuel-tx/src/transaction/consensus_parameters/gas/default_gas_costs.rs
@@ -3,7 +3,7 @@ use super::*;
 /// hash
 pub const GIT: &str = "98341e564b75d1157e61d7d5f38612f6224a5b30";
 pub fn default_gas_costs() -> GasCostsValues {
-    GasCostsValues {
+    GasCostsValuesV1 {
         add: 1,
         addi: 1,
         aloc: 1,
@@ -180,4 +180,5 @@ pub fn default_gas_costs() -> GasCostsValues {
             gas_per_unit: 0,
         },
     }
+    .into()
 }

--- a/fuel-tx/src/transaction/fee.rs
+++ b/fuel-tx/src/transaction/fee.rs
@@ -124,7 +124,7 @@ pub trait Chargeable: field::Inputs + field::Witnesses + field::Policies {
         let bytes_size = self.metered_bytes_size();
 
         let vm_initialization_gas =
-            gas_costs.vm_initialization.resolve(bytes_size as Word);
+            gas_costs.vm_initialization().resolve(bytes_size as Word);
 
         let bytes_gas = bytes_size as u64 * fee.gas_per_byte;
         // It's okay to saturate because we have the `max_gas_per_tx` rule for transaction
@@ -239,7 +239,7 @@ pub trait Chargeable: field::Inputs + field::Witnesses + field::Policies {
                 // Charge EC recovery cost for signed inputs
                 Input::CoinSigned(_)
                 | Input::MessageCoinSigned(_)
-                | Input::MessageDataSigned(_) => gas_costs.ecr1,
+                | Input::MessageDataSigned(_) => gas_costs.ecr1(),
                 // Charge the cost of the contract root for predicate inputs
                 Input::CoinPredicate(CoinPredicate {
                     predicate,
@@ -258,9 +258,9 @@ pub trait Chargeable: field::Inputs + field::Witnesses + field::Policies {
                 }) => {
                     let bytes_size = self.metered_bytes_size();
                     let vm_initialization_gas =
-                        gas_costs.vm_initialization.resolve(bytes_size as Word);
+                        gas_costs.vm_initialization().resolve(bytes_size as Word);
                     gas_costs
-                        .contract_root
+                        .contract_root()
                         .resolve(predicate.len() as u64)
                         .saturating_add(*predicate_gas_used)
                         .saturating_add(vm_initialization_gas)

--- a/fuel-tx/src/transaction/types/create.rs
+++ b/fuel-tx/src/transaction/types/create.rs
@@ -223,12 +223,9 @@ impl FormatValidityChecks for Create {
         block_height: BlockHeight,
         consensus_params: &ConsensusParameters,
     ) -> Result<(), ValidityError> {
-        let ConsensusParameters {
-            contract_params,
-            chain_id,
-            base_asset_id,
-            ..
-        } = consensus_params;
+        let contract_params = consensus_params.contract_params();
+        let chain_id = consensus_params.chain_id();
+        let base_asset_id = consensus_params.base_asset_id();
 
         check_common_part(self, block_height, consensus_params)?;
 
@@ -281,7 +278,7 @@ impl FormatValidityChecks for Create {
             if let Some(metadata) = &self.metadata {
                 (metadata.state_root, metadata.contract_id)
             } else {
-                let metadata = CreateMetadata::compute(self, chain_id)?;
+                let metadata = CreateMetadata::compute(self, &chain_id)?;
                 (metadata.state_root, metadata.contract_id)
             };
 

--- a/fuel-tx/src/transaction/types/create.rs
+++ b/fuel-tx/src/transaction/types/create.rs
@@ -174,19 +174,19 @@ impl Chargeable for Create {
             .map(|c| c.as_ref().len())
             .unwrap_or(0);
 
-        let contract_root_gas = gas_costs.contract_root.resolve(contract_len as Word);
+        let contract_root_gas = gas_costs.contract_root().resolve(contract_len as Word);
         let state_root_length = storage_slots.len() as Word;
-        let state_root_gas = gas_costs.state_root.resolve(state_root_length);
+        let state_root_gas = gas_costs.state_root().resolve(state_root_length);
 
         // See https://github.com/FuelLabs/fuel-specs/blob/master/src/identifiers/contract-id.md
         let contract_id_input_length = core::mem::size_of::<Bytes4>()
             + core::mem::size_of::<Salt>()
             + core::mem::size_of::<Bytes32>()
             + core::mem::size_of::<Bytes32>();
-        let contract_id_gas = gas_costs.s256.resolve(contract_id_input_length as Word);
+        let contract_id_gas = gas_costs.s256().resolve(contract_id_input_length as Word);
         let bytes = canonical::Serialize::size(self);
         // Gas required to calculate the `tx_id`.
-        let tx_id_gas = gas_costs.s256.resolve(bytes as u64);
+        let tx_id_gas = gas_costs.s256().resolve(bytes as u64);
 
         contract_root_gas
             .saturating_add(state_root_gas)

--- a/fuel-tx/src/transaction/types/mint.rs
+++ b/fuel-tx/src/transaction/types/mint.rs
@@ -111,7 +111,7 @@ impl FormatValidityChecks for Mint {
         }
 
         // It is temporary check until https://github.com/FuelLabs/fuel-core/issues/1205
-        if self.mint_asset_id != consensus_params.base_asset_id {
+        if &self.mint_asset_id != consensus_params.base_asset_id() {
             return Err(ValidityError::TransactionMintNonBaseAsset);
         }
 

--- a/fuel-tx/src/transaction/types/script.rs
+++ b/fuel-tx/src/transaction/types/script.rs
@@ -161,7 +161,7 @@ impl Chargeable for Script {
     fn gas_used_by_metadata(&self, gas_cost: &GasCosts) -> Word {
         let bytes = Serialize::size(self);
         // Gas required to calculate the `tx_id`.
-        gas_cost.s256.resolve(bytes as u64)
+        gas_cost.s256().resolve(bytes as u64)
     }
 }
 

--- a/fuel-tx/src/transaction/validity.rs
+++ b/fuel-tx/src/transaction/validity.rs
@@ -317,14 +317,11 @@ pub(crate) fn check_common_part<T>(
 where
     T: canonical::Serialize + Chargeable + field::Outputs,
 {
-    let ConsensusParameters {
-        tx_params,
-        predicate_params,
-        base_asset_id,
-        gas_costs,
-        fee_params,
-        ..
-    } = consensus_params;
+    let tx_params = consensus_params.tx_params();
+    let predicate_params = consensus_params.predicate_params();
+    let base_asset_id = consensus_params.base_asset_id();
+    let gas_costs = consensus_params.gas_costs();
+    let fee_params = consensus_params.fee_params();
 
     check_size(tx, tx_params)?;
 

--- a/fuel-vm/src/checked_transaction.rs
+++ b/fuel-vm/src/checked_transaction.rs
@@ -297,7 +297,7 @@ pub trait IntoChecked: FormatValidityChecks + Sized {
     {
         let check_predicate_params = consensus_params.into();
         self.into_checked_basic(block_height, consensus_params)?
-            .check_signatures(&consensus_params.chain_id)?
+            .check_signatures(&consensus_params.chain_id())?
             .check_predicates(&check_predicate_params)
     }
 
@@ -350,7 +350,7 @@ impl From<&ConsensusParameters> for CheckPredicateParams {
     fn from(value: &ConsensusParameters) -> Self {
         CheckPredicateParams {
             gas_costs: value.gas_costs().clone(),
-            chain_id: value.chain_id,
+            chain_id: value.chain_id(),
             max_gas_per_predicate: value.predicate_params().max_gas_per_predicate,
             max_gas_per_tx: value.tx_params().max_gas_per_tx,
             max_inputs: value.tx_params().max_inputs,
@@ -358,7 +358,7 @@ impl From<&ConsensusParameters> for CheckPredicateParams {
             max_message_data_length: value.predicate_params().max_message_data_length,
             tx_offset: value.tx_params().tx_offset(),
             fee_params: *(value.fee_params()),
-            base_asset_id: value.base_asset_id,
+            base_asset_id: *value.base_asset_id(),
         }
     }
 }
@@ -762,6 +762,7 @@ mod tests {
             ScriptParameters::default(),
             ContractParameters::default(),
             FeeParameters::default().with_gas_price_factor(factor),
+            Default::default(),
             Default::default(),
             Default::default(),
             Default::default(),
@@ -1764,10 +1765,8 @@ mod tests {
 
         let tx = predicate_tx(&mut rng, 1000000, 1000000, 1000000, gas_costs.ret());
 
-        let consensus_params = ConsensusParameters {
-            gas_costs,
-            ..ConsensusParameters::standard()
-        };
+        let mut consensus_params = ConsensusParameters::standard();
+        consensus_params.set_gas_costs(gas_costs);
 
         let check_predicate_params = CheckPredicateParams::from(&consensus_params);
 

--- a/fuel-vm/src/checked_transaction.rs
+++ b/fuel-vm/src/checked_transaction.rs
@@ -1111,9 +1111,9 @@ mod tests {
 
         let min_fee = fee.min_fee();
         let expected_min_fee = (tx.metered_bytes_size() as u64 * fee_params.gas_per_byte
-            + gas_costs.vm_initialization.resolve(tx.size() as u64)
-            + 3 * gas_costs.ecr1
-            + gas_costs.s256.resolve(tx.size() as u64))
+            + gas_costs.vm_initialization().resolve(tx.size() as u64)
+            + 3 * gas_costs.ecr1()
+            + gas_costs.s256().resolve(tx.size() as u64))
             * gas_price;
         assert_eq!(min_fee, expected_min_fee);
 
@@ -1164,9 +1164,9 @@ mod tests {
         // be recovered once. Therefore, we charge only once for the address
         // recovery of the signed inputs.
         let expected_min_fee = (tx.metered_bytes_size() as u64 * fee_params.gas_per_byte
-            + gas_costs.vm_initialization.resolve(tx.size() as u64)
-            + gas_costs.ecr1
-            + gas_costs.s256.resolve(tx.size() as u64))
+            + gas_costs.vm_initialization().resolve(tx.size() as u64)
+            + gas_costs.ecr1()
+            + gas_costs.s256().resolve(tx.size() as u64))
             * gas_price;
         assert_eq!(min_fee, expected_min_fee);
 
@@ -1230,15 +1230,15 @@ mod tests {
 
         let min_fee = fee.min_fee();
         let expected_min_fee = (tx.size() as u64 * fee_params.gas_per_byte
-            + gas_costs.vm_initialization.resolve(tx.size() as u64)
-            + gas_costs.contract_root.resolve(predicate_1.len() as u64)
-            + gas_costs.contract_root.resolve(predicate_2.len() as u64)
-            + gas_costs.contract_root.resolve(predicate_3.len() as u64)
-            + 3 * gas_costs.vm_initialization.resolve(tx.size() as u64)
+            + gas_costs.vm_initialization().resolve(tx.size() as u64)
+            + gas_costs.contract_root().resolve(predicate_1.len() as u64)
+            + gas_costs.contract_root().resolve(predicate_2.len() as u64)
+            + gas_costs.contract_root().resolve(predicate_3.len() as u64)
+            + 3 * gas_costs.vm_initialization().resolve(tx.size() as u64)
             + 50
             + 100
             + 200
-            + gas_costs.s256.resolve(tx.size() as u64))
+            + gas_costs.s256().resolve(tx.size() as u64))
             * gas_price;
         assert_eq!(min_fee, expected_min_fee);
 
@@ -1316,16 +1316,16 @@ mod tests {
 
         let min_fee = fee.min_fee();
         let expected_min_fee = (tx.metered_bytes_size() as u64 * fee_params.gas_per_byte
-            + 3 * gas_costs.ecr1
-            + gas_costs.vm_initialization.resolve(tx.size() as u64)
-            + gas_costs.contract_root.resolve(predicate_1.len() as u64)
-            + gas_costs.contract_root.resolve(predicate_2.len() as u64)
-            + gas_costs.contract_root.resolve(predicate_3.len() as u64)
-            + 3 * gas_costs.vm_initialization.resolve(tx.size() as u64)
+            + 3 * gas_costs.ecr1()
+            + gas_costs.vm_initialization().resolve(tx.size() as u64)
+            + gas_costs.contract_root().resolve(predicate_1.len() as u64)
+            + gas_costs.contract_root().resolve(predicate_2.len() as u64)
+            + gas_costs.contract_root().resolve(predicate_3.len() as u64)
+            + 3 * gas_costs.vm_initialization().resolve(tx.size() as u64)
             + 50
             + 100
             + 200
-            + gas_costs.s256.resolve(tx.size() as u64))
+            + gas_costs.s256().resolve(tx.size() as u64))
             * gas_price;
         assert_eq!(min_fee, expected_min_fee);
 
@@ -1358,11 +1358,11 @@ mod tests {
 
         let min_fee = fee.min_fee();
         let expected_min_fee = (tx.metered_bytes_size() as u64 * fee_params.gas_per_byte
-            + gas_costs.state_root.resolve(storage_slots_len as Word)
-            + gas_costs.contract_root.resolve(bytecode_len as Word)
-            + gas_costs.vm_initialization.resolve(tx.size() as u64)
-            + gas_costs.s256.resolve(100)
-            + gas_costs.s256.resolve(tx.size() as u64))
+            + gas_costs.state_root().resolve(storage_slots_len as Word)
+            + gas_costs.contract_root().resolve(bytecode_len as Word)
+            + gas_costs.vm_initialization().resolve(tx.size() as u64)
+            + gas_costs.s256().resolve(100)
+            + gas_costs.s256().resolve(tx.size() as u64))
             * gas_price;
         assert_eq!(min_fee, expected_min_fee);
 
@@ -1392,11 +1392,11 @@ mod tests {
 
         let min_fee = fee.min_fee();
         let expected_min_fee = (tx.metered_bytes_size() as u64 * fee_params.gas_per_byte
-            + gas_costs.state_root.resolve(0)
-            + gas_costs.contract_root.resolve(0)
-            + gas_costs.vm_initialization.resolve(tx.size() as u64)
-            + gas_costs.s256.resolve(100)
-            + gas_costs.s256.resolve(tx.size() as u64))
+            + gas_costs.state_root().resolve(0)
+            + gas_costs.contract_root().resolve(0)
+            + gas_costs.vm_initialization().resolve(tx.size() as u64)
+            + gas_costs.s256().resolve(100)
+            + gas_costs.s256().resolve(tx.size() as u64))
             * gas_price;
         assert_eq!(min_fee, expected_min_fee);
 
@@ -1762,7 +1762,7 @@ mod tests {
         let block_height = 1.into();
         let gas_costs = GasCosts::default();
 
-        let tx = predicate_tx(&mut rng, 1000000, 1000000, 1000000, gas_costs.ret);
+        let tx = predicate_tx(&mut rng, 1000000, 1000000, 1000000, gas_costs.ret());
 
         let consensus_params = ConsensusParameters {
             gas_costs,
@@ -1810,7 +1810,7 @@ mod tests {
             .saturating_add(gas_used_by_metadata)
             .saturating_add(
                 gas_costs
-                    .vm_initialization
+                    .vm_initialization()
                     .resolve(tx.metered_bytes_size() as u64),
             );
 
@@ -1851,7 +1851,7 @@ mod tests {
             .saturating_add(gas_used_by_metadata)
             .saturating_add(
                 gas_costs
-                    .vm_initialization
+                    .vm_initialization()
                     .resolve(tx.metered_bytes_size() as u64),
             );
         let total = gas as u128 * gas_price as u128;

--- a/fuel-vm/src/checked_transaction/types.rs
+++ b/fuel-vm/src/checked_transaction/types.rs
@@ -218,7 +218,7 @@ pub mod script {
                 non_retryable_balances: NonRetryableFreeBalances(non_retryable_balances),
                 retryable_balance: RetryableAmount {
                     amount: retryable_balance,
-                    base_asset_id: consensus_params.base_asset_id,
+                    base_asset_id: *consensus_params.base_asset_id(),
                 },
                 block_height,
                 min_gas: self

--- a/fuel-vm/src/interpreter/blockchain.rs
+++ b/fuel-vm/src/interpreter/blockchain.rs
@@ -103,7 +103,7 @@ where
         contract_offset: Word,
         length_unpadded: Word,
     ) -> IoResult<(), S::DataError> {
-        let gas_cost = self.gas_costs().ldc;
+        let gas_cost = self.gas_costs().ldc();
         // Charge only for the `base` execution.
         // We will charge for the contracts size in the `load_contract_code`.
         self.gas_charge(gas_cost.base())?;
@@ -164,7 +164,7 @@ where
     }
 
     pub(crate) fn mint(&mut self, a: Word, b: Word) -> IoResult<(), S::DataError> {
-        let new_storage_gas_per_byte = self.gas_costs().new_storage_per_byte;
+        let new_storage_gas_per_byte = self.gas_costs().new_storage_per_byte();
         let (
             SystemRegisters {
                 cgas,
@@ -199,7 +199,7 @@ where
         c: Word,
         d: Word,
     ) -> IoResult<(), S::DataError> {
-        let gas_cost = self.gas_costs().ccp;
+        let gas_cost = self.gas_costs().ccp();
         // Charge only for the `base` execution.
         // We will charge for the contract's size in the `code_copy`.
         self.gas_charge(gas_cost.base())?;
@@ -263,7 +263,7 @@ where
     }
 
     pub(crate) fn code_root(&mut self, a: Word, b: Word) -> IoResult<(), S::DataError> {
-        let gas_cost = self.gas_costs().croo;
+        let gas_cost = self.gas_costs().croo();
         self.gas_charge(gas_cost.base())?;
         let current_contract =
             current_contract(&self.context, self.registers.fp(), self.memory.as_ref())?
@@ -299,7 +299,7 @@ where
         ra: RegisterId,
         b: Word,
     ) -> IoResult<(), S::DataError> {
-        let gas_cost = self.gas_costs().csiz;
+        let gas_cost = self.gas_costs().csiz();
         // Charge only for the `base` execution.
         // We will charge for the contracts size in the `code_size`.
         self.gas_charge(gas_cost.base())?;
@@ -412,7 +412,7 @@ where
         rb: RegisterId,
         c: Word,
     ) -> IoResult<(), S::DataError> {
-        let new_storage_gas_per_byte = self.gas_costs().new_storage_per_byte;
+        let new_storage_gas_per_byte = self.gas_costs().new_storage_per_byte();
         let (
             SystemRegisters {
                 cgas,
@@ -458,7 +458,7 @@ where
         c: Word,
         d: Word,
     ) -> IoResult<(), S::DataError> {
-        let new_storage_per_byte = self.gas_costs().new_storage_per_byte;
+        let new_storage_per_byte = self.gas_costs().new_storage_per_byte();
         let contract_id = self.internal_contract().copied();
         let (
             SystemRegisters {

--- a/fuel-vm/src/interpreter/blockchain/croo_tests.rs
+++ b/fuel-vm/src/interpreter/blockchain/croo_tests.rs
@@ -65,7 +65,7 @@ fn test_code_root() {
         .storage_contract_insert(&contract_id, &contract)
         .expect("Failed to insert contract");
 
-    let gas_cost = GasCosts::default().croo;
+    let gas_cost = GasCosts::default().croo();
     let ownership_registers = initialize_ownership_registers();
     let SystemRegisters {
         mut pc,
@@ -118,7 +118,7 @@ fn test_code_root_contract_not_found() {
     let mut memory: Memory<MEM_SIZE> = vec![1u8; MEM_SIZE].try_into().unwrap();
     memory[0..ContractId::LEN].copy_from_slice(contract_id.as_slice());
 
-    let gas_cost = GasCosts::default().croo;
+    let gas_cost = GasCosts::default().croo();
     let ownership_registers = initialize_ownership_registers();
     let SystemRegisters {
         mut pc,
@@ -165,7 +165,7 @@ fn test_code_root_contract_not_in_inputs() {
     let mut memory: Memory<MEM_SIZE> = vec![1u8; MEM_SIZE].try_into().unwrap();
     memory[0..ContractId::LEN].copy_from_slice(contract_id.as_slice());
 
-    let gas_cost = GasCosts::default().croo;
+    let gas_cost = GasCosts::default().croo();
     let ownership_registers = initialize_ownership_registers();
     let SystemRegisters {
         mut pc,

--- a/fuel-vm/src/interpreter/contract.rs
+++ b/fuel-vm/src/interpreter/contract.rs
@@ -95,7 +95,7 @@ where
         b: Word,
         c: Word,
     ) -> IoResult<(), S::DataError> {
-        let new_storage_gas_per_byte = self.gas_costs().new_storage_per_byte;
+        let new_storage_gas_per_byte = self.gas_costs().new_storage_per_byte();
         let tx_offset = self.tx_offset();
         let (
             SystemRegisters {
@@ -135,7 +135,7 @@ where
         d: Word,
     ) -> IoResult<(), S::DataError> {
         let tx_offset = self.tx_offset();
-        let new_storage_gas_per_byte = self.gas_costs().new_storage_per_byte;
+        let new_storage_gas_per_byte = self.gas_costs().new_storage_per_byte();
         let (
             SystemRegisters {
                 cgas,

--- a/fuel-vm/src/interpreter/debug.rs
+++ b/fuel-vm/src/interpreter/debug.rs
@@ -95,8 +95,8 @@ fn breakpoint_script() {
         .expect("failed to generate checked tx")
         .into_ready(
             gas_price,
-            &consensus_params.gas_costs,
-            &consensus_params.fee_params,
+            consensus_params.gas_costs(),
+            consensus_params.fee_params(),
         )
         .unwrap();
 
@@ -174,8 +174,8 @@ fn single_stepping() {
         .expect("failed to generate checked tx")
         .into_ready(
             gas_price,
-            &consensus_params.gas_costs,
-            &consensus_params.fee_params,
+            consensus_params.gas_costs(),
+            consensus_params.fee_params(),
         )
         .unwrap();
 

--- a/fuel-vm/src/interpreter/executors/instruction.rs
+++ b/fuel-vm/src/interpreter/executors/instruction.rs
@@ -114,7 +114,7 @@ where
 
         match instruction {
             Instruction::ADD(add) => {
-                self.gas_charge(self.gas_costs().add)?;
+                self.gas_charge(self.gas_costs().add())?;
                 let (a, b, c) = add.unpack();
                 self.alu_capture_overflow(
                     a.into(),
@@ -125,7 +125,7 @@ where
             }
 
             Instruction::ADDI(addi) => {
-                self.gas_charge(self.gas_costs().addi)?;
+                self.gas_charge(self.gas_costs().addi())?;
                 let (a, b, imm) = addi.unpack();
                 self.alu_capture_overflow(
                     a.into(),
@@ -136,64 +136,64 @@ where
             }
 
             Instruction::AND(and) => {
-                self.gas_charge(self.gas_costs().and)?;
+                self.gas_charge(self.gas_costs().and())?;
                 let (a, b, c) = and.unpack();
                 self.alu_set(a.into(), r!(b) & r!(c))?;
             }
 
             Instruction::ANDI(andi) => {
-                self.gas_charge(self.gas_costs().andi)?;
+                self.gas_charge(self.gas_costs().andi())?;
                 let (a, b, imm) = andi.unpack();
                 self.alu_set(a.into(), r!(b) & Word::from(imm))?;
             }
 
             Instruction::DIV(div) => {
-                self.gas_charge(self.gas_costs().div)?;
+                self.gas_charge(self.gas_costs().div())?;
                 let (a, b, c) = div.unpack();
                 let c = r!(c);
                 self.alu_error(a.into(), Word::div, r!(b), c, c == 0)?;
             }
 
             Instruction::DIVI(divi) => {
-                self.gas_charge(self.gas_costs().divi)?;
+                self.gas_charge(self.gas_costs().divi())?;
                 let (a, b, imm) = divi.unpack();
                 let imm = Word::from(imm);
                 self.alu_error(a.into(), Word::div, r!(b), imm, imm == 0)?;
             }
 
             Instruction::EQ(eq) => {
-                self.gas_charge(self.gas_costs().eq)?;
+                self.gas_charge(self.gas_costs().eq_())?;
                 let (a, b, c) = eq.unpack();
                 self.alu_set(a.into(), (r!(b) == r!(c)) as Word)?;
             }
 
             Instruction::EXP(exp) => {
-                self.gas_charge(self.gas_costs().exp)?;
+                self.gas_charge(self.gas_costs().exp())?;
                 let (a, b, c) = exp.unpack();
                 self.alu_boolean_overflow(a.into(), alu::exp, r!(b), r!(c))?;
             }
 
             Instruction::EXPI(expi) => {
-                self.gas_charge(self.gas_costs().expi)?;
+                self.gas_charge(self.gas_costs().expi())?;
                 let (a, b, imm) = expi.unpack();
                 let expo = u32::from(imm);
                 self.alu_boolean_overflow(a.into(), Word::overflowing_pow, r!(b), expo)?;
             }
 
             Instruction::GT(gt) => {
-                self.gas_charge(self.gas_costs().gt)?;
+                self.gas_charge(self.gas_costs().gt())?;
                 let (a, b, c) = gt.unpack();
                 self.alu_set(a.into(), (r!(b) > r!(c)) as Word)?;
             }
 
             Instruction::LT(lt) => {
-                self.gas_charge(self.gas_costs().lt)?;
+                self.gas_charge(self.gas_costs().lt())?;
                 let (a, b, c) = lt.unpack();
                 self.alu_set(a.into(), (r!(b) < r!(c)) as Word)?;
             }
 
             Instruction::WDCM(wdcm) => {
-                self.gas_charge(self.gas_costs().wdcm)?;
+                self.gas_charge(self.gas_costs().wdcm())?;
                 let (a, b, c, imm) = wdcm.unpack();
                 let args = wideint::CompareArgs::from_imm(imm)
                     .ok_or(PanicReason::InvalidImmediateValue)?;
@@ -201,7 +201,7 @@ where
             }
 
             Instruction::WQCM(wdcm) => {
-                self.gas_charge(self.gas_costs().wqcm)?;
+                self.gas_charge(self.gas_costs().wqcm())?;
                 let (a, b, c, imm) = wdcm.unpack();
                 let args = wideint::CompareArgs::from_imm(imm)
                     .ok_or(PanicReason::InvalidImmediateValue)?;
@@ -209,7 +209,7 @@ where
             }
 
             Instruction::WDOP(wdop) => {
-                self.gas_charge(self.gas_costs().wdcm)?;
+                self.gas_charge(self.gas_costs().wdcm())?;
                 let (a, b, c, imm) = wdop.unpack();
                 let args = wideint::MathArgs::from_imm(imm)
                     .ok_or(PanicReason::InvalidImmediateValue)?;
@@ -217,7 +217,7 @@ where
             }
 
             Instruction::WQOP(wqop) => {
-                self.gas_charge(self.gas_costs().wqcm)?;
+                self.gas_charge(self.gas_costs().wqcm())?;
                 let (a, b, c, imm) = wqop.unpack();
                 let args = wideint::MathArgs::from_imm(imm)
                     .ok_or(PanicReason::InvalidImmediateValue)?;
@@ -225,7 +225,7 @@ where
             }
 
             Instruction::WDML(wdml) => {
-                self.gas_charge(self.gas_costs().wdml)?;
+                self.gas_charge(self.gas_costs().wdml())?;
                 let (a, b, c, imm) = wdml.unpack();
                 let args = wideint::MulArgs::from_imm(imm)
                     .ok_or(PanicReason::InvalidImmediateValue)?;
@@ -233,7 +233,7 @@ where
             }
 
             Instruction::WQML(wqml) => {
-                self.gas_charge(self.gas_costs().wqml)?;
+                self.gas_charge(self.gas_costs().wqml())?;
                 let (a, b, c, imm) = wqml.unpack();
                 let args = wideint::MulArgs::from_imm(imm)
                     .ok_or(PanicReason::InvalidImmediateValue)?;
@@ -241,7 +241,7 @@ where
             }
 
             Instruction::WDDV(wddv) => {
-                self.gas_charge(self.gas_costs().wddv)?;
+                self.gas_charge(self.gas_costs().wddv())?;
                 let (a, b, c, imm) = wddv.unpack();
                 let args = wideint::DivArgs::from_imm(imm)
                     .ok_or(PanicReason::InvalidImmediateValue)?;
@@ -249,7 +249,7 @@ where
             }
 
             Instruction::WQDV(wqdv) => {
-                self.gas_charge(self.gas_costs().wqdv)?;
+                self.gas_charge(self.gas_costs().wqdv())?;
                 let (a, b, c, imm) = wqdv.unpack();
                 let args = wideint::DivArgs::from_imm(imm)
                     .ok_or(PanicReason::InvalidImmediateValue)?;
@@ -257,40 +257,40 @@ where
             }
 
             Instruction::WDMD(wdmd) => {
-                self.gas_charge(self.gas_costs().wdmd)?;
+                self.gas_charge(self.gas_costs().wdmd())?;
                 let (a, b, c, d) = wdmd.unpack();
                 self.alu_wideint_muldiv_u128(r!(a), r!(b), r!(c), r!(d))?;
             }
 
             Instruction::WQMD(wqmd) => {
-                self.gas_charge(self.gas_costs().wqmd)?;
+                self.gas_charge(self.gas_costs().wqmd())?;
                 let (a, b, c, d) = wqmd.unpack();
                 self.alu_wideint_muldiv_u256(r!(a), r!(b), r!(c), r!(d))?;
             }
 
             Instruction::WDAM(wdam) => {
-                self.gas_charge(self.gas_costs().wdam)?;
+                self.gas_charge(self.gas_costs().wdam())?;
                 let (a, b, c, d) = wdam.unpack();
                 self.alu_wideint_addmod_u128(r!(a), r!(b), r!(c), r!(d))?;
             }
             Instruction::WQAM(wqam) => {
-                self.gas_charge(self.gas_costs().wqam)?;
+                self.gas_charge(self.gas_costs().wqam())?;
                 let (a, b, c, d) = wqam.unpack();
                 self.alu_wideint_addmod_u256(r!(a), r!(b), r!(c), r!(d))?;
             }
             Instruction::WDMM(wdmm) => {
-                self.gas_charge(self.gas_costs().wdmm)?;
+                self.gas_charge(self.gas_costs().wdmm())?;
                 let (a, b, c, d) = wdmm.unpack();
                 self.alu_wideint_mulmod_u128(r!(a), r!(b), r!(c), r!(d))?;
             }
             Instruction::WQMM(wqmm) => {
-                self.gas_charge(self.gas_costs().wqmm)?;
+                self.gas_charge(self.gas_costs().wqmm())?;
                 let (a, b, c, d) = wqmm.unpack();
                 self.alu_wideint_mulmod_u256(r!(a), r!(b), r!(c), r!(d))?;
             }
 
             Instruction::MLOG(mlog) => {
-                self.gas_charge(self.gas_costs().mlog)?;
+                self.gas_charge(self.gas_costs().mlog())?;
                 let (a, b, c) = mlog.unpack();
                 let (lhs, rhs) = (r!(b), r!(c));
                 self.alu_error(
@@ -307,33 +307,33 @@ where
             }
 
             Instruction::MOD(mod_) => {
-                self.gas_charge(self.gas_costs().mod_op)?;
+                self.gas_charge(self.gas_costs().mod_op())?;
                 let (a, b, c) = mod_.unpack();
                 let rhs = r!(c);
                 self.alu_error(a.into(), Word::wrapping_rem, r!(b), rhs, rhs == 0)?;
             }
 
             Instruction::MODI(modi) => {
-                self.gas_charge(self.gas_costs().modi)?;
+                self.gas_charge(self.gas_costs().modi())?;
                 let (a, b, imm) = modi.unpack();
                 let rhs = Word::from(imm);
                 self.alu_error(a.into(), Word::wrapping_rem, r!(b), rhs, rhs == 0)?;
             }
 
             Instruction::MOVE(move_) => {
-                self.gas_charge(self.gas_costs().move_op)?;
+                self.gas_charge(self.gas_costs().move_op())?;
                 let (a, b) = move_.unpack();
                 self.alu_set(a.into(), r!(b))?;
             }
 
             Instruction::MOVI(movi) => {
-                self.gas_charge(self.gas_costs().movi)?;
+                self.gas_charge(self.gas_costs().movi())?;
                 let (a, imm) = movi.unpack();
                 self.alu_set(a.into(), Word::from(imm))?;
             }
 
             Instruction::MROO(mroo) => {
-                self.gas_charge(self.gas_costs().mroo)?;
+                self.gas_charge(self.gas_costs().mroo())?;
                 let (a, b, c) = mroo.unpack();
                 let (lhs, rhs) = (r!(b), r!(c));
                 self.alu_error(
@@ -350,7 +350,7 @@ where
             }
 
             Instruction::MUL(mul) => {
-                self.gas_charge(self.gas_costs().mul)?;
+                self.gas_charge(self.gas_costs().mul())?;
                 let (a, b, c) = mul.unpack();
                 self.alu_capture_overflow(
                     a.into(),
@@ -361,7 +361,7 @@ where
             }
 
             Instruction::MULI(muli) => {
-                self.gas_charge(self.gas_costs().muli)?;
+                self.gas_charge(self.gas_costs().muli())?;
                 let (a, b, imm) = muli.unpack();
                 self.alu_capture_overflow(
                     a.into(),
@@ -372,36 +372,36 @@ where
             }
 
             Instruction::MLDV(mldv) => {
-                self.gas_charge(self.gas_costs().mldv)?;
+                self.gas_charge(self.gas_costs().mldv())?;
                 let (a, b, c, d) = mldv.unpack();
                 self.alu_muldiv(a.into(), r!(b), r!(c), r!(d))?;
             }
 
             Instruction::NOOP(_noop) => {
-                self.gas_charge(self.gas_costs().noop)?;
+                self.gas_charge(self.gas_costs().noop())?;
                 self.alu_clear()?;
             }
 
             Instruction::NOT(not) => {
-                self.gas_charge(self.gas_costs().not)?;
+                self.gas_charge(self.gas_costs().not())?;
                 let (a, b) = not.unpack();
                 self.alu_set(a.into(), !r!(b))?;
             }
 
             Instruction::OR(or) => {
-                self.gas_charge(self.gas_costs().or)?;
+                self.gas_charge(self.gas_costs().or())?;
                 let (a, b, c) = or.unpack();
                 self.alu_set(a.into(), r!(b) | r!(c))?;
             }
 
             Instruction::ORI(ori) => {
-                self.gas_charge(self.gas_costs().ori)?;
+                self.gas_charge(self.gas_costs().ori())?;
                 let (a, b, imm) = ori.unpack();
                 self.alu_set(a.into(), r!(b) | Word::from(imm))?;
             }
 
             Instruction::SLL(sll) => {
-                self.gas_charge(self.gas_costs().sll)?;
+                self.gas_charge(self.gas_costs().sll())?;
                 let (a, b, c) = sll.unpack();
 
                 self.alu_set(
@@ -415,14 +415,14 @@ where
             }
 
             Instruction::SLLI(slli) => {
-                self.gas_charge(self.gas_costs().slli)?;
+                self.gas_charge(self.gas_costs().slli())?;
                 let (a, b, imm) = slli.unpack();
                 let rhs = u32::from(imm);
                 self.alu_set(a.into(), r!(b).checked_shl(rhs).unwrap_or_default())?;
             }
 
             Instruction::SRL(srl) => {
-                self.gas_charge(self.gas_costs().srl)?;
+                self.gas_charge(self.gas_costs().srl())?;
                 let (a, b, c) = srl.unpack();
                 self.alu_set(
                     a.into(),
@@ -435,14 +435,14 @@ where
             }
 
             Instruction::SRLI(srli) => {
-                self.gas_charge(self.gas_costs().srli)?;
+                self.gas_charge(self.gas_costs().srli())?;
                 let (a, b, imm) = srli.unpack();
                 let rhs = u32::from(imm);
                 self.alu_set(a.into(), r!(b).checked_shr(rhs).unwrap_or_default())?;
             }
 
             Instruction::SUB(sub) => {
-                self.gas_charge(self.gas_costs().sub)?;
+                self.gas_charge(self.gas_costs().sub())?;
                 let (a, b, c) = sub.unpack();
                 self.alu_capture_overflow(
                     a.into(),
@@ -453,7 +453,7 @@ where
             }
 
             Instruction::SUBI(subi) => {
-                self.gas_charge(self.gas_costs().subi)?;
+                self.gas_charge(self.gas_costs().subi())?;
                 let (a, b, imm) = subi.unpack();
                 self.alu_capture_overflow(
                     a.into(),
@@ -464,25 +464,25 @@ where
             }
 
             Instruction::XOR(xor) => {
-                self.gas_charge(self.gas_costs().xor)?;
+                self.gas_charge(self.gas_costs().xor())?;
                 let (a, b, c) = xor.unpack();
                 self.alu_set(a.into(), r!(b) ^ r!(c))?;
             }
 
             Instruction::XORI(xori) => {
-                self.gas_charge(self.gas_costs().xori)?;
+                self.gas_charge(self.gas_costs().xori())?;
                 let (a, b, imm) = xori.unpack();
                 self.alu_set(a.into(), r!(b) ^ Word::from(imm))?;
             }
 
             Instruction::JI(ji) => {
-                self.gas_charge(self.gas_costs().ji)?;
+                self.gas_charge(self.gas_costs().ji())?;
                 let imm = ji.unpack();
                 self.jump(JumpArgs::new(JumpMode::Absolute).to_address(imm.into()))?;
             }
 
             Instruction::JNEI(jnei) => {
-                self.gas_charge(self.gas_costs().jnei)?;
+                self.gas_charge(self.gas_costs().jnei())?;
                 let (a, b, imm) = jnei.unpack();
                 self.jump(
                     JumpArgs::new(JumpMode::Absolute)
@@ -492,7 +492,7 @@ where
             }
 
             Instruction::JNZI(jnzi) => {
-                self.gas_charge(self.gas_costs().jnzi)?;
+                self.gas_charge(self.gas_costs().jnzi())?;
                 let (a, imm) = jnzi.unpack();
                 self.jump(
                     JumpArgs::new(JumpMode::Absolute)
@@ -502,13 +502,13 @@ where
             }
 
             Instruction::JMP(jmp) => {
-                self.gas_charge(self.gas_costs().jmp)?;
+                self.gas_charge(self.gas_costs().jmp())?;
                 let a = jmp.unpack();
                 self.jump(JumpArgs::new(JumpMode::Absolute).to_address(r!(a)))?;
             }
 
             Instruction::JNE(jne) => {
-                self.gas_charge(self.gas_costs().jne)?;
+                self.gas_charge(self.gas_costs().jne())?;
                 let (a, b, c) = jne.unpack();
                 self.jump(
                     JumpArgs::new(JumpMode::Absolute)
@@ -518,7 +518,7 @@ where
             }
 
             Instruction::JMPF(jmpf) => {
-                self.gas_charge(self.gas_costs().jmpf)?;
+                self.gas_charge(self.gas_costs().jmpf())?;
                 let (a, offset) = jmpf.unpack();
                 self.jump(
                     JumpArgs::new(JumpMode::RelativeForwards)
@@ -528,7 +528,7 @@ where
             }
 
             Instruction::JMPB(jmpb) => {
-                self.gas_charge(self.gas_costs().jmpb)?;
+                self.gas_charge(self.gas_costs().jmpb())?;
                 let (a, offset) = jmpb.unpack();
                 self.jump(
                     JumpArgs::new(JumpMode::RelativeBackwards)
@@ -538,7 +538,7 @@ where
             }
 
             Instruction::JNZF(jnzf) => {
-                self.gas_charge(self.gas_costs().jnzf)?;
+                self.gas_charge(self.gas_costs().jnzf())?;
                 let (a, b, offset) = jnzf.unpack();
                 self.jump(
                     JumpArgs::new(JumpMode::RelativeForwards)
@@ -549,7 +549,7 @@ where
             }
 
             Instruction::JNZB(jnzb) => {
-                self.gas_charge(self.gas_costs().jnzb)?;
+                self.gas_charge(self.gas_costs().jnzb())?;
                 let (a, b, offset) = jnzb.unpack();
                 self.jump(
                     JumpArgs::new(JumpMode::RelativeBackwards)
@@ -560,7 +560,7 @@ where
             }
 
             Instruction::JNEF(jnef) => {
-                self.gas_charge(self.gas_costs().jnef)?;
+                self.gas_charge(self.gas_costs().jnef())?;
                 let (a, b, c, offset) = jnef.unpack();
                 self.jump(
                     JumpArgs::new(JumpMode::RelativeForwards)
@@ -571,7 +571,7 @@ where
             }
 
             Instruction::JNEB(jneb) => {
-                self.gas_charge(self.gas_costs().jneb)?;
+                self.gas_charge(self.gas_costs().jneb())?;
                 let (a, b, c, offset) = jneb.unpack();
                 self.jump(
                     JumpArgs::new(JumpMode::RelativeBackwards)
@@ -582,7 +582,7 @@ where
             }
 
             Instruction::RET(ret) => {
-                self.gas_charge(self.gas_costs().ret)?;
+                self.gas_charge(self.gas_costs().ret())?;
                 let a = ret.unpack();
                 let ra = r!(a);
                 self.ret(ra)?;
@@ -592,12 +592,12 @@ where
             Instruction::RETD(retd) => {
                 let (a, b) = retd.unpack();
                 let len = r!(b);
-                self.dependent_gas_charge(self.gas_costs().retd, len)?;
+                self.dependent_gas_charge(self.gas_costs().retd(), len)?;
                 return Ok(self.ret_data(r!(a), len).map(ExecuteState::ReturnData)?)
             }
 
             Instruction::RVRT(rvrt) => {
-                self.gas_charge(self.gas_costs().rvrt)?;
+                self.gas_charge(self.gas_costs().rvrt())?;
                 let a = rvrt.unpack();
                 let ra = r!(a);
                 self.revert(ra)?;
@@ -606,72 +606,72 @@ where
 
             Instruction::SMO(smo) => {
                 let (a, b, c, d) = smo.unpack();
-                self.dependent_gas_charge(self.gas_costs().smo, r!(c))?;
+                self.dependent_gas_charge(self.gas_costs().smo(), r!(c))?;
                 self.message_output(r!(a), r!(b), r!(c), r!(d))?;
             }
 
             Instruction::ALOC(aloc) => {
-                self.gas_charge(self.gas_costs().aloc)?;
+                self.gas_charge(self.gas_costs().aloc())?;
                 let a = aloc.unpack();
                 self.malloc(r!(a))?;
             }
 
             Instruction::CFEI(cfei) => {
-                self.gas_charge(self.gas_costs().cfei)?;
+                self.gas_charge(self.gas_costs().cfei())?;
                 let imm = cfei.unpack();
                 self.stack_pointer_overflow(Word::overflowing_add, imm.into())?;
             }
 
             Instruction::CFE(cfe) => {
-                self.gas_charge(self.gas_costs().cfei)?;
+                self.gas_charge(self.gas_costs().cfei())?;
                 let a = cfe.unpack();
                 self.stack_pointer_overflow(Word::overflowing_add, r!(a))?;
             }
 
             Instruction::CFSI(cfsi) => {
-                self.gas_charge(self.gas_costs().cfsi)?;
+                self.gas_charge(self.gas_costs().cfsi())?;
                 let imm = cfsi.unpack();
                 self.stack_pointer_overflow(Word::overflowing_sub, imm.into())?;
             }
 
             Instruction::CFS(cfs) => {
-                self.gas_charge(self.gas_costs().cfsi)?;
+                self.gas_charge(self.gas_costs().cfsi())?;
                 let a = cfs.unpack();
                 self.stack_pointer_overflow(Word::overflowing_sub, r!(a))?;
             }
 
             Instruction::PSHL(pshl) => {
-                self.gas_charge(self.gas_costs().pshl)?;
+                self.gas_charge(self.gas_costs().pshl())?;
                 let bitmask = pshl.unpack();
                 self.push_selected_registers(ProgramRegistersSegment::Low, bitmask)?;
             }
 
             Instruction::PSHH(pshh) => {
-                self.gas_charge(self.gas_costs().pshh)?;
+                self.gas_charge(self.gas_costs().pshh())?;
                 let bitmask = pshh.unpack();
                 self.push_selected_registers(ProgramRegistersSegment::High, bitmask)?;
             }
 
             Instruction::POPL(popl) => {
-                self.gas_charge(self.gas_costs().popl)?;
+                self.gas_charge(self.gas_costs().popl())?;
                 let bitmask = popl.unpack();
                 self.pop_selected_registers(ProgramRegistersSegment::Low, bitmask)?;
             }
 
             Instruction::POPH(poph) => {
-                self.gas_charge(self.gas_costs().poph)?;
+                self.gas_charge(self.gas_costs().poph())?;
                 let bitmask = poph.unpack();
                 self.pop_selected_registers(ProgramRegistersSegment::High, bitmask)?;
             }
 
             Instruction::LB(lb) => {
-                self.gas_charge(self.gas_costs().lb)?;
+                self.gas_charge(self.gas_costs().lb())?;
                 let (a, b, imm) = lb.unpack();
                 self.load_byte(a.into(), r!(b), imm.into())?;
             }
 
             Instruction::LW(lw) => {
-                self.gas_charge(self.gas_costs().lw)?;
+                self.gas_charge(self.gas_costs().lw())?;
                 let (a, b, imm) = lw.unpack();
                 self.load_word(a.into(), r!(b), imm.into())?;
             }
@@ -679,70 +679,70 @@ where
             Instruction::MCL(mcl) => {
                 let (a, b) = mcl.unpack();
                 let len = r!(b);
-                self.dependent_gas_charge(self.gas_costs().mcl, len)?;
+                self.dependent_gas_charge(self.gas_costs().mcl(), len)?;
                 self.memclear(r!(a), len)?;
             }
 
             Instruction::MCLI(mcli) => {
                 let (a, imm) = mcli.unpack();
                 let len = Word::from(imm);
-                self.dependent_gas_charge(self.gas_costs().mcli, len)?;
+                self.dependent_gas_charge(self.gas_costs().mcli(), len)?;
                 self.memclear(r!(a), len)?;
             }
 
             Instruction::MCP(mcp) => {
                 let (a, b, c) = mcp.unpack();
                 let len = r!(c);
-                self.dependent_gas_charge(self.gas_costs().mcp, len)?;
+                self.dependent_gas_charge(self.gas_costs().mcp(), len)?;
                 self.memcopy(r!(a), r!(b), len)?;
             }
 
             Instruction::MCPI(mcpi) => {
                 let (a, b, imm) = mcpi.unpack();
                 let len = imm.into();
-                self.dependent_gas_charge(self.gas_costs().mcpi, len)?;
+                self.dependent_gas_charge(self.gas_costs().mcpi(), len)?;
                 self.memcopy(r!(a), r!(b), len)?;
             }
 
             Instruction::MEQ(meq) => {
                 let (a, b, c, d) = meq.unpack();
                 let len = r!(d);
-                self.dependent_gas_charge(self.gas_costs().meq, len)?;
+                self.dependent_gas_charge(self.gas_costs().meq(), len)?;
                 self.memeq(a.into(), r!(b), r!(c), len)?;
             }
 
             Instruction::SB(sb) => {
-                self.gas_charge(self.gas_costs().sb)?;
+                self.gas_charge(self.gas_costs().sb())?;
                 let (a, b, imm) = sb.unpack();
                 self.store_byte(r!(a), r!(b), imm.into())?;
             }
 
             Instruction::SW(sw) => {
-                self.gas_charge(self.gas_costs().sw)?;
+                self.gas_charge(self.gas_costs().sw())?;
                 let (a, b, imm) = sw.unpack();
                 self.store_word(r!(a), r!(b), imm.into())?;
             }
 
             Instruction::BAL(bal) => {
-                self.gas_charge(self.gas_costs().bal)?;
+                self.gas_charge(self.gas_costs().bal())?;
                 let (a, b, c) = bal.unpack();
                 self.contract_balance(a.into(), r!(b), r!(c))?;
             }
 
             Instruction::BHEI(bhei) => {
-                self.gas_charge(self.gas_costs().bhei)?;
+                self.gas_charge(self.gas_costs().bhei())?;
                 let a = bhei.unpack();
                 self.block_height(a.into())?;
             }
 
             Instruction::BHSH(bhsh) => {
-                self.gas_charge(self.gas_costs().bhsh)?;
+                self.gas_charge(self.gas_costs().bhsh())?;
                 let (a, b) = bhsh.unpack();
                 self.block_hash(r!(a), r!(b))?;
             }
 
             Instruction::BURN(burn) => {
-                self.gas_charge(self.gas_costs().burn)?;
+                self.gas_charge(self.gas_costs().burn())?;
                 let (a, b) = burn.unpack();
                 self.burn(r!(a), r!(b))?;
             }
@@ -756,7 +756,7 @@ where
             }
 
             Instruction::CB(cb) => {
-                self.gas_charge(self.gas_costs().cb)?;
+                self.gas_charge(self.gas_costs().cb())?;
                 let a = cb.unpack();
                 self.block_proposer(r!(a))?;
             }
@@ -784,73 +784,73 @@ where
             }
 
             Instruction::LOG(log) => {
-                self.gas_charge(self.gas_costs().log)?;
+                self.gas_charge(self.gas_costs().log())?;
                 let (a, b, c, d) = log.unpack();
                 self.log(r!(a), r!(b), r!(c), r!(d))?;
             }
 
             Instruction::LOGD(logd) => {
                 let (a, b, c, d) = logd.unpack();
-                self.dependent_gas_charge(self.gas_costs().logd, r!(d))?;
+                self.dependent_gas_charge(self.gas_costs().logd(), r!(d))?;
                 self.log_data(r!(a), r!(b), r!(c), r!(d))?;
             }
 
             Instruction::MINT(mint) => {
-                self.gas_charge(self.gas_costs().mint)?;
+                self.gas_charge(self.gas_costs().mint())?;
                 let (a, b) = mint.unpack();
                 self.mint(r!(a), r!(b))?;
             }
 
             Instruction::SCWQ(scwq) => {
                 let (a, b, c) = scwq.unpack();
-                self.dependent_gas_charge(self.gas_costs().scwq, r!(c))?;
+                self.dependent_gas_charge(self.gas_costs().scwq(), r!(c))?;
                 self.state_clear_qword(r!(a), b.into(), r!(c))?;
             }
 
             Instruction::SRW(srw) => {
-                self.gas_charge(self.gas_costs().srw)?;
+                self.gas_charge(self.gas_costs().srw())?;
                 let (a, b, c) = srw.unpack();
                 self.state_read_word(a.into(), b.into(), r!(c))?;
             }
 
             Instruction::SRWQ(srwq) => {
                 let (a, b, c, d) = srwq.unpack();
-                self.dependent_gas_charge(self.gas_costs().srwq, r!(d))?;
+                self.dependent_gas_charge(self.gas_costs().srwq(), r!(d))?;
                 self.state_read_qword(r!(a), b.into(), r!(c), r!(d))?;
             }
 
             Instruction::SWW(sww) => {
-                self.gas_charge(self.gas_costs().sww)?;
+                self.gas_charge(self.gas_costs().sww())?;
                 let (a, b, c) = sww.unpack();
                 self.state_write_word(r!(a), b.into(), r!(c))?;
             }
 
             Instruction::SWWQ(swwq) => {
                 let (a, b, c, d) = swwq.unpack();
-                self.dependent_gas_charge(self.gas_costs().swwq, r!(d))?;
+                self.dependent_gas_charge(self.gas_costs().swwq(), r!(d))?;
                 self.state_write_qword(r!(a), b.into(), r!(c), r!(d))?;
             }
 
             Instruction::TIME(time) => {
-                self.gas_charge(self.gas_costs().time)?;
+                self.gas_charge(self.gas_costs().time())?;
                 let (a, b) = time.unpack();
                 self.timestamp(a.into(), r!(b))?;
             }
 
             Instruction::ECK1(eck1) => {
-                self.gas_charge(self.gas_costs().eck1)?;
+                self.gas_charge(self.gas_costs().eck1())?;
                 let (a, b, c) = eck1.unpack();
                 self.secp256k1_recover(r!(a), r!(b), r!(c))?;
             }
 
             Instruction::ECR1(ecr1) => {
-                self.gas_charge(self.gas_costs().ecr1)?;
+                self.gas_charge(self.gas_costs().ecr1())?;
                 let (a, b, c) = ecr1.unpack();
                 self.secp256r1_recover(r!(a), r!(b), r!(c))?;
             }
 
             Instruction::ED19(ed19) => {
-                self.gas_charge(self.gas_costs().ed19)?;
+                self.gas_charge(self.gas_costs().ed19())?;
                 let (a, b, c) = ed19.unpack();
                 self.ed25519_verify(r!(a), r!(b), r!(c))?;
             }
@@ -858,43 +858,43 @@ where
             Instruction::K256(k256) => {
                 let (a, b, c) = k256.unpack();
                 let len = r!(c);
-                self.dependent_gas_charge(self.gas_costs().k256, len)?;
+                self.dependent_gas_charge(self.gas_costs().k256(), len)?;
                 self.keccak256(r!(a), r!(b), len)?;
             }
 
             Instruction::S256(s256) => {
                 let (a, b, c) = s256.unpack();
                 let len = r!(c);
-                self.dependent_gas_charge(self.gas_costs().s256, len)?;
+                self.dependent_gas_charge(self.gas_costs().s256(), len)?;
                 self.sha256(r!(a), r!(b), len)?;
             }
 
             Instruction::FLAG(flag) => {
-                self.gas_charge(self.gas_costs().flag)?;
+                self.gas_charge(self.gas_costs().flag())?;
                 let a = flag.unpack();
                 self.set_flag(r!(a))?;
             }
 
             Instruction::GM(gm) => {
-                self.gas_charge(self.gas_costs().gm)?;
+                self.gas_charge(self.gas_costs().gm())?;
                 let (a, imm) = gm.unpack();
                 self.metadata(a.into(), imm.into())?;
             }
 
             Instruction::GTF(gtf) => {
-                self.gas_charge(self.gas_costs().gtf)?;
+                self.gas_charge(self.gas_costs().gtf())?;
                 let (a, b, imm) = gtf.unpack();
                 self.get_transaction_field(a.into(), r!(b), imm.into())?;
             }
 
             Instruction::TR(tr) => {
-                self.gas_charge(self.gas_costs().tr)?;
+                self.gas_charge(self.gas_costs().tr())?;
                 let (a, b, c) = tr.unpack();
                 self.transfer(r!(a), r!(b), r!(c))?;
             }
 
             Instruction::TRO(tro) => {
-                self.gas_charge(self.gas_costs().tro)?;
+                self.gas_charge(self.gas_costs().tro())?;
                 let (a, b, c, d) = tro.unpack();
                 self.transfer_output(r!(a), r!(b), r!(c), r!(d))?;
             }

--- a/fuel-vm/src/interpreter/executors/instruction/tests/reserved_registers.rs
+++ b/fuel-vm/src/interpreter/executors/instruction/tests/reserved_registers.rs
@@ -50,10 +50,8 @@ fn cant_write_to_reserved_registers(raw_random_instruction: u32) -> TestResult {
     }
 
     let fee_params = FeeParameters::default().with_gas_price_factor(1);
-    let consensus_params = ConsensusParameters {
-        fee_params,
-        ..Default::default()
-    };
+    let mut consensus_params = ConsensusParameters::default();
+    consensus_params.set_fee_params(fee_params);
 
     let mut vm = Interpreter::<_, _>::with_storage(
         MemoryStorage::default(),

--- a/fuel-vm/src/interpreter/flow.rs
+++ b/fuel-vm/src/interpreter/flow.rs
@@ -368,8 +368,8 @@ where
             asset_id_mem_address,
             amount_of_gas_to_forward,
         };
-        let gas_cost = self.gas_costs().call;
-        let new_storage_gas_per_byte = self.gas_costs().new_storage_per_byte;
+        let gas_cost = self.gas_costs().call();
+        let new_storage_gas_per_byte = self.gas_costs().new_storage_per_byte();
         // Charge only for the `base` execution.
         // We will charge for the frame size in the `prepare_call`.
         self.gas_charge(gas_cost.base())?;

--- a/fuel-vm/src/interpreter/internal/tests.rs
+++ b/fuel-vm/src/interpreter/internal/tests.rs
@@ -37,7 +37,7 @@ fn external_balance() {
     let height = Default::default();
     let gas_price = 0;
     let gas_costs = GasCosts::default();
-    let fee_params = ConsensusParameters::standard().fee_params;
+    let fee_params = *ConsensusParameters::standard().fee_params();
 
     let script = op::ret(0x01).to_bytes().to_vec();
     let balances = vec![(rng.gen(), 100), (rng.gen(), 500)];
@@ -132,7 +132,7 @@ fn variable_output_updates_in_memory() {
         .into_ready(
             zero_gas_price,
             &GasCosts::default(),
-            &consensus_params.fee_params,
+            consensus_params.fee_params(),
         )
         .unwrap();
 

--- a/fuel-vm/src/interpreter/memory/tests.rs
+++ b/fuel-vm/src/interpreter/memory/tests.rs
@@ -18,10 +18,8 @@ fn memcopy() {
     let tx_params = TxParameters::default().with_max_gas_per_tx(Word::MAX / 2);
     let zero_gas_price = 0;
 
-    let consensus_params = ConsensusParameters {
-        tx_params,
-        ..Default::default()
-    };
+    let mut consensus_params = ConsensusParameters::default();
+    consensus_params.set_tx_params(tx_params);
 
     let mut vm = Interpreter::<_, _>::with_storage(
         MemoryStorage::default(),
@@ -37,8 +35,8 @@ fn memcopy() {
         .expect("default tx should produce a valid checked transaction")
         .into_ready(
             zero_gas_price,
-            &consensus_params.gas_costs,
-            &consensus_params.fee_params,
+            consensus_params.gas_costs(),
+            consensus_params.fee_params(),
         )
         .unwrap();
 
@@ -102,8 +100,8 @@ fn memrange() {
         .expect("Empty script should be valid")
         .into_ready(
             gas_price,
-            &consensus_params.gas_costs,
-            &consensus_params.fee_params,
+            consensus_params.gas_costs(),
+            consensus_params.fee_params(),
         )
         .unwrap();
     let mut vm = Interpreter::<_, _>::with_memory_storage();
@@ -140,8 +138,8 @@ fn stack_alloc_ownership() {
         .expect("Empty script should be valid")
         .into_ready(
             gas_price,
-            &consensus_params.gas_costs,
-            &consensus_params.fee_params,
+            consensus_params.gas_costs(),
+            consensus_params.fee_params(),
         )
         .unwrap();
     vm.init_script(tx).expect("Failed to init VM");

--- a/fuel-vm/src/tests/blockchain.rs
+++ b/fuel-vm/src/tests/blockchain.rs
@@ -367,12 +367,12 @@ fn ldc__gas_cost_is_not_dependent_on_rC() {
     let mut client = MemoryClient::default();
 
     let gas_costs = client.gas_costs();
-    let ldc_cost = gas_costs.ldc;
+    let ldc_cost = gas_costs.ldc();
     let ldc_dep_len = match ldc_cost {
         DependentCost::LightOperation { units_per_gas, .. } => units_per_gas,
         DependentCost::HeavyOperation { gas_per_unit, .. } => gas_per_unit,
     };
-    let noop_cost = gas_costs.noop;
+    let noop_cost = gas_costs.noop();
 
     let contract_size = 1000;
     let offset = 0;
@@ -472,7 +472,7 @@ fn ldc__offset_affects_read_code() {
     let mut client = MemoryClient::default();
 
     let gas_costs = client.gas_costs();
-    let noop_cost = gas_costs.noop;
+    let noop_cost = gas_costs.noop();
 
     let number_of_opcodes = 25;
     let offset = 0;
@@ -504,7 +504,7 @@ fn ldc__cost_is_proportional_to_total_contracts_size_not_rC() {
     let mut client = MemoryClient::default();
 
     let gas_costs = client.gas_costs();
-    let ldc_cost = gas_costs.ldc;
+    let ldc_cost = gas_costs.ldc();
     let ldc_dep_len = match ldc_cost {
         DependentCost::LightOperation { units_per_gas, .. } => units_per_gas,
         DependentCost::HeavyOperation { gas_per_unit, .. } => gas_per_unit,

--- a/fuel-vm/src/tests/blockchain.rs
+++ b/fuel-vm/src/tests/blockchain.rs
@@ -701,10 +701,8 @@ fn ldc_reason_helper(cmd: Vec<Instruction>, expected_reason: PanicReason) {
     // make gas costs free
     let gas_costs = GasCosts::default();
 
-    let consensus_params = ConsensusParameters {
-        gas_costs,
-        ..Default::default()
-    };
+    let mut consensus_params = ConsensusParameters::default();
+    consensus_params.set_gas_costs(gas_costs);
 
     let interpreter_params = InterpreterParams::new(gas_price, &consensus_params);
 

--- a/fuel-vm/src/tests/external.rs
+++ b/fuel-vm/src/tests/external.rs
@@ -32,7 +32,7 @@ impl ::fuel_vm::interpreter::EcalHandler for NoopEcal {
         _: RegId,
         _: RegId,
     ) -> ::fuel_vm::error::SimpleResult<()> {
-        vm.gas_charge(vm.gas_costs().noop)
+        vm.gas_charge(vm.gas_costs().noop())
     }
 }
 

--- a/fuel-vm/src/tests/gas_factor.rs
+++ b/fuel-vm/src/tests/gas_factor.rs
@@ -49,11 +49,9 @@ fn gas_factor_rounds_correctly() {
 
     let profiler = GasProfiler::default();
 
-    let consensus_params = ConsensusParameters {
-        fee_params,
-        gas_costs,
-        ..ConsensusParameters::standard()
-    };
+    let mut consensus_params = ConsensusParameters::standard();
+    consensus_params.set_gas_costs(gas_costs);
+    consensus_params.set_fee_params(fee_params);
 
     let interpreter_params = InterpreterParams::new(gas_price, &consensus_params);
     let storage = MemoryStorage::default();

--- a/fuel-vm/src/tests/limits.rs
+++ b/fuel-vm/src/tests/limits.rs
@@ -25,7 +25,7 @@ fn cannot_exceed_max_inputs() {
         vec![op::ret(RegId::ONE)].into_iter().collect(),
         vec![],
     );
-    for _ in 0..=params.tx_params.max_inputs {
+    for _ in 0..=params.tx_params().max_inputs {
         script.add_input(Input::coin_signed(
             rng.gen(),
             rng.gen(),
@@ -50,7 +50,7 @@ fn cannot_exceed_max_outputs() {
         vec![op::ret(RegId::ONE)].into_iter().collect(),
         vec![],
     );
-    for _ in 0..=params.tx_params.max_outputs {
+    for _ in 0..=params.tx_params().max_outputs {
         script.add_output(Output::variable(rng.gen(), rng.gen(), rng.gen()));
     }
     script
@@ -68,7 +68,7 @@ fn cannot_exceed_max_witnesses() {
         vec![op::ret(RegId::ONE)].into_iter().collect(),
         vec![],
     );
-    for _ in 0..=params.tx_params.max_witnesses {
+    for _ in 0..=params.tx_params().max_witnesses {
         script.add_witness(Witness::from(vec![rng.gen::<u8>(); 1]));
     }
     script

--- a/fuel-vm/src/tests/metadata.rs
+++ b/fuel-vm/src/tests/metadata.rs
@@ -349,7 +349,7 @@ fn get_transaction_fields() {
         1_500,
         rng.gen(),
         rng.gen(),
-        gas_costs.ret,
+        gas_costs.ret(),
         predicate.clone(),
         predicate_data.clone(),
     );
@@ -373,7 +373,7 @@ fn get_transaction_fields() {
         owner,
         7_500,
         rng.gen(),
-        gas_costs.ret,
+        gas_costs.ret(),
         m_data.clone(),
         m_predicate.clone(),
         m_predicate_data.clone(),

--- a/fuel-vm/src/tests/outputs.rs
+++ b/fuel-vm/src/tests/outputs.rs
@@ -168,6 +168,7 @@ fn correct_change_is_provided_for_coin_outputs_create() {
         context.get_chain_id(),
         context.get_gas_costs().to_owned(),
         *context.get_base_asset_id(),
+        context.get_block_gas_limit(),
     );
     let create = create
         .into_checked_basic(context.get_block_height(), &consensus_params)

--- a/fuel-vm/src/tests/test_helpers.rs
+++ b/fuel-vm/src/tests/test_helpers.rs
@@ -44,7 +44,7 @@ pub fn run_script(script: Vec<Instruction>) -> Vec<Receipt> {
             SecretKey::random(&mut rng),
             rng.gen(),
             arb_max_fee,
-            consensus_params.base_asset_id,
+            *consensus_params.base_asset_id(),
             Default::default(),
         )
         .finalize()

--- a/fuel-vm/src/tests/validation.rs
+++ b/fuel-vm/src/tests/validation.rs
@@ -63,7 +63,7 @@ fn malleable_fields_do_not_affect_validity() {
     let params = ConsensusParameters::default();
 
     let tx_size_ptr =
-        32 + (params.tx_params.max_inputs as usize * (AssetId::LEN + WORD_SIZE));
+        32 + (params.tx_params().max_inputs as usize * (AssetId::LEN + WORD_SIZE));
     let tx_start_ptr = tx_size_ptr + 8;
 
     let tx = TransactionBuilder::script(
@@ -114,7 +114,7 @@ fn malleable_fields_do_not_affect_validity() {
         ]
         .into_iter()
         .collect(),
-        params.chain_id.to_be_bytes().to_vec(),
+        params.chain_id().to_be_bytes().to_vec(),
     )
     .add_unsigned_coin_input(
         SecretKey::random(rng),
@@ -127,7 +127,7 @@ fn malleable_fields_do_not_affect_validity() {
     .finalize();
 
     let run_tx = |tx: Script| {
-        let original_id = tx.id(&params.chain_id);
+        let original_id = tx.id(&params.chain_id());
 
         let vm = Interpreter::<_, Script>::with_memory_storage();
         let mut client = MemoryClient::from_txtor(vm.into());

--- a/fuel-vm/src/util.rs
+++ b/fuel-vm/src/util.rs
@@ -314,12 +314,12 @@ pub mod test_helpers {
         }
 
         pub fn with_fee_params(&mut self, fee_params: FeeParameters) -> &mut TestBuilder {
-            self.consensus_params.fee_params = fee_params;
+            self.consensus_params.set_fee_params(fee_params);
             self
         }
 
         pub fn base_asset_id(&mut self, base_asset_id: AssetId) -> &mut TestBuilder {
-            self.consensus_params.base_asset_id = base_asset_id;
+            self.consensus_params.set_base_asset_id(base_asset_id);
             self
         }
 
@@ -358,6 +358,10 @@ pub mod test_helpers {
 
         pub fn get_base_asset_id(&self) -> &AssetId {
             self.consensus_params.base_asset_id()
+        }
+
+        pub fn get_block_gas_limit(&self) -> u64 {
+            self.consensus_params.block_gas_limit()
         }
 
         pub fn get_chain_id(&self) -> ChainId {


### PR DESCRIPTION
Related https://github.com/FuelLabs/fuel-core/issues/1753

Wrapped `ConsensusParameters` and `GasCosts` into an enum to support versioning.
Moved `block_gas_limit` from `fuel_core_chain_config::ChainConfig` to `ConsensusPataremeters`.
Reduced default `MAX_SIZE` to be 110kb - related https://github.com/FuelLabs/fuel-core/pull/1761.
Reduced default `MAX_CONTRACT_SIZE` to be 100kb - related https://github.com/FuelLabs/fuel-core/pull/1761.
