### PR TITLE
Add advanced fuzzer

### DIFF
--- a/fuel-asm/src/macros.rs
+++ b/fuel-asm/src/macros.rs
@@ -1007,6 +1007,7 @@ macro_rules! impl_instructions {
         /// Solely the opcode portion of an instruction represented as a single byte.
         #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
         #[repr(u8)]
         pub enum Opcode {
             $(

--- a/fuel-crypto/src/secp256/signature_format.rs
+++ b/fuel-crypto/src/secp256/signature_format.rs
@@ -55,6 +55,8 @@ impl TryFrom<secp256k1::ecdsa::RecoveryId> for RecoveryId {
 /// Panics if the highest bit of byte at index 32 is set, as this indicates non-normalized
 /// signature. Panics if the recovery id is in reduced-x form.
 pub fn encode_signature(mut signature: [u8; 64], recovery_id: RecoveryId) -> [u8; 64] {
+    // This assertion is hit during fuzzing. Verify it is safe to disable.
+    #[cfg(not(any(fuzzing, feature = "test-helpers")))]
     assert!(signature[32] >> 7 == 0, "Non-normalized signature");
     let v = recovery_id.is_y_odd as u8;
 

--- a/fuel-tx/src/transaction/validity.rs
+++ b/fuel-tx/src/transaction/validity.rs
@@ -112,6 +112,8 @@ impl Input {
                     recover_address()?
                 };
 
+                // This error is reached during fuzzing often, verify it is safe to disable it
+                #[cfg(not(any(fuzzing, feature = "test-helpers")))]
                 if owner != &recovered_address {
                     return Err(ValidityError::InputInvalidSignature { index });
                 }

--- a/fuel-vm/fuzz/Cargo.toml
+++ b/fuel-vm/fuzz/Cargo.toml
@@ -3,22 +3,54 @@ name = "fuel-vm-fuzz"
 version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true
 
 [dependencies]
 arbitrary = { version = "1.0", features = ["derive"] }
-fuel-vm = { path = "..", features = ["arbitrary"] }
-libfuzzer-sys = "0.4"
+fuel-vm = { path = "..", features = ["arbitrary", "test-helpers"] }
+libfuzzer-sys = { features = ["arbitrary-derive"], package = "libafl_libfuzzer" }
+#libfuzzer-sys = "0.4"
+clap = { version = "4.0", features = ["derive"] }
+hex = "*"
 
 # Prevent this from interfering with workspaces as this crate requires unstable features.
 [workspace]
 members = ["."]
+
+[profile.release]
+panic = 'abort'
+
+[profile.dev]
+panic = 'abort'
 
 [[bin]]
 name = "grammar_aware"
 path = "fuzz_targets/grammar_aware.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "grammar_aware_advanced"
+path = "fuzz_targets/grammar_aware_advanced.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "seed"
+path = "src/seed.rs"
+
+[[bin]]
+name = "libafl"
+path = "src/libafl.rs"
+
+[[bin]]
+name = "execute"
+path = "src/execute.rs"
+
+[[bin]]
+name = "collect"
+path = "src/collect.rs"
+

--- a/fuel-vm/fuzz/Cargo.toml
+++ b/fuel-vm/fuzz/Cargo.toml
@@ -11,8 +11,8 @@ cargo-fuzz = true
 [dependencies]
 arbitrary = { version = "1.0", features = ["derive"] }
 fuel-vm = { path = "..", features = ["arbitrary", "test-helpers"] }
-libfuzzer-sys = { features = ["arbitrary-derive"], package = "libafl_libfuzzer" }
-#libfuzzer-sys = "0.4"
+# For LibAFL: libfuzzer-sys = { features = ["arbitrary-derive"], package = "libafl_libfuzzer" }
+libfuzzer-sys = "0.4"
 clap = { version = "4.0", features = ["derive"] }
 hex = "*"
 
@@ -41,10 +41,6 @@ doc = false
 [[bin]]
 name = "seed"
 path = "src/seed.rs"
-
-[[bin]]
-name = "libafl"
-path = "src/libafl.rs"
 
 [[bin]]
 name = "execute"

--- a/fuel-vm/fuzz/README.md
+++ b/fuel-vm/fuzz/README.md
@@ -1,0 +1,58 @@
+
+## Manual for grammar_aware_advanced fuzzer
+
+
+Install:
+```
+cargo install cargo-fuzz
+apt install clang pkg-config libssl-dev # for LibAFL
+rustup component add llvm-tools-preview --toolchain nightly
+```
+
+General information about fuzzing Rust might be found on [appsec.guide](https://appsec.guide/docs/fuzzing/rust/cargo-fuzz/).
+
+
+### Generate Seeds
+
+It is necessary to first convert Sway programs into a suitable format for use as seed input to the fuzzer. This can be done with the following command:
+```
+cargo run --bin seed <input dir> <output dir>
+```
+
+### Running the Fuzzer
+The Rust nightly version is required for executing cargo-fuzz. We also disable AddressSanitizer for a significant speed improvement, as we do not expect memory issues in a Rust program that does not use a significant amount of unsafe code, which our [cargo-geiger](https://github.com/rust-secure-code/cargo-geiger) analysis showed. It makes sense to leave AddressSanitizer turned on if the Fuel project uses more unsafe Rust in the future (either directly or through dependencies). The remaining flags are either required for LibAFL or are useful to make it use seven cores.
+```
+cargo +nightly fuzz run --sanitizer none grammar_aware -- \
+	-ignore_crashes=1 -ignore_timeouts=1 -ignore_ooms=1 -fork=7
+```
+
+If you use libfuzzer (default) then the following command is enough:
+
+```
+cargo fuzz run --sanitizer none grammar_aware
+```
+
+### Execute a Test Case
+Test cases can be executed using the following command. This is useful for triaging issues.
+```
+cd fuzz/
+cargo run --bin execute <file/dir>
+```
+
+### Collect Statistics
+We created a tool that writes gas statistics to a file called gas_statistics.csv. This can be used to analyze the execution time versus gas usage on a test corpus.
+```
+cargo run --bin collect <file/dir>
+```
+
+### Generate Coverage
+Regardless of how inputs are generated, it is important to measure a fuzzing campaign’s coverage after its run. To perform this measure, we used the support provided by cargo-fuzz and [rustc](https://doc.rust-lang.org/stable/rustc/instrument-coverage.html). First, install [cargo-binutils](https://github.com/rust-embedded/cargo-binutils#installation). After that, execute the following command:
+```
+cargo +nightly fuzz coverage grammar_aware corpus/grammar_aware
+```
+Finally, generate an HTML file using LLVM:
+
+```
+cargo cov -- show
+target/x86_64-unknown-linux-gnu/coverage/x86_64-unknown-linux-gnu/release/grammar_aware --format=html -instr-profile=coverage/grammar_aware/coverage.profdata /root/audit/fuel-vm > index.html
+```

--- a/fuel-vm/fuzz/fuzz_targets/grammar_aware_advanced.rs
+++ b/fuel-vm/fuzz/fuzz_targets/grammar_aware_advanced.rs
@@ -1,0 +1,10 @@
+#![no_main]
+
+use fuel_vm_fuzz::{decode, execute};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Some(data) = decode(data) {
+        execute(data);
+    }
+});

--- a/fuel-vm/fuzz/src/collect.rs
+++ b/fuel-vm/fuzz/src/collect.rs
@@ -1,0 +1,50 @@
+use crate::fs::File;
+use fuel_vm::consts::WORD_SIZE;
+use fuel_vm::fuel_asm::op;
+use fuel_vm::fuel_asm::RegId;
+use fuel_vm::fuel_asm::{Instruction, RawInstruction};
+use fuel_vm::fuel_crypto::rand::Rng;
+use fuel_vm::fuel_crypto::rand::SeedableRng;
+use fuel_vm::fuel_types::Word;
+use fuel_vm::prelude::SecretKey;
+use fuel_vm_fuzz::execute;
+use fuel_vm_fuzz::FuzzData;
+use fuel_vm_fuzz::{decode, decode_instructions, encode};
+use std::convert::TryFrom;
+use std::convert::TryInto;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+fn main() {
+    let path = std::env::args().nth(1).expect("no path given");
+    let mut file = File::create("gas_statistics.csv").unwrap();
+
+    write!(file, "name\tgas\ttime_ms\n").unwrap();
+
+    if Path::new(&path).is_file() {
+        eprintln!("Pass directory")
+    } else {
+        let paths = fs::read_dir(path).unwrap();
+
+        for path in paths {
+            let entry = path.unwrap();
+            let data = std::fs::read(entry.path()).unwrap();
+            let name = entry.file_name();
+            let name = name.to_str().unwrap();
+            println!("{:?}", name);
+
+            let Some(data) = decode(&data) else {  eprintln!("unable to decode"); continue; };
+
+            let now = Instant::now();
+            let result = execute(data);
+            let gas = result.gas_used;
+
+            write!(file, "{name}\t{gas}\t{}\n", now.elapsed().as_millis()).unwrap();
+            if result.success {
+                println!("{:?}:{}", name, result.success);
+            }
+        }
+    }
+}

--- a/fuel-vm/fuzz/src/execute.rs
+++ b/fuel-vm/fuzz/src/execute.rs
@@ -1,0 +1,46 @@
+use fuel_vm::consts::WORD_SIZE;
+use fuel_vm::fuel_asm::op;
+use fuel_vm::fuel_asm::RegId;
+use fuel_vm::fuel_asm::{Instruction, RawInstruction};
+use fuel_vm::fuel_crypto::rand::Rng;
+use fuel_vm::fuel_crypto::rand::SeedableRng;
+use fuel_vm::fuel_types::Word;
+use fuel_vm::prelude::SecretKey;
+use fuel_vm_fuzz::execute;
+use fuel_vm_fuzz::FuzzData;
+use fuel_vm_fuzz::{decode, decode_instructions, encode};
+use std::convert::TryFrom;
+use std::convert::TryInto;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn main() {
+    let path = std::env::args().nth(1).expect("no path given");
+
+    if Path::new(&path).is_file() {
+        let data = std::fs::read(&path).unwrap();
+
+        let data = decode(&data).unwrap();
+
+        let result = execute(data);
+        if result.success {
+            println!("{:?}:{}", path, result.success);
+        }
+    } else {
+        let paths = fs::read_dir(path).unwrap();
+
+        for path in paths {
+            let entry = path.unwrap();
+            println!("{:?}", entry.file_name());
+
+            let data = std::fs::read(entry.path()).unwrap();
+
+            let data = decode(&data).unwrap();
+
+            let result = execute(data);
+            if result.success {
+                println!("{:?}:{}", entry.file_name(), result.success);
+            }
+        }
+    }
+}

--- a/fuel-vm/fuzz/src/lib.rs
+++ b/fuel-vm/fuzz/src/lib.rs
@@ -1,0 +1,175 @@
+use fuel_vm::checked_transaction::IntoChecked;
+use fuel_vm::consts::WORD_SIZE;
+use fuel_vm::fuel_asm::op;
+use fuel_vm::fuel_asm::{Instruction, InvalidOpcode, RawInstruction};
+use fuel_vm::fuel_crypto::coins_bip32::ecdsa::signature::digest::typenum::Pow;
+use fuel_vm::fuel_crypto::coins_bip32::ecdsa::signature::digest::Reset;
+use fuel_vm::fuel_crypto::rand;
+use fuel_vm::fuel_crypto::rand::Rng;
+use fuel_vm::fuel_crypto::rand::SeedableRng;
+use fuel_vm::fuel_types::Word;
+use fuel_vm::prelude::field::Script;
+use fuel_vm::prelude::*;
+
+use fuel_vm::util::test_helpers::{find_change, TestBuilder};
+use fuel_vm::{fuel_asm, script_with_data_offset};
+
+use std::convert::TryFrom;
+use std::convert::TryInto;
+use std::hint::black_box;
+use std::io::Read;
+use std::ops::Range;
+use std::path::PathBuf;
+
+const SEP: [u8; 8] = [0x00u8, 0xAD, 0xBE, 0xEF, 0x55, 0x66, 0xCE, 0xAA];
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct FuzzData {
+    pub program: Vec<u8>,
+    pub sub_program: Vec<u8>,
+    pub script_data: Vec<u8>,
+}
+
+pub fn encode(data: &FuzzData) -> Vec<u8> {
+    let seperator: Vec<_> = SEP.into();
+    let parts: [Vec<u8>; 5] = [
+        data.program.iter().copied().collect(),
+        seperator.clone(),
+        data.script_data.clone(),
+        seperator.clone(),
+        data.sub_program.iter().copied().collect(),
+    ];
+
+    let data: Vec<u8> = parts.iter().flatten().copied().collect();
+    data
+}
+
+fn split_by_separator(data: &[u8], separator: &[u8]) -> Vec<Range<usize>> {
+    let separator_len = separator.len();
+
+    let mut last: usize = 0;
+
+    let mut result: Vec<_> = data
+        .windows(separator_len)
+        .enumerate()
+        .filter_map(|(i, window)| {
+            if window == separator {
+                let option = Some(last..i);
+                last = i + separator_len;
+                return option;
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    result.push(last..data.len());
+
+    result
+}
+
+pub fn decode(data: &[u8]) -> Option<FuzzData> {
+    let x = split_by_separator(data, &SEP);
+
+    if x.len() != 3 {
+        return None;
+    }
+
+    let program = data[x[0].clone()].to_vec();
+    let sub_program = data[x[2].clone()].to_vec();
+    Some(FuzzData {
+        program,
+        script_data: data[x[1].clone()].to_vec(),
+        sub_program,
+    })
+}
+
+pub fn decode_instructions(bytes: &[u8]) -> Option<Vec<Instruction>> {
+    let instructions: Vec<_> = fuel_vm::fuel_asm::from_bytes(bytes.iter().cloned())
+        .flat_map(|i: Result<Instruction, InvalidOpcode>| i.ok())
+        .collect();
+    return Some(instructions);
+}
+
+pub struct ExecuteResult {
+    pub success: bool,
+    pub gas_used: u64,
+}
+
+pub fn execute(data: FuzzData) -> ExecuteResult {
+    let gas_limit = 1_000_000;
+    let asset_id: AssetId = AssetId::new([
+        0xFA, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1,
+    ]);
+
+    let mut test_context = TestBuilder::new(2322u64);
+    let subcontract: Vec<_> = [
+        // Pass some data to fuzzer
+        op::addi(
+            0x10,
+            fuel_asm::RegId::FP,
+            CallFrame::b_offset() as Immediate12,
+        ),
+        fuel_vm::fuel_asm::op::lw(0x10, 0x10, 0), // load address word
+    ]
+    .iter()
+    .copied()
+    .flat_map(Instruction::to_bytes)
+    .chain(data.sub_program.iter().copied())
+    .collect::<Vec<u8>>();
+
+    let contract_id = test_context
+        .setup_contract_bytes(subcontract.clone(), None, None)
+        .contract_id;
+
+    let max_program_length = 2usize.pow(18)
+        - test_context.tx_offset()
+        - <fuel_vm::prelude::Script as Script>::script_offset_static()
+        - 256; // TODO reevalute this one
+
+    let actual_program = &data.program[..max_program_length.min(data.program.len())];
+
+    let (script_ops, script_data_offset): (Vec<u8>, Immediate18) = script_with_data_offset!(
+        script_data_offset,
+        actual_program.to_vec(),
+        test_context.tx_offset()
+    );
+
+    let call = Call::new(contract_id, 0, script_data_offset as Word).to_bytes();
+    let script_data: [&[u8]; 2] = [asset_id.as_ref(), call.as_slice()];
+
+    // Provide an asset id and the contract_id
+    let script_data: Vec<u8> = script_data.iter().copied().flatten().copied().collect();
+
+    let script_data = script_data
+        .iter()
+        .chain(data.script_data.iter())
+        .copied()
+        .collect::<Vec<_>>();
+
+    let transfer_tx = test_context
+        .start_script_bytes(script_ops.iter().copied().collect(), script_data)
+        .gas_limit(gas_limit)
+        .gas_price(0)
+        .coin_input(asset_id, 1000)
+        .contract_input(contract_id)
+        .contract_output(&contract_id)
+        .change_output(asset_id)
+        .execute();
+
+    let gas_used: u64 = *transfer_tx
+        .receipts()
+        .iter()
+        .filter_map(|recipt| match recipt {
+            Receipt::ScriptResult { gas_used, .. } => Some(gas_used),
+            _ => None,
+        })
+        .next()
+        .unwrap();
+
+    ExecuteResult {
+        success: !transfer_tx.should_revert(),
+        gas_used,
+    }
+}

--- a/fuel-vm/fuzz/src/seed.rs
+++ b/fuel-vm/fuzz/src/seed.rs
@@ -1,0 +1,42 @@
+use fuel_vm::consts::WORD_SIZE;
+use fuel_vm::fuel_asm::{Instruction, RawInstruction};
+use fuel_vm::fuel_crypto::rand::Rng;
+use fuel_vm::fuel_crypto::rand::SeedableRng;
+use fuel_vm::fuel_types::Word;
+use fuel_vm::prelude::SecretKey;
+use fuel_vm_fuzz::FuzzData;
+use fuel_vm_fuzz::{decode, decode_instructions, encode};
+use std::convert::TryFrom;
+use std::convert::TryInto;
+use std::fs;
+use std::path::PathBuf;
+
+fn main() {
+    let input = std::env::args().nth(1).expect("no input path given");
+    let output = std::env::args().nth(2).expect("no output path given");
+    let paths = fs::read_dir(input).unwrap();
+
+    for path in paths {
+        let entry = path.unwrap();
+        let program = std::fs::read(entry.path()).unwrap();
+
+        println!("{:?}", entry.file_name().to_str().unwrap());
+
+        let data = FuzzData {
+            program,
+            sub_program: vec![],
+            script_data: vec![],
+        };
+
+        let encoded = encode(&data);
+        let decoded = decode(&encoded).unwrap();
+
+        if decoded != data {
+            println!("{:?}", data);
+            println!("{:?}", decoded);
+            panic!("mismatch")
+        }
+
+        fs::write(PathBuf::from(&output).join(entry.file_name()), &encoded).unwrap();
+    }
+}

--- a/fuel-vm/src/util.rs
+++ b/fuel-vm/src/util.rs
@@ -201,13 +201,30 @@ pub mod test_helpers {
             self.block_height
         }
 
+        #[cfg(any(fuzzing, feature = "test-helpers"))]
+        pub fn start_script_bytes(
+            &mut self,
+            script: Vec<u8>,
+            script_data: Vec<u8>,
+        ) -> &mut Self {
+            self.start_script_inner(script, script_data)
+        }
+
         pub fn start_script(
             &mut self,
             script: Vec<Instruction>,
             script_data: Vec<u8>,
         ) -> &mut Self {
-            let bytecode = script.into_iter().collect();
-            self.builder = TransactionBuilder::script(bytecode, script_data);
+            let script = script.into_iter().collect();
+            self.start_script_inner(script, script_data)
+        }
+
+        fn start_script_inner(
+            &mut self,
+            script: Vec<u8>,
+            script_data: Vec<u8>,
+        ) -> &mut Self {
+            self.builder = TransactionBuilder::script(script, script_data);
             self.builder.script_gas_limit(self.script_gas_limit);
             self
         }
@@ -414,9 +431,34 @@ pub mod test_helpers {
                 .build()
         }
 
+        #[cfg(any(fuzzing, feature = "test-helpers"))]
+        pub fn setup_contract_bytes(
+            &mut self,
+            contract: Vec<u8>,
+            initial_balance: Option<(AssetId, Word)>,
+            initial_state: Option<Vec<StorageSlot>>,
+        ) -> CreatedContract {
+            self.setup_contract_inner(contract, initial_balance, initial_state)
+        }
+
         pub fn setup_contract(
             &mut self,
             contract: Vec<Instruction>,
+            initial_balance: Option<(AssetId, Word)>,
+            initial_state: Option<Vec<StorageSlot>>,
+        ) -> CreatedContract {
+            let contract = contract
+                .into_iter()
+                .flat_map(Instruction::to_bytes)
+                .collect::<Vec<u8>>()
+                .into();
+
+            self.setup_contract_inner(contract, initial_balance, initial_state)
+        }
+
+        fn setup_contract_inner(
+            &mut self,
+            contract: Vec<u8>,
             initial_balance: Option<(AssetId, Word)>,
             initial_state: Option<Vec<StorageSlot>>,
         ) -> CreatedContract {
@@ -427,11 +469,7 @@ pub mod test_helpers {
             };
 
             let salt: Salt = self.rng.gen();
-            let program: Witness = contract
-                .into_iter()
-                .flat_map(Instruction::to_bytes)
-                .collect::<Vec<u8>>()
-                .into();
+            let program: Witness = contract.into();
             let storage_root = Contract::initial_state_root(storage_slots.iter());
             let contract = Contract::from(program.as_ref());
             let contract_root = contract.root();


### PR DESCRIPTION
Adds a fuzzer which:
* Can call contracts
* Uses complete scripts with fuzzed script data
* Can use LibAFL


## Manual

```
cargo install cargo-fuzz
apt install clang pkg-config libssl-dev # for LibAFL
rustup component add llvm-tools-preview --toolchain nightly
```


### Generate Seeds

It is necessary to first convert Sway programs into a suitable format for use as seed input to the fuzzer. This can be done with the following command:
```
cargo run --bin seed <input dir> <output dir>
```

### Running the Fuzzer
The Rust nightly version is required for executing cargo-fuzz. We also disable AddressSanitizer for a significant speed improvement, as we do not expect memory issues in a Rust program that does not use a significant amount of unsafe code, which our [cargo-geiger](https://github.com/rust-secure-code/cargo-geiger) analysis showed. It makes sense to leave AddressSanitizer turned on if the Fuel project uses more unsafe Rust in the future (either directly or through dependencies). The remaining flags are either required for LibAFL or are useful to make it use seven cores.
```
cargo +nightly fuzz run --sanitizer none grammar_aware -- \
	-ignore_crashes=1 -ignore_timeouts=1 -ignore_ooms=1 -fork=7
```

If you use libfuzzer (default) then the following command is enough:

```
cargo fuzz run --sanitizer none grammar_aware
```

### Execute a Test Case
Test cases can be executed using the following command. This is useful for triaging issues.
```
cd fuzz/
cargo run --bin execute <file/dir>
```

### Collect Statistics
We created a tool that writes gas statistics to a file called gas_statistics.csv. This can be used to analyze the execution time versus gas usage on a test corpus.
```
cargo run --bin collect <file/dir>
```

### Generate Coverage
Regardless of how inputs are generated, it is important to measure a fuzzing campaign’s coverage after its run. To perform this measure, we used the support provided by cargo-fuzz and [rustc](https://doc.rust-lang.org/stable/rustc/instrument-coverage.html). First, install [cargo-binutils](https://github.com/rust-embedded/cargo-binutils#installation). After that, execute the following command:
```
cargo +nightly fuzz coverage grammar_aware corpus/grammar_aware
```
Finally, generate an HTML file using LLVM:

```
cargo cov -- show
target/x86_64-unknown-linux-gnu/coverage/x86_64-unknown-linux-gnu/release/grammar_aware --format=html -instr-profile=coverage/grammar_aware/coverage.profdata /root/audit/fuel-vm > index.html
```


The last argument to `cargo cov` defines the filter based on the host file paths.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

TODO

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
