### PR TITLE
Release v0.52.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.52.0]
+
 ### Changed
 
 #### Breaking

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,17 +17,17 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.51.0"
+version = "0.52.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.51.0", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.51.0", path = "fuel-crypto", default-features = false }
-fuel-derive = { version = "0.51.0", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.51.0", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.51.0", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.51.0", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.51.0", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.51.0", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.52.0", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.52.0", path = "fuel-crypto", default-features = false }
+fuel-derive = { version = "0.52.0", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.52.0", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.52.0", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.52.0", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.52.0", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.52.0", path = "fuel-vm", default-features = false }
 bitflags = "2"
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
## Version v0.52.0

### Changed

#### Breaking

- [#748](https://github.com/FuelLabs/fuel-vm/pull/748): Make `VmMemoryPool::get_new` async.
- [#747](https://github.com/FuelLabs/fuel-vm/pull/747): Use `DependentCost` for `aloc` opcode. The cost of the `aloc` opcode is now dependent on the size of the allocation.

## What's Changed
* Use `DependentCost` for `aloc` opcode by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/747
* Make `VmMemoryPool::get_new` async by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/748


**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.51.0...v0.52.0