### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+[Link to related issue(s) here, if any]
+
+[Short description of the changes.]
+
+## Checklist
+- [ ] Breaking changes are clearly marked as such in the PR description and changelog
+- [ ] New behavior is reflected in tests
+- [ ] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
+- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)
+
+### Before requesting review
+- [ ] I have reviewed the code myself
+- [ ] I have created follow-up issues caused by this PR and linked them here
+
+### After merging, notify other teams
+
+[Add or remove entries as needed]
+
+- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
+- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
+- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
+- [ ] Someone else?


### PR DESCRIPTION
Part of https://github.com/FuelLabs/fuel-core/issues/1804

Adds a template for the PR description, containing a handy checklist.
