### PR TITLE
Zero $flag on call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - [#732](https://github.com/FuelLabs/fuel-vm/pull/732): Makes the VM generic over the memory type, allowing reuse of relatively expensive-to-allocate VM memories through `VmMemoryPool`. Functions and traits which require VM initalization such as `estimate_predicates` now take either the memory or `VmMemoryPool` as an argument. The `Interpterter::eq` method now only compares accessible memory regions. `Memory` was renamed into `MemoryInstance` and `Memory` is a trait now.
 
+### Changed
+
+#### Breaking
+
+- [#743](https://github.com/FuelLabs/fuel-vm/pull/743): Zeroes `$flag` on `CALL`, so that contracts can assume clean `$flag` state.
 
 ## [Version 0.50.0]
 

--- a/fuel-vm/src/interpreter/flow.rs
+++ b/fuel-vm/src/interpreter/flow.rs
@@ -420,6 +420,7 @@ struct PrepareCallSystemRegisters<'a> {
     bal: RegMut<'a, BAL>,
     cgas: RegMut<'a, CGAS>,
     ggas: RegMut<'a, GGAS>,
+    flag: RegMut<'a, FLAG>,
 }
 
 struct PrepareCallRegisters<'a> {
@@ -435,7 +436,6 @@ struct PrepareCallUnusedRegisters<'a> {
     err: Reg<'a, ERR>,
     ret: Reg<'a, RET>,
     retl: Reg<'a, RETL>,
-    flag: Reg<'a, FLAG>,
 }
 
 impl<'a> PrepareCallRegisters<'a> {
@@ -607,6 +607,7 @@ where
         *self.registers.system_registers.bal = self.params.amount_of_coins_to_forward;
         *self.registers.system_registers.is = *self.registers.system_registers.pc;
         *self.registers.system_registers.cgas = forward_gas_amount;
+        *self.registers.system_registers.flag = 0;
 
         let receipt = Receipt::call(
             id,
@@ -659,13 +660,13 @@ impl<'a> From<&'a PrepareCallRegisters<'_>> for SystemRegistersRef<'a> {
             bal: registers.system_registers.bal.as_ref(),
             cgas: registers.system_registers.cgas.as_ref(),
             ggas: registers.system_registers.ggas.as_ref(),
+            flag: registers.system_registers.flag.as_ref(),
             zero: registers.unused_registers.zero,
             one: registers.unused_registers.one,
             of: registers.unused_registers.of,
             err: registers.unused_registers.err,
             ret: registers.unused_registers.ret,
             retl: registers.unused_registers.retl,
-            flag: registers.unused_registers.flag,
         }
     }
 }
@@ -699,6 +700,7 @@ impl<'reg> From<SystemRegisters<'reg>>
             bal: registers.bal,
             cgas: registers.cgas,
             ggas: registers.ggas,
+            flag: registers.flag,
         };
 
         (
@@ -710,7 +712,6 @@ impl<'reg> From<SystemRegisters<'reg>>
                 err: registers.err.into(),
                 ret: registers.ret.into(),
                 retl: registers.retl.into(),
-                flag: registers.flag.into(),
             },
         )
     }


### PR DESCRIPTION
Spec PR: https://github.com/FuelLabs/fuel-specs/pull/585

Called contracts shouldn't inherit the `$flag` register.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
