### PR TITLE
Generate and publish code coverage reports in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ env:
   CARGO_TERM_COLOR: always
   RUST_VERSION: 1.75.0
   NIGHTLY_RUST_VERSION: nightly-2024-02-07
+  GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
 
 jobs:
   check-changelog:
@@ -104,6 +105,42 @@ jobs:
         with:
           version: "0.36.4"
       - run: cargo ${{ matrix.command }} ${{ matrix.args }}
+
+  publish-codecov:
+    name: Publish code coverage report on GitHub pages branch
+    runs-on: buildjet-4vcpu-ubuntu-2204
+    needs:
+      - cargo
+    permissions: # Write access to push changes to pages
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install latest Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - name: Install cargo-llvm-codecov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Code coverage report
+        run: cargo llvm-cov --all-features --html
+
+      - name: Checkout the repo again for pushing pages revision
+        uses: actions/checkout@v3
+        with:
+          ref: 'codecov-pages'
+          path: 'pages-branch'
+
+      - name: Push codecov report to it's branch
+        working-directory: ./pages-branch
+        run: |
+          git config user.email "2204863+Dentosal@users.noreply.github.com"
+          git config user.name "Dentosal"
+          cp -r ../target/llvm-cov/html ${{ env.GIT_BRANCH }}
+          git add .
+          git commit -m "Update codecov for ${{ env.GIT_BRANCH }}"
+          git push
 
   rustfmt:
     runs-on: buildjet-4vcpu-ubuntu-2204

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,15 +132,21 @@ jobs:
           ref: 'codecov-pages'
           path: 'pages-branch'
 
-      - name: Push codecov report to it's branch
+      - name: Push codecov report to pages branch
         working-directory: ./pages-branch
         run: |
+          export BRANCH_B64=$(echo -n "${{ env.GIT_BRANCH }}" | basenc --base64url)
           git config user.email "2204863+Dentosal@users.noreply.github.com"
           git config user.name "Dentosal"
-          cp -r ../target/llvm-cov/html ${{ env.GIT_BRANCH }}
+          cp -r ../target/llvm-cov/html "$BRANCH_B64"
+          python3 ../.github/workflows/scripts/generate_pages_index.py > index.html
           git add .
           git commit -m "Update codecov for ${{ env.GIT_BRANCH }}"
           git push
+          export PAGES_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/$BRANCH_B64/index.html"
+          echo "$PAGES_URL"
+          echo "Codecov report $PAGES_URL" >> $GITHUB_STEP_SUMMARY          
+        
 
   rustfmt:
     runs-on: buildjet-4vcpu-ubuntu-2204

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_VERSION: 1.75.0
-  NIGHTLY_RUST_VERSION: nightly-2024-02-07
+  RUST_VERSION_FMT: nightly-2024-02-07
+  RUST_VERSION_COV: nightly-2024-06-05
   GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
 
 jobs:
@@ -118,13 +119,13 @@ jobs:
       - name: Install latest Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ env.RUST_VERSION }}
+          toolchain: ${{ env.RUST_VERSION_COV }}
 
       - name: Install cargo-llvm-codecov
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Code coverage report
-        run: cargo llvm-cov --all-features --html
+        run: cargo  +${{ env.RUST_VERSION_COV }} llvm-cov --all-features --html --branch
 
       - name: Checkout the repo again for pushing pages revision
         uses: actions/checkout@v3
@@ -155,11 +156,11 @@ jobs:
       - name: Install latest nightly
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ env.NIGHTLY_RUST_VERSION }}
+          toolchain: ${{ env.RUST_VERSION_FMT }}
           components: rustfmt
 
       - name: Rustfmt check
-        run: cargo +${{ env.NIGHTLY_RUST_VERSION }} fmt --all -- --check
+        run: cargo +${{ env.RUST_VERSION_FMT }} fmt --all -- --check
 
   cargo-toml-fmt-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/scripts/generate_pages_index.py
+++ b/.github/workflows/scripts/generate_pages_index.py
@@ -1,0 +1,17 @@
+#!python3
+# Generate index.html for code coverage pages
+
+from glob import iglob
+from base64 import urlsafe_b64encode, urlsafe_b64decode
+
+master_path = urlsafe_b64encode(b"master").decode("utf-8")
+
+print("<html><head><title>Code Coverage</title>")
+print("<style>body { font-size: 1.2em }</style>")
+print(f"</head><body><h1>Code coverage</h1>")
+print(f"<h2>Per branch (<a href=\"{master_path}/index.html\">master</a>)</h2><ul>")
+for path in sorted(list(iglob("*/index.html", recursive=True))):
+    name = urlsafe_b64decode(path.split("/")[0].encode()).decode()
+    style = "font-weight: bold" if name == "master" else ""
+    print(f'<li style="{style}"><a href="{path}">{name}</a></li>')
+print("</ul></body></html>")


### PR DESCRIPTION
Closes #745

This PR sets up code coverage reporting. It commits the report to [a branch called `codecov-pages`](https://github.com/FuelLabs/fuel-vm/tree/codecov-pages), which contains a folder for each branch. Branch names are urlsafe-base64-encoded to avoid (security) bugs. Every time a PR workflow runs or the  `master` receives new commits, a CI action pushes updated codecov report there.

The testing for this feature is done in https://github.com/Dentosal/test-repo, and ported here.

Possible improvements:
- [ ] Clean up deleted branches automatically
- [x] Generate `index.html` that contains link to all branches
- [ ] Replace my personal name and email from the commit message with something like org-owned bot

## Repository setup

The configuration has to be done by someone who has permission to edit [the repo settings](https://github.com/FuelLabs/fuel-vm/settings/pages): set deployment from `codecov-pages` branch, like this:
<img width="510" alt="Screenshot of the settings page" src="https://github.com/FuelLabs/fuel-vm/assets/2204863/e22d5c43-825d-4fd2-b5e1-0a2c3e826ce8">



