### PR TITLE
Use `DependentCost` for `aloc` opcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+#### Breaking
+
+- [#747](https://github.com/FuelLabs/fuel-vm/pull/747): Use `DependentCost` for `aloc` opcode. The cost of the `aloc` opcode is now dependent on the size of the allocation.
+
 ## [Version 0.51.0]
 
 ### Added

--- a/fuel-tx/src/transaction/consensus_parameters/gas.rs
+++ b/fuel-tx/src/transaction/consensus_parameters/gas.rs
@@ -73,667 +73,782 @@ impl Default for GasCostsValues {
 pub enum GasCostsValues {
     /// Version 1 of the gas costs.
     V1(GasCostsValuesV1),
+    /// Version 2 of the gas costs.
+    V2(GasCostsValuesV2),
 }
 
 #[allow(missing_docs)]
 impl GasCostsValues {
     pub fn add(&self) -> Word {
         match self {
-            GasCostsValues::V1(v1) => v1.add,
+            GasCostsValues::V1(v) => v.add,
+            GasCostsValues::V2(v) => v.add,
         }
     }
 
     pub fn addi(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.addi,
-        }
-    }
-
-    pub fn aloc(&self) -> Word {
-        match self {
-            GasCostsValues::V1(v1) => v1.aloc,
+            GasCostsValues::V2(v2) => v2.addi,
         }
     }
 
     pub fn and(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.and,
+            GasCostsValues::V2(v2) => v2.and,
         }
     }
 
     pub fn andi(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.andi,
+            GasCostsValues::V2(v2) => v2.andi,
         }
     }
 
     pub fn bal(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.bal,
+            GasCostsValues::V2(v2) => v2.bal,
         }
     }
 
     pub fn bhei(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.bhei,
+            GasCostsValues::V2(v2) => v2.bhei,
         }
     }
 
     pub fn bhsh(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.bhsh,
+            GasCostsValues::V2(v2) => v2.bhsh,
         }
     }
 
     pub fn burn(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.burn,
+            GasCostsValues::V2(v2) => v2.burn,
         }
     }
 
     pub fn cb(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.cb,
+            GasCostsValues::V2(v2) => v2.cb,
         }
     }
 
     pub fn cfei(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.cfei,
+            GasCostsValues::V2(v2) => v2.cfei,
         }
     }
 
     pub fn cfsi(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.cfsi,
+            GasCostsValues::V2(v2) => v2.cfsi,
         }
     }
 
     pub fn div(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.div,
+            GasCostsValues::V2(v2) => v2.div,
         }
     }
 
     pub fn divi(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.divi,
+            GasCostsValues::V2(v2) => v2.divi,
         }
     }
 
     pub fn eck1(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.eck1,
+            GasCostsValues::V2(v2) => v2.eck1,
         }
     }
 
     pub fn ecr1(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.ecr1,
+            GasCostsValues::V2(v2) => v2.ecr1,
         }
     }
 
     pub fn ed19(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.ed19,
+            GasCostsValues::V2(v2) => v2.ed19,
         }
     }
 
     pub fn eq_(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.eq,
+            GasCostsValues::V2(v2) => v2.eq,
         }
     }
 
     pub fn exp(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.exp,
+            GasCostsValues::V2(v2) => v2.exp,
         }
     }
 
     pub fn expi(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.expi,
+            GasCostsValues::V2(v2) => v2.expi,
         }
     }
 
     pub fn flag(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.flag,
+            GasCostsValues::V2(v2) => v2.flag,
         }
     }
 
     pub fn gm(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.gm,
+            GasCostsValues::V2(v2) => v2.gm,
         }
     }
 
     pub fn gt(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.gt,
+            GasCostsValues::V2(v2) => v2.gt,
         }
     }
 
     pub fn gtf(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.gtf,
+            GasCostsValues::V2(v2) => v2.gtf,
         }
     }
 
     pub fn ji(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.ji,
+            GasCostsValues::V2(v2) => v2.ji,
         }
     }
 
     pub fn jmp(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.jmp,
+            GasCostsValues::V2(v2) => v2.jmp,
         }
     }
 
     pub fn jne(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.jne,
+            GasCostsValues::V2(v2) => v2.jne,
         }
     }
 
     pub fn jnei(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.jnei,
+            GasCostsValues::V2(v2) => v2.jnei,
         }
     }
 
     pub fn jnzi(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.jnzi,
+            GasCostsValues::V2(v2) => v2.jnzi,
         }
     }
 
     pub fn jmpf(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.jmpf,
+            GasCostsValues::V2(v2) => v2.jmpf,
         }
     }
 
     pub fn jmpb(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.jmpb,
+            GasCostsValues::V2(v2) => v2.jmpb,
         }
     }
 
     pub fn jnzf(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.jnzf,
+            GasCostsValues::V2(v2) => v2.jnzf,
         }
     }
 
     pub fn jnzb(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.jnzb,
+            GasCostsValues::V2(v2) => v2.jnzb,
         }
     }
 
     pub fn jnef(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.jnef,
+            GasCostsValues::V2(v2) => v2.jnef,
         }
     }
 
     pub fn jneb(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.jneb,
+            GasCostsValues::V2(v2) => v2.jneb,
         }
     }
 
     pub fn lb(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.lb,
+            GasCostsValues::V2(v2) => v2.lb,
         }
     }
 
     pub fn log(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.log,
+            GasCostsValues::V2(v2) => v2.log,
         }
     }
 
     pub fn lt(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.lt,
+            GasCostsValues::V2(v2) => v2.lt,
         }
     }
 
     pub fn lw(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.lw,
+            GasCostsValues::V2(v2) => v2.lw,
         }
     }
 
     pub fn mint(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.mint,
+            GasCostsValues::V2(v2) => v2.mint,
         }
     }
 
     pub fn mlog(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.mlog,
+            GasCostsValues::V2(v2) => v2.mlog,
         }
     }
 
     pub fn mod_op(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.mod_op,
+            GasCostsValues::V2(v2) => v2.mod_op,
         }
     }
 
     pub fn modi(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.modi,
+            GasCostsValues::V2(v2) => v2.modi,
         }
     }
 
     pub fn move_op(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.move_op,
+            GasCostsValues::V2(v2) => v2.move_op,
         }
     }
 
     pub fn movi(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.movi,
+            GasCostsValues::V2(v2) => v2.movi,
         }
     }
 
     pub fn mroo(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.mroo,
+            GasCostsValues::V2(v2) => v2.mroo,
         }
     }
 
     pub fn mul(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.mul,
+            GasCostsValues::V2(v2) => v2.mul,
         }
     }
 
     pub fn muli(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.muli,
+            GasCostsValues::V2(v2) => v2.muli,
         }
     }
 
     pub fn mldv(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.mldv,
+            GasCostsValues::V2(v2) => v2.mldv,
         }
     }
 
     pub fn noop(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.noop,
+            GasCostsValues::V2(v2) => v2.noop,
         }
     }
 
     pub fn not(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.not,
+            GasCostsValues::V2(v2) => v2.not,
         }
     }
 
     pub fn or(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.or,
+            GasCostsValues::V2(v2) => v2.or,
         }
     }
 
     pub fn ori(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.ori,
+            GasCostsValues::V2(v2) => v2.ori,
         }
     }
 
     pub fn poph(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.poph,
+            GasCostsValues::V2(v2) => v2.poph,
         }
     }
 
     pub fn popl(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.popl,
+            GasCostsValues::V2(v2) => v2.popl,
         }
     }
 
     pub fn pshh(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.pshh,
+            GasCostsValues::V2(v2) => v2.pshh,
         }
     }
 
     pub fn pshl(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.pshl,
+            GasCostsValues::V2(v2) => v2.pshl,
         }
     }
 
     pub fn ret(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.ret,
+            GasCostsValues::V2(v2) => v2.ret,
         }
     }
 
     pub fn rvrt(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.rvrt,
+            GasCostsValues::V2(v2) => v2.rvrt,
         }
     }
 
     pub fn sb(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.sb,
+            GasCostsValues::V2(v2) => v2.sb,
         }
     }
 
     pub fn sll(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.sll,
+            GasCostsValues::V2(v2) => v2.sll,
         }
     }
 
     pub fn slli(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.slli,
+            GasCostsValues::V2(v2) => v2.slli,
         }
     }
 
     pub fn srl(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.srl,
+            GasCostsValues::V2(v2) => v2.srl,
         }
     }
 
     pub fn srli(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.srli,
+            GasCostsValues::V2(v2) => v2.srli,
         }
     }
 
     pub fn srw(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.srw,
+            GasCostsValues::V2(v2) => v2.srw,
         }
     }
 
     pub fn sub(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.sub,
+            GasCostsValues::V2(v2) => v2.sub,
         }
     }
 
     pub fn subi(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.subi,
+            GasCostsValues::V2(v2) => v2.subi,
         }
     }
 
     pub fn sw(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.sw,
+            GasCostsValues::V2(v2) => v2.sw,
         }
     }
 
     pub fn sww(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.sww,
+            GasCostsValues::V2(v2) => v2.sww,
         }
     }
 
     pub fn time(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.time,
+            GasCostsValues::V2(v2) => v2.time,
         }
     }
 
     pub fn tr(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.tr,
+            GasCostsValues::V2(v2) => v2.tr,
         }
     }
 
     pub fn tro(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.tro,
+            GasCostsValues::V2(v2) => v2.tro,
         }
     }
 
     pub fn wdcm(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.wdcm,
+            GasCostsValues::V2(v2) => v2.wdcm,
         }
     }
 
     pub fn wqcm(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.wqcm,
+            GasCostsValues::V2(v2) => v2.wqcm,
         }
     }
 
     pub fn wdop(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.wdop,
+            GasCostsValues::V2(v2) => v2.wdop,
         }
     }
 
     pub fn wqop(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.wqop,
+            GasCostsValues::V2(v2) => v2.wqop,
         }
     }
 
     pub fn wdml(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.wdml,
+            GasCostsValues::V2(v2) => v2.wdml,
         }
     }
 
     pub fn wqml(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.wqml,
+            GasCostsValues::V2(v2) => v2.wqml,
         }
     }
 
     pub fn wddv(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.wddv,
+            GasCostsValues::V2(v2) => v2.wddv,
         }
     }
 
     pub fn wqdv(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.wqdv,
+            GasCostsValues::V2(v2) => v2.wqdv,
         }
     }
 
     pub fn wdmd(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.wdmd,
+            GasCostsValues::V2(v2) => v2.wdmd,
         }
     }
 
     pub fn wqmd(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.wqmd,
+            GasCostsValues::V2(v2) => v2.wqmd,
         }
     }
 
     pub fn wdam(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.wdam,
+            GasCostsValues::V2(v2) => v2.wdam,
         }
     }
 
     pub fn wqam(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.wqam,
+            GasCostsValues::V2(v2) => v2.wqam,
         }
     }
 
     pub fn wdmm(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.wdmm,
+            GasCostsValues::V2(v2) => v2.wdmm,
         }
     }
 
     pub fn wqmm(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.wqmm,
+            GasCostsValues::V2(v2) => v2.wqmm,
         }
     }
 
     pub fn xor(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.xor,
+            GasCostsValues::V2(v2) => v2.xor,
         }
     }
 
     pub fn xori(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.xori,
+            GasCostsValues::V2(v2) => v2.xori,
+        }
+    }
+
+    pub fn aloc(&self) -> DependentCost {
+        match self {
+            GasCostsValues::V1(v1) => DependentCost::HeavyOperation {
+                base: v1.aloc,
+                gas_per_unit: 0,
+            },
+            GasCostsValues::V2(v2) => v2.aloc,
         }
     }
 
     pub fn call(&self) -> DependentCost {
         match self {
             GasCostsValues::V1(v1) => v1.call,
+            GasCostsValues::V2(v2) => v2.call,
         }
     }
 
     pub fn ccp(&self) -> DependentCost {
         match self {
             GasCostsValues::V1(v1) => v1.ccp,
+            GasCostsValues::V2(v2) => v2.ccp,
         }
     }
 
     pub fn croo(&self) -> DependentCost {
         match self {
             GasCostsValues::V1(v1) => v1.croo,
+            GasCostsValues::V2(v2) => v2.croo,
         }
     }
 
     pub fn csiz(&self) -> DependentCost {
         match self {
             GasCostsValues::V1(v1) => v1.csiz,
+            GasCostsValues::V2(v2) => v2.csiz,
         }
     }
 
     pub fn k256(&self) -> DependentCost {
         match self {
             GasCostsValues::V1(v1) => v1.k256,
+            GasCostsValues::V2(v2) => v2.k256,
         }
     }
 
     pub fn ldc(&self) -> DependentCost {
         match self {
             GasCostsValues::V1(v1) => v1.ldc,
+            GasCostsValues::V2(v2) => v2.ldc,
         }
     }
 
     pub fn logd(&self) -> DependentCost {
         match self {
             GasCostsValues::V1(v1) => v1.logd,
+            GasCostsValues::V2(v2) => v2.logd,
         }
     }
 
     pub fn mcl(&self) -> DependentCost {
         match self {
             GasCostsValues::V1(v1) => v1.mcl,
+            GasCostsValues::V2(v2) => v2.mcl,
         }
     }
 
     pub fn mcli(&self) -> DependentCost {
         match self {
             GasCostsValues::V1(v1) => v1.mcli,
+            GasCostsValues::V2(v2) => v2.mcli,
         }
     }
 
     pub fn mcp(&self) -> DependentCost {
         match self {
             GasCostsValues::V1(v1) => v1.mcp,
+            GasCostsValues::V2(v2) => v2.mcp,
         }
     }
 
     pub fn mcpi(&self) -> DependentCost {
         match self {
             GasCostsValues::V1(v1) => v1.mcpi,
+            GasCostsValues::V2(v2) => v2.mcpi,
         }
     }
 
     pub fn meq(&self) -> DependentCost {
         match self {
             GasCostsValues::V1(v1) => v1.meq,
+            GasCostsValues::V2(v2) => v2.meq,
         }
     }
 
     pub fn retd(&self) -> DependentCost {
         match self {
             GasCostsValues::V1(v1) => v1.retd,
+            GasCostsValues::V2(v2) => v2.retd,
         }
     }
 
     pub fn s256(&self) -> DependentCost {
         match self {
             GasCostsValues::V1(v1) => v1.s256,
+            GasCostsValues::V2(v2) => v2.s256,
         }
     }
 
     pub fn scwq(&self) -> DependentCost {
         match self {
             GasCostsValues::V1(v1) => v1.scwq,
+            GasCostsValues::V2(v2) => v2.scwq,
         }
     }
 
     pub fn smo(&self) -> DependentCost {
         match self {
             GasCostsValues::V1(v1) => v1.smo,
+            GasCostsValues::V2(v2) => v2.smo,
         }
     }
 
     pub fn srwq(&self) -> DependentCost {
         match self {
             GasCostsValues::V1(v1) => v1.srwq,
+            GasCostsValues::V2(v2) => v2.srwq,
         }
     }
 
     pub fn swwq(&self) -> DependentCost {
         match self {
             GasCostsValues::V1(v1) => v1.swwq,
+            GasCostsValues::V2(v2) => v2.swwq,
         }
     }
 
     pub fn contract_root(&self) -> DependentCost {
         match self {
             GasCostsValues::V1(v1) => v1.contract_root,
+            GasCostsValues::V2(v2) => v2.contract_root,
         }
     }
 
     pub fn state_root(&self) -> DependentCost {
         match self {
             GasCostsValues::V1(v1) => v1.state_root,
+            GasCostsValues::V2(v2) => v2.state_root,
         }
     }
 
     pub fn new_storage_per_byte(&self) -> Word {
         match self {
             GasCostsValues::V1(v1) => v1.new_storage_per_byte,
+            GasCostsValues::V2(v2) => v2.new_storage_per_byte,
         }
     }
 
     pub fn vm_initialization(&self) -> DependentCost {
         match self {
             GasCostsValues::V1(v1) => v1.vm_initialization,
+            GasCostsValues::V2(v2) => v2.vm_initialization,
         }
     }
 }
