### PR TITLE
Release v0.49.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.49.0]
+
 ### Added
 
 - [#721](https://github.com/FuelLabs/fuel-vm/pull/721): Added additional logic to the BMT proof verification algorithm to check the length of the provided proof set against the index provided in the proof.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,17 +17,17 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.48.0"
+version = "0.49.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.48.0", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.48.0", path = "fuel-crypto", default-features = false }
-fuel-derive = { version = "0.48.0", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.48.0", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.48.0", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.48.0", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.48.0", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.48.0", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.49.0", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.49.0", path = "fuel-crypto", default-features = false }
+fuel-derive = { version = "0.49.0", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.49.0", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.49.0", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.49.0", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.49.0", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.49.0", path = "fuel-vm", default-features = false }
 bitflags = "2"
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
## Version v0.49.0

### Added

- [#721](https://github.com/FuelLabs/fuel-vm/pull/721): Added additional logic to the BMT proof verification algorithm to check the length of the provided proof set against the index provided in the proof.

#### Breaking

- [#719](https://github.com/FuelLabs/fuel-vm/pull/719): Fix overflow in `LDC` instruction when contract size with padding would overflow.
- [#715](https://github.com/FuelLabs/fuel-vm/pull/715): The `Interpreter` supports the processing of the `Upload` transaction. The change affects `InterpreterStorage`, adding `StorageMutate<UploadedBytes>` constrain.
- [#714](https://github.com/FuelLabs/fuel-vm/pull/714): The change adds a new `Upload` transaction that allows uploading huge byte code on chain subsection by subsection. This transaction is chargeable and is twice as expensive as the `Create` transaction. Anyone can submit this transaction.
- [#712](https://github.com/FuelLabs/fuel-vm/pull/712): The `Interpreter` supports the processing of the `Upgrade` transaction. The change affects `InterpreterStorage`, adding 5 new methods that must be implemented.
- [#707](https://github.com/FuelLabs/fuel-vm/pull/707): The change adds a new `Upgrade` transaction that allows upgrading either consensus parameters or state transition function used by the network to produce future blocks.
    The purpose of the upgrade is defined by the `Upgrade Purpose` type:
    
    ```rust
    pub enum UpgradePurpose {
        /// The upgrade is performed to change the consensus parameters.
        ConsensusParameters {
            /// The index of the witness in the [`Witnesses`] field that contains
            /// the serialized consensus parameters.
            witness_index: u16,
            /// The hash of the serialized consensus parameters.
            /// Since the serialized consensus parameters live inside witnesses(malleable
            /// data), any party can override them. The `checksum` is used to verify that the
            /// data was not modified.
            checksum: Bytes32,
        },
        /// The upgrade is performed to change the state transition function.
        StateTransition {
            /// The Merkle root of the new bytecode of the state transition function.
            /// The bytecode must be present on the blockchain(should be known by the
            /// network) at the moment of inclusion of this transaction.
            root: Bytes32,
        },
    }
    ```
    
    The `Upgrade` transaction is chargeable, and the sender should pay for it. Transaction inputs should contain only base assets.
    
    Only the privileged address can upgrade the network. The privileged address can be either a real account or a predicate.
    
    Since serialized consensus parameters are small(< 2kb), they can be part of the upgrade transaction and live inside of witness data. The bytecode of the blockchain state transition function is huge ~1.6MB(relative to consensus parameters), and it is impossible to fit it into one transaction. So when we perform the upgrade of the state transition function, it should already be available on the blockchain. The transaction to actually upload the bytecode(`Upload` transaction) will implemented in the https://github.com/FuelLabs/fuel-core/issues/1754.

### Changed

- [#707](https://github.com/FuelLabs/fuel-vm/pull/707): Used the same pattern everywhere in the codebase: 
    ```rust
                 Self::Script(tx) => tx.encode_static(buffer),
                 Self::Create(tx) => tx.encode_static(buffer),
                 Self::Mint(tx) => tx.encode_static(buffer),
                 Self::Upgrade(tx) => tx.encode_static(buffer),
    ```
  
    Instead of:
    ```rust
                 Transaction::Script(script) => script.encode_static(buffer),
                 Transaction::Create(create) => create.encode_static(buffer),
                 Transaction::Mint(mint) => mint.encode_static(buffer),
                 Transaction::Upgrade(upgrade) => upgrade.encode_static(buffer),
    ```

#### Breaking

- [#714](https://github.com/FuelLabs/fuel-vm/pull/714): Added `max_bytecode_subsections` field to the `TxParameters` to limit the number of subsections that can be uploaded.
- [#707](https://github.com/FuelLabs/fuel-vm/pull/707): Side small breaking for tests changes from the `Upgrade` transaction:
  - Moved `fuel-tx-test-helpers` logic into the `fuel_tx::test_helpers` module.
  - Added a new rule for `Create` transaction: all inputs should use base asset otherwise it returns `TransactionInputContainsNonBaseAssetId` error.
  - Renamed some errors because now they are used for several transactions(`Upgrade` uses some errors from `Create` and some from `Script` transactions):
    - `TransactionScriptOutputContractCreated` -> `TransactionOutputContainsContractCreated`.
    - `TransactionCreateOutputContract` -> `TransactionOutputContainsContract`.
    - `TransactionCreateOutputVariable` -> `TransactionOutputContainsVariable`.
    - `TransactionCreateOutputChangeNotBaseAsset` -> `TransactionChangeChangeUsesNotBaseAsset`.
    - `TransactionCreateInputContract` -> `TransactionInputContainsContract`.
    - `TransactionCreateMessageData` -> `TransactionInputContainsMessageData`.
  - The combination of `serde` and `postcard` is used to serialize and deserialize `ConsensusParameters` during the upgrade. This means the protocol and state transition function requires the `serde` feature by default for `ConsensusParameters` and `fuel-types`.

- [#697](https://github.com/FuelLabs/fuel-vm/pull/697): Changed the VM to internally use separate buffers for the stack and the heap to improve startup time. After this change, memory that was never part of the stack or the heap cannot be accessed, even for reading. Also, even if the whole memory is allocated, accesses spanning from the stack to the heap are not allowed. This PR also fixes a bug that required one-byte gap between the stack and the heap. Multiple errors have been changed to be more sensible ones, and sometimes the order of which error is returned has changed. `ALOC` opcode now zeroes the newly allocated memory.

## What's Changed
* Store stack and heap separately by @Dentosal @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/697
* Add PR template by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/713
* A new `Upgrade` transaction to perform network upgrades by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/707
* Process `Upgrade` transaction inside of the `Interpreter` by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/712
* A new `Upload` transaction to upload the huge bytecode on the chain by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/720
* Process `Upload` transaction inside the `Interpreter` by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/715
* test: BMT proof verify tests and additional verify logic by @bvrooman in https://github.com/FuelLabs/fuel-vm/pull/721
* Handle padded_len_* overflows gracefully by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/719


**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.48.0...v0.49.0