### PR TITLE
chore: Remove erroneous comment about placeholder merges

### DIFF
--- a/fuel-merkle/src/sparse/merkle_tree/node.rs
+++ b/fuel-merkle/src/sparse/merkle_tree/node.rs
@@ -103,7 +103,6 @@ impl Node {
             // of the two leaves diverge. The joined node may be a direct parent
             // of the leaves or an ancestor multiple generations above the
             // leaves.
-            // N.B.: A leaf can be a placeholder.
             #[allow(clippy::cast_possible_truncation)] // Key is 32 bytes
             let parent_depth = path_node.common_path_length(side_node) as u32;
             #[allow(clippy::arithmetic_side_effects)] // parent_depth <= max_height


### PR DESCRIPTION
Related issues:

- Ottersec issue 3 about comment described here: https://fuellabs.slack.com/archives/C06P42TQEFL/p1714101628804279

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog (N/A)
- [ ] New behavior is reflected in tests (N/A)
- [ ] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that (N/A)
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed) (N/A)

### Before requesting review
- [x] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