@@ -864,6 +979,134 @@ pub struct GasCostsValuesV1 {
     pub vm_initialization: DependentCost,
 }
 
+/// Gas costs for every op.
+/// The difference with [`GasCostsValuesV1`]:
+/// - `aloc` is a [`DependentCost`] instead of a [`Word`]
+#[allow(missing_docs)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(default = "GasCostsValuesV2::unit")]
+pub struct GasCostsValuesV2 {
+    pub add: Word,
+    pub addi: Word,
+    pub and: Word,
+    pub andi: Word,
+    pub bal: Word,
+    pub bhei: Word,
+    pub bhsh: Word,
+    pub burn: Word,
+    pub cb: Word,
+    pub cfei: Word,
+    pub cfsi: Word,
+    pub div: Word,
+    pub divi: Word,
+    pub eck1: Word,
+    pub ecr1: Word,
+    pub ed19: Word,
+    pub eq: Word,
+    pub exp: Word,
+    pub expi: Word,
+    pub flag: Word,
+    pub gm: Word,
+    pub gt: Word,
+    pub gtf: Word,
+    pub ji: Word,
+    pub jmp: Word,
+    pub jne: Word,
+    pub jnei: Word,
+    pub jnzi: Word,
+    pub jmpf: Word,
+    pub jmpb: Word,
+    pub jnzf: Word,
+    pub jnzb: Word,
+    pub jnef: Word,
+    pub jneb: Word,
+    pub lb: Word,
+    pub log: Word,
+    pub lt: Word,
+    pub lw: Word,
+    pub mint: Word,
+    pub mlog: Word,
+    #[cfg_attr(feature = "serde", serde(rename = "mod"))]
+    pub mod_op: Word,
+    pub modi: Word,
+    #[cfg_attr(feature = "serde", serde(rename = "move"))]
+    pub move_op: Word,
+    pub movi: Word,
+    pub mroo: Word,
+    pub mul: Word,
+    pub muli: Word,
+    pub mldv: Word,
+    pub noop: Word,
+    pub not: Word,
+    pub or: Word,
+    pub ori: Word,
+    pub poph: Word,
+    pub popl: Word,
+    pub pshh: Word,
+    pub pshl: Word,
+    #[cfg_attr(feature = "serde", serde(rename = "ret_contract"))]
+    pub ret: Word,
+    #[cfg_attr(feature = "serde", serde(rename = "rvrt_contract"))]
+    pub rvrt: Word,
+    pub sb: Word,
+    pub sll: Word,
+    pub slli: Word,
+    pub srl: Word,
+    pub srli: Word,
+    pub srw: Word,
+    pub sub: Word,
+    pub subi: Word,
+    pub sw: Word,
+    pub sww: Word,
+    pub time: Word,
+    pub tr: Word,
+    pub tro: Word,
+    pub wdcm: Word,
+    pub wqcm: Word,
+    pub wdop: Word,
+    pub wqop: Word,
+    pub wdml: Word,
+    pub wqml: Word,
+    pub wddv: Word,
+    pub wqdv: Word,
+    pub wdmd: Word,
+    pub wqmd: Word,
+    pub wdam: Word,
+    pub wqam: Word,
+    pub wdmm: Word,
+    pub wqmm: Word,
+    pub xor: Word,
+    pub xori: Word,
+
+    // Dependent
+    pub aloc: DependentCost,
+    pub call: DependentCost,
+    pub ccp: DependentCost,
+    pub croo: DependentCost,
+    pub csiz: DependentCost,
+    pub k256: DependentCost,
+    pub ldc: DependentCost,
+    pub logd: DependentCost,
+    pub mcl: DependentCost,
+    pub mcli: DependentCost,
+    pub mcp: DependentCost,
+    pub mcpi: DependentCost,
+    pub meq: DependentCost,
+    #[cfg_attr(feature = "serde", serde(rename = "retd_contract"))]
+    pub retd: DependentCost,
+    pub s256: DependentCost,
+    pub scwq: DependentCost,
+    pub smo: DependentCost,
+    pub srwq: DependentCost,
+    pub swwq: DependentCost,
+
+    // Non-opcode costs
+    pub contract_root: DependentCost,
+    pub state_root: DependentCost,
+    pub new_storage_per_byte: Word,
+    pub vm_initialization: DependentCost,
+}
+
 /// Dependent cost is a cost that depends on the number of units.
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
@@ -908,12 +1151,12 @@ impl GasCosts {
 impl GasCostsValues {
     /// Create costs that are all set to zero.
     pub fn free() -> Self {
-        GasCostsValuesV1::free().into()
+        GasCostsValuesV2::free().into()
     }
 
     /// Create costs that are all set to one.
     pub fn unit() -> Self {
-        GasCostsValuesV1::unit().into()
+        GasCostsValuesV2::unit().into()
     }
 }
 
@@ -1155,6 +1398,244 @@ impl GasCostsValuesV1 {
     }
 }
 
