### PR TITLE
Release v0.51.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.51.0]
+
 ### Added
 
 - [#732](https://github.com/FuelLabs/fuel-vm/pull/732):  Adds `reset` method to VM memory.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,17 +17,17 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.50.0"
+version = "0.51.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.50.0", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.50.0", path = "fuel-crypto", default-features = false }
-fuel-derive = { version = "0.50.0", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.50.0", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.50.0", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.50.0", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.50.0", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.50.0", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.51.0", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.51.0", path = "fuel-crypto", default-features = false }
+fuel-derive = { version = "0.51.0", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.51.0", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.51.0", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.51.0", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.51.0", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.51.0", path = "fuel-vm", default-features = false }
 bitflags = "2"
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
## Version v0.51.0

### Added

- [#732](https://github.com/FuelLabs/fuel-vm/pull/732):  Adds `reset` method to VM memory.

#### Breaking

- [#732](https://github.com/FuelLabs/fuel-vm/pull/732): Makes the VM generic over the memory type, allowing reuse of relatively expensive-to-allocate VM memories through `VmMemoryPool`. Functions and traits which require VM initalization such as `estimate_predicates` now take either the memory or `VmMemoryPool` as an argument. The `Interpterter::eq` method now only compares accessible memory regions. `Memory` was renamed into `MemoryInstance` and `Memory` is a trait now.

### Changed

#### Breaking

- [#743](https://github.com/FuelLabs/fuel-vm/pull/743): Zeroes `$flag` on `CALL`, so that contracts can assume clean `$flag` state.
- [#737](https://github.com/FuelLabs/fuel-vm/pull/737): Panic on instructions with non-zero reserved part.

## What's Changed
* Memory pool/reuse by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/732
* chore: Remove erroneous comment about placeholder merges by @bvrooman in https://github.com/FuelLabs/fuel-vm/pull/741
* Panic on instructions with non-zero reserved part by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/737
* Zero $flag on call by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/743


**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.50.0...v0.51.0