### PR TITLE
Make `VmMemoryPool::get_new` async

### DIFF
--- a/fuel-vm/src/interpreter/executors/main.rs
+++ b/fuel-vm/src/interpreter/executors/main.rs
@@ -251,7 +251,7 @@ where
             {
                 let tx = kind.tx().clone();
                 let my_params = params.clone();
-                let mut memory = pool.get_new();
+                let mut memory = pool.get_new().await;
 
                 let verify_task = E::create_task(move || {
                     Interpreter::check_predicate(

--- a/fuel-vm/src/pool.rs
+++ b/fuel-vm/src/pool.rs
@@ -11,7 +11,7 @@ pub trait VmMemoryPool: Sync {
     type Memory: Memory + Send + Sync + 'static;
 
     /// Gets a new VM memory instance from the pool.
-    fn get_new(&self) -> Self::Memory;
+    fn get_new(&self) -> impl core::future::Future<Output = Self::Memory> + Send;
 }
 
 /// Dummy pool that just returns new instance every time.
@@ -23,7 +23,7 @@ pub struct DummyPool;
 impl VmMemoryPool for DummyPool {
     type Memory = MemoryInstance;
 
-    fn get_new(&self) -> Self::Memory {
-        MemoryInstance::new()
+    fn get_new(&self) -> impl core::future::Future<Output = Self::Memory> + Send {
+        core::future::ready(MemoryInstance::new())
     }
 }


### PR DESCRIPTION
In `fuel-core` we are using a tokio mutex and it requires `async` context.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog

### Before requesting review
- [x] I have reviewed the code myself
