### PR TITLE
Release v0.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.50.0]
+
 ### Changed
 
 - [#725](https://github.com/FuelLabs/fuel-vm/pull/725): Adds more clippy lints to catch possible integer overflow and casting bugs on compile time.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,17 +17,17 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.49.0"
+version = "0.50.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.49.0", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.49.0", path = "fuel-crypto", default-features = false }
-fuel-derive = { version = "0.49.0", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.49.0", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.49.0", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.49.0", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.49.0", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.49.0", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.50.0", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.50.0", path = "fuel-crypto", default-features = false }
+fuel-derive = { version = "0.50.0", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.50.0", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.50.0", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.50.0", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.50.0", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.50.0", path = "fuel-vm", default-features = false }
 bitflags = "2"
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
## Version v0.50.0

### Changed

- [#725](https://github.com/FuelLabs/fuel-vm/pull/725): Adds more clippy lints to catch possible integer overflow and casting bugs on compile time.
- [#729](https://github.com/FuelLabs/fuel-vm/pull/729): Adds more clippy lints to `fuel-merkle` to catch possible integer overflow and casting bugs on compile time. It also does some internal refactoring.

### Added

#### Breaking

- [#725](https://github.com/FuelLabs/fuel-vm/pull/725): `UtxoId::from_str` now rejects inputs with multiple `0x` prefixes. Many `::from_str` implementations also reject extra data in the end of the input, instead of silently ignoring it. `UtxoId::from_str` allows a single `:` between the fields. Unused `GasUnit` struct removed.
- [#726](https://github.com/FuelLabs/fuel-vm/pull/726): Removed code related to Binary Merkle Sum Trees (BMSTs). The BMST is deprecated and not used in production environments. 
- [#729](https://github.com/FuelLabs/fuel-vm/pull/729): Removed default implementation of `Node::key_size_bits`, implementors must now define it themselves. Also some helper traits have been merged together, or their types changed.
### Fixed

#### Breaking

- [#736](https://github.com/FuelLabs/fuel-vm/pull/736): LDC instruction now works in internal contexts as well. Call frames use code size padded to word alignment.

## What's Changed
* Remove Sum Tree codebase by @bvrooman in https://github.com/FuelLabs/fuel-vm/pull/726
* Deny clippy::arithmetic_side_effects by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/725
* Add a single stepping example by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/728
* Delete duplicate rustfmt.toml by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/731
* Deny clippy::arithmetic_side_effects for fuel-merkle by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/729
* Fix ldc opcode in internal contexts by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/736


**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.49.0...v0.50.0