### PR TITLE
Release v0.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.48.0]
+
 ### Added
 
 - [#705](https://github.com/FuelLabs/fuel-vm/pull/705): Added `privileged_address` to the `ConsensusParameters` for permissioned operations(like upgrade of the network).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,17 +18,17 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.47.1"
+version = "0.48.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.47.1", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.47.1", path = "fuel-crypto", default-features = false }
-fuel-derive = { version = "0.47.1", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.47.1", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.47.1", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.47.1", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.47.1", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.47.1", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.48.0", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.48.0", path = "fuel-crypto", default-features = false }
+fuel-derive = { version = "0.48.0", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.48.0", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.48.0", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.48.0", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.48.0", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.48.0", path = "fuel-vm", default-features = false }
 bitflags = "2"
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
## Version v0.48.0

### Added

- [#705](https://github.com/FuelLabs/fuel-vm/pull/705): Added `privileged_address` to the `ConsensusParameters` for permissioned operations(like upgrade of the network).
- [#648](https://github.com/FuelLabs/fuel-vm/pull/648): Added support for generating proofs for Sparse Merkle Trees (SMTs) and proof verification. Proofs can be used to attest to the inclusion or exclusion of data from the set.

### Changed

#### Breaking

- [#709](https://github.com/FuelLabs/fuel-vm/pull/709): Removed `bytecode_length` from the `Create` transaction.
- [#706](https://github.com/FuelLabs/fuel-vm/pull/706): Unified `Create` and `Script` logic via `ChargeableTransaction`. The change is breaking because affects JSON serialization and deserialization. Now `Script` and `Create` transactions have `body` fields that include unique transactions.
- [#703](https://github.com/FuelLabs/fuel-vm/pull/703): Reshuffled fields `Script` and `Create` transactions to unify part used by all chargeable transactions. It breaks the serialization and deserialization and requires adoption on the SDK side.
- [#708](https://github.com/FuelLabs/fuel-vm/pull/708): Hidden `Default` params under the "test-helper" feature to avoid accidental use in production code. It is a huge breaking change for any code that has used them before in production, and instead, it should be fetched from the network. In the case of tests simply use the "test-helper" feature in your `[dev-dependencies]` section.
- [#702](https://github.com/FuelLabs/fuel-vm/pull/702): Wrapped `FeeParameters`, `PredicateParameters`, `TxParameters`, `ScriptParameters` and `ContractParameters` into an enum to support versioning. 
- [#701](https://github.com/FuelLabs/fuel-vm/pull/701): Wrapped `ConsensusParameters` and `GasCosts` into an enum to support versioning. Moved `block_gas_limit` from `fuel_core_chain_config::ChainConfig` to `ConsensusPataremeters`. Reduced default `MAX_SIZE` to be [110kb](https://github.com/FuelLabs/fuel-core/pull/1761) and `MAX_CONTRACT_SIZE` to be [100kb](https://github.com/FuelLabs/fuel-core/pull/1761).
- [#692](https://github.com/FuelLabs/fuel-vm/pull/692): Add GTF getters for tx size and address.
- [#698](https://github.com/FuelLabs/fuel-vm/pull/698): Store input, output and witness limits to u16, while keeping the values limited to 255.

## What's Changed
* Add GTF getters for tx bytes size and address by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/692
* feat: SMT Proofs (Inclusion and Exclusion) by @bvrooman in https://github.com/FuelLabs/fuel-vm/pull/648
* Increase size of inputs, outputs and witnesses to uint16 by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/698
* Versioning of `ConsensusParameters` and `GasCosts` by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/701
* feat: `serde::Serialize` and `serde::Deserialize` for `double_key!` by @segfault-magnet in https://github.com/FuelLabs/fuel-vm/pull/704
* Added privileged address to the `ConsensusParameters` by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/705
* Add GM for base asset ID by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/700
* Versioning of sub parameters by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/702
* Hide `Default` params under the "test-helper" feature  by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/708
* Reshuffled fields `Script` and `Create` transactions to unify part used by all chargeable transactions by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/703
* Unified `Create` and `Script` logic via `ChargeableTransaction` by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/706
* Removed `bytecode_length` from the `Create` transaction by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/709
* Missed functionality required to for upgrading `fuel-core` to next `fuel-vm` release by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/710

## New Contributors
* @segfault-magnet made their first contribution in https://github.com/FuelLabs/fuel-vm/pull/704

**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.47.1...v0.48.0