+impl GasCostsValuesV2 {
+    /// Create costs that are all set to zero.
+    pub fn free() -> Self {
+        Self {
+            add: 0,
+            addi: 0,
+            and: 0,
+            andi: 0,
+            bal: 0,
+            bhei: 0,
+            bhsh: 0,
+            burn: 0,
+            cb: 0,
+            cfei: 0,
+            cfsi: 0,
+            div: 0,
+            divi: 0,
+            eck1: 0,
+            ecr1: 0,
+            ed19: 0,
+            eq: 0,
+            exp: 0,
+            expi: 0,
+            flag: 0,
+            gm: 0,
+            gt: 0,
+            gtf: 0,
+            ji: 0,
+            jmp: 0,
+            jne: 0,
+            jnei: 0,
+            jnzi: 0,
+            jmpf: 0,
+            jmpb: 0,
+            jnzf: 0,
+            jnzb: 0,
+            jnef: 0,
+            jneb: 0,
+            lb: 0,
+            log: 0,
+            lt: 0,
+            lw: 0,
+            mint: 0,
+            mlog: 0,
+            mod_op: 0,
+            modi: 0,
+            move_op: 0,
+            movi: 0,
+            mroo: 0,
+            mul: 0,
+            muli: 0,
+            mldv: 0,
+            noop: 0,
+            not: 0,
+            or: 0,
+            ori: 0,
+            poph: 0,
+            popl: 0,
+            pshh: 0,
+            pshl: 0,
+            ret: 0,
+            rvrt: 0,
+            sb: 0,
+            sll: 0,
+            slli: 0,
+            srl: 0,
+            srli: 0,
+            srw: 0,
+            sub: 0,
+            subi: 0,
+            sw: 0,
+            sww: 0,
+            time: 0,
+            tr: 0,
+            tro: 0,
+            wdcm: 0,
+            wqcm: 0,
+            wdop: 0,
+            wqop: 0,
+            wdml: 0,
+            wqml: 0,
+            wddv: 0,
+            wqdv: 0,
+            wdmd: 0,
+            wqmd: 0,
+            wdam: 0,
+            wqam: 0,
+            wdmm: 0,
+            wqmm: 0,
+            xor: 0,
+            xori: 0,
+            aloc: DependentCost::free(),
+            call: DependentCost::free(),
+            ccp: DependentCost::free(),
+            croo: DependentCost::free(),
+            csiz: DependentCost::free(),
+            k256: DependentCost::free(),
+            ldc: DependentCost::free(),
+            logd: DependentCost::free(),
+            mcl: DependentCost::free(),
+            mcli: DependentCost::free(),
+            mcp: DependentCost::free(),
+            mcpi: DependentCost::free(),
+            meq: DependentCost::free(),
+            retd: DependentCost::free(),
+            s256: DependentCost::free(),
+            scwq: DependentCost::free(),
+            smo: DependentCost::free(),
+            srwq: DependentCost::free(),
+            swwq: DependentCost::free(),
+
+            // Non-opcode costs
+            contract_root: DependentCost::free(),
+            state_root: DependentCost::free(),
+            new_storage_per_byte: 0,
+            vm_initialization: DependentCost::free(),
+        }
+    }
+
+    /// Create costs that are all set to one.
+    pub fn unit() -> Self {
+        Self {
+            add: 1,
+            addi: 1,
+            and: 1,
+            andi: 1,
+            bal: 1,
+            bhei: 1,
+            bhsh: 1,
+            burn: 1,
+            cb: 1,
+            cfei: 1,
+            cfsi: 1,
+            div: 1,
+            divi: 1,
+            eck1: 1,
+            ecr1: 1,
+            ed19: 1,
+            eq: 1,
+            exp: 1,
+            expi: 1,
+            flag: 1,
+            gm: 1,
+            gt: 1,
+            gtf: 1,
+            ji: 1,
+            jmp: 1,
+            jne: 1,
+            jnei: 1,
+            jnzi: 1,
+            jmpf: 1,
+            jmpb: 1,
+            jnzf: 1,
+            jnzb: 1,
+            jnef: 1,
+            jneb: 1,
+            lb: 1,
+            log: 1,
+            lt: 1,
+            lw: 1,
+            mint: 1,
+            mlog: 1,
+            mod_op: 1,
+            modi: 1,
+            move_op: 1,
+            movi: 1,
+            mroo: 1,
+            mul: 1,
+            muli: 1,
+            mldv: 1,
+            noop: 1,
+            not: 1,
+            or: 1,
+            ori: 1,
+            ret: 1,
+            poph: 1,
+            popl: 1,
+            pshh: 1,
+            pshl: 1,
+            rvrt: 1,
+            sb: 1,
+            sll: 1,
+            slli: 1,
+            srl: 1,
+            srli: 1,
+            srw: 1,
+            sub: 1,
+            subi: 1,
+            sw: 1,
+            sww: 1,
+            time: 1,
+            tr: 1,
+            tro: 1,
+            wdcm: 1,
+            wqcm: 1,
+            wdop: 1,
+            wqop: 1,
+            wdml: 1,
+            wqml: 1,
+            wddv: 1,
+            wqdv: 1,
+            wdmd: 1,
+            wqmd: 1,
+            wdam: 1,
+            wqam: 1,
+            wdmm: 1,
+            wqmm: 1,
+            xor: 1,
+            xori: 1,
+            aloc: DependentCost::unit(),
+            call: DependentCost::unit(),
+            ccp: DependentCost::unit(),
+            croo: DependentCost::unit(),
+            csiz: DependentCost::unit(),
+            k256: DependentCost::unit(),
+            ldc: DependentCost::unit(),
+            logd: DependentCost::unit(),
+            mcl: DependentCost::unit(),
+            mcli: DependentCost::unit(),
+            mcp: DependentCost::unit(),
+            mcpi: DependentCost::unit(),
+            meq: DependentCost::unit(),
+            retd: DependentCost::unit(),
+            s256: DependentCost::unit(),
+            scwq: DependentCost::unit(),
+            smo: DependentCost::unit(),
+            srwq: DependentCost::unit(),
+            swwq: DependentCost::unit(),
+
+            // Non-opcode costs
+            contract_root: DependentCost::unit(),
+            state_root: DependentCost::unit(),
+            new_storage_per_byte: 1,
+            vm_initialization: DependentCost::unit(),
+        }
+    }
+}
+
 impl DependentCost {
     /// Create costs that make operations free.
     pub fn free() -> Self {
@@ -1255,6 +1736,12 @@ impl From<GasCosts> for GasCostsValues {
 impl From<GasCostsValuesV1> for GasCostsValues {
     fn from(i: GasCostsValuesV1) -> Self {
         GasCostsValues::V1(i)
+    }
+}
+
+impl From<GasCostsValuesV2> for GasCostsValues {
+    fn from(i: GasCostsValuesV2) -> Self {
+        GasCostsValues::V2(i)
     }
 }
 

--- a/fuel-tx/src/transaction/consensus_parameters/gas/default_gas_costs.rs
+++ b/fuel-tx/src/transaction/consensus_parameters/gas/default_gas_costs.rs
@@ -3,10 +3,9 @@ use super::*;
 /// hash
 pub const GIT: &str = "98341e564b75d1157e61d7d5f38612f6224a5b30";
 pub fn default_gas_costs() -> GasCostsValues {
-    GasCostsValuesV1 {
+    GasCostsValuesV2 {
         add: 1,
         addi: 1,
-        aloc: 1,
         and: 1,
         andi: 1,
         bal: 13,
@@ -91,6 +90,10 @@ pub fn default_gas_costs() -> GasCostsValues {
         wqmm: 3,
         xor: 1,
         xori: 1,
+        aloc: DependentCost::LightOperation {
+            base: 2,
+            units_per_gas: 214,
+        },
         k256: DependentCost::LightOperation {
             base: 11,
             units_per_gas: 214,

--- a/fuel-vm/src/interpreter/executors/instruction.rs
+++ b/fuel-vm/src/interpreter/executors/instruction.rs
@@ -604,9 +604,10 @@ where
             }
 
             Instruction::ALOC(aloc) => {
-                self.gas_charge(self.gas_costs().aloc())?;
                 let a = aloc.unpack();
-                self.malloc(r!(a))?;
+                let number_of_bytes = r!(a);
+                self.dependent_gas_charge(self.gas_costs().aloc(), number_of_bytes)?;
+                self.malloc(number_of_bytes)?;
             }
 
             Instruction::CFEI(cfei) => {

--- a/fuel-vm/src/interpreter/executors/main.rs
+++ b/fuel-vm/src/interpreter/executors/main.rs
@@ -251,7 +251,7 @@ where
             {
                 let tx = kind.tx().clone();
                 let my_params = params.clone();
-                let mut memory = pool.get_new();
+                let mut memory = pool.get_new().await;
 
                 let verify_task = E::create_task(move || {
                     Interpreter::check_predicate(

--- a/fuel-vm/src/interpreter/executors/main.rs
+++ b/fuel-vm/src/interpreter/executors/main.rs
@@ -251,7 +251,7 @@ where
             {
                 let tx = kind.tx().clone();
                 let my_params = params.clone();
-                let mut memory = pool.get_new().await;
+                let mut memory = pool.get_new();
 
                 let verify_task = E::create_task(move || {
                     Interpreter::check_predicate(

--- a/fuel-vm/src/memory_client.rs
+++ b/fuel-vm/src/memory_client.rs
@@ -8,7 +8,6 @@ use crate::{
         EcalHandler,
         InterpreterParams,
         Memory,
-        MemoryInstance,
         NotSupportedEcal,
     },
     state::StateTransitionRef,
@@ -25,6 +24,9 @@ use fuel_tx::{
     Upgrade,
     Upload,
 };
+
+#[cfg(any(test, feature = "test-helpers"))]
+use crate::interpreter::MemoryInstance;
 
 #[derive(Debug)]
 /// Client implementation with in-memory storage backend.

--- a/fuel-vm/src/pool.rs
+++ b/fuel-vm/src/pool.rs
@@ -11,7 +11,7 @@ pub trait VmMemoryPool: Sync {
     type Memory: Memory + Send + Sync + 'static;
 
     /// Gets a new VM memory instance from the pool.
-    fn get_new(&self) -> impl core::future::Future<Output = Self::Memory> + Send;
+    fn get_new(&self) -> Self::Memory;
 }
 
 /// Dummy pool that just returns new instance every time.
@@ -23,7 +23,7 @@ pub struct DummyPool;
 impl VmMemoryPool for DummyPool {
     type Memory = MemoryInstance;
 
-    fn get_new(&self) -> impl core::future::Future<Output = Self::Memory> + Send {
-        core::future::ready(MemoryInstance::new())
+    fn get_new(&self) -> Self::Memory {
+        MemoryInstance::new()
     }
 }

--- a/fuel-vm/src/pool.rs
+++ b/fuel-vm/src/pool.rs
@@ -1,9 +1,9 @@
 //! Pool of VM memory instances for reuse.
 
-use crate::interpreter::{
-    Memory,
-    MemoryInstance,
-};
+use crate::interpreter::Memory;
+
+#[cfg(any(test, feature = "test-helpers"))]
+use crate::interpreter::MemoryInstance;
 
 /// Trait for a VM memory pool.
 pub trait VmMemoryPool: Sync {
@@ -11,7 +11,7 @@ pub trait VmMemoryPool: Sync {
     type Memory: Memory + Send + Sync + 'static;
 
     /// Gets a new VM memory instance from the pool.
-    fn get_new(&self) -> Self::Memory;
+    fn get_new(&self) -> impl core::future::Future<Output = Self::Memory> + Send;
 }
 
 /// Dummy pool that just returns new instance every time.
@@ -23,7 +23,7 @@ pub struct DummyPool;
 impl VmMemoryPool for DummyPool {
     type Memory = MemoryInstance;
 
-    fn get_new(&self) -> Self::Memory {
-        MemoryInstance::new()
+    fn get_new(&self) -> impl core::future::Future<Output = Self::Memory> + Send {
+        core::future::ready(MemoryInstance::new())
     }
 }

--- a/fuel-vm/src/transactor.rs
+++ b/fuel-vm/src/transactor.rs
@@ -15,7 +15,6 @@ use crate::{
         Interpreter,
         InterpreterParams,
         Memory,
-        MemoryInstance,
         NotSupportedEcal,
     },
     state::{
@@ -34,6 +33,9 @@ use fuel_tx::{
     Upgrade,
     Upload,
 };
+
+#[cfg(any(test, feature = "test-helpers"))]
+use crate::interpreter::MemoryInstance;
 
 #[derive(Debug)]
 /// State machine to execute transactions and provide runtime entities on


### PR DESCRIPTION
Since we zero bytes during the heap allocation, we need to iterate over `n` bytes of memory. It may be a lot of work so we need to charge for it properly.

<img width="754" alt="image" src="https://github.com/FuelLabs/fuel-vm/assets/18346821/fc79e977-da66-422d-ac76-49cabdc34243">

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that - https://github.com/FuelLabs/fuel-core/pull/1934

### Before requesting review
- [x] I have reviewed the code myself
