### PR TITLE
Remove Bug type

### DIFF
--- a/fuel-vm/Cargo.toml
+++ b/fuel-vm/Cargo.toml
@@ -36,16 +36,12 @@ hashbrown = "0.14"
 itertools = { version = "0.10", default-features = false }
 libm = { version = "0.2", default-features = false }
 paste = "1.0"
-percent-encoding = { version = "2.3", features = [
-    "alloc",
-], default-features = false }
 primitive-types = { version = "0.12", default-features = false }
 rand = { version = "0.8", optional = true }
 serde = { version = "1.0", features = ["derive", "rc"], optional = true }
 serde_with = { version = "3.7", optional = true }
 sha3 = { version = "0.10", default-features = false }
 static_assertions = "1.1"
-strum = { version = "0.24", features = ["derive"], default-features = false }
 tai64 = { version = "4.0", default-features = false }
 
 [dev-dependencies]

--- a/fuel-vm/src/error.rs
+++ b/fuel-vm/src/error.rs
@@ -11,10 +11,7 @@ use fuel_tx::ValidityError;
 use crate::checked_transaction::CheckError;
 use alloc::{
     format,
-    string::{
-        String,
-        ToString,
-    },
+    string::String,
 };
 use core::{
     convert::Infallible,
@@ -49,9 +46,6 @@ pub enum InterpreterError<StorageError> {
     /// Storage I/O error
     #[display(fmt = "Storage error: {}", _0)]
     Storage(StorageError),
-    /// Encountered a bug
-    #[display(fmt = "Bug: {_0}")]
-    Bug(Bug),
     /// The `Ready` transaction provided to `Interpreter` doesn't have expected gas price
     #[display(
         fmt = "The transaction's gas price is wrong: expected {expected}, got {actual}"
@@ -117,7 +111,6 @@ where
             Self::Panic(e) => InterpreterError::Panic(*e),
             Self::NoTransactionInitialized => InterpreterError::NoTransactionInitialized,
             Self::DebugStateNotInitialized => InterpreterError::DebugStateNotInitialized,
-            Self::Bug(e) => InterpreterError::Bug(e.clone()),
             Self::CheckError(e) => InterpreterError::CheckError(e.clone()),
             InterpreterError::ReadyTransactionWrongGasPrice { expected, actual } => {
                 InterpreterError::ReadyTransactionWrongGasPrice {
@@ -133,7 +126,6 @@ impl<StorageError> From<RuntimeError<StorageError>> for InterpreterError<Storage
     fn from(error: RuntimeError<StorageError>) -> Self {
         match error {
             RuntimeError::Recoverable(e) => Self::Panic(e),
-            RuntimeError::Bug(e) => Self::Bug(e),
             RuntimeError::Storage(e) => Self::Storage(e),
         }
     }
@@ -156,9 +148,9 @@ where
     }
 }
 
-impl<StorageError> From<Bug> for InterpreterError<StorageError> {
-    fn from(bug: Bug) -> Self {
-        Self::Bug(bug)
+impl<StorageError> From<PanicReason> for InterpreterError<StorageError> {
+    fn from(reason: PanicReason) -> Self {
+        Self::Panic(reason)
     }
 }
 
@@ -181,8 +173,6 @@ impl<StorageError> From<ValidityError> for InterpreterError<StorageError> {
 pub enum RuntimeError<StorageError> {
     /// Specified error with well-formed fallback strategy, i.e. vm panics.
     Recoverable(PanicReason),
-    /// Invalid interpreter state reached unexpectedly, this is a bug
-    Bug(Bug),
     /// Storage io error
     Storage(StorageError),
 }
@@ -203,7 +193,6 @@ impl<StorageError: PartialEq> PartialEq for RuntimeError<StorageError> {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (RuntimeError::Recoverable(a), RuntimeError::Recoverable(b)) => a == b,
-            (RuntimeError::Bug(a), RuntimeError::Bug(b)) => a == b,
             (RuntimeError::Storage(a), RuntimeError::Storage(b)) => a == b,
             _ => false,
         }
@@ -214,7 +203,6 @@ impl<StorageError: core::fmt::Debug> fmt::Display for RuntimeError<StorageError>
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Recoverable(reason) => write!(f, "Recoverable error: {}", reason),
-            Self::Bug(err) => write!(f, "Bug: {}", err),
             Self::Storage(err) => write!(f, "Unrecoverable storage error: {:?}", err),
         }
     }
@@ -229,12 +217,6 @@ impl<StorageError> From<PanicReason> for RuntimeError<StorageError> {
 impl<StorageError> From<core::array::TryFromSliceError> for RuntimeError<StorageError> {
     fn from(value: core::array::TryFromSliceError) -> Self {
         Self::Recoverable(value.into())
-    }
-}
-
-impl<StorageError> From<Bug> for RuntimeError<StorageError> {
-    fn from(bug: Bug) -> Self {
-        Self::Bug(bug)
     }
 }
 
@@ -269,9 +251,6 @@ pub enum PredicateVerificationFailed {
     /// The cumulative gas overflowed the u64 accumulator
     #[display(fmt = "Cumulative gas computation overflowed the u64 accumulator")]
     GasOverflow,
-    /// Invalid interpreter state reached unexpectedly, this is a bug
-    #[display(fmt = "Invalid interpreter state reached unexpectedly")]
-    Bug(Bug),
     /// The VM execution resulted in a well-formed panic, caused by an instruction.
     #[display(fmt = "Execution error: {_0:?}")]
     PanicInstruction(PanicInstruction),
@@ -297,16 +276,9 @@ impl From<InterpreterError<predicate::StorageUnavailable>>
             InterpreterError::PanicInstruction(result) => {
                 PredicateVerificationFailed::PanicInstruction(result)
             }
-            InterpreterError::Bug(bug) => PredicateVerificationFailed::Bug(bug),
             InterpreterError::Storage(_) => PredicateVerificationFailed::Storage,
             _ => PredicateVerificationFailed::False,
         }
-    }
-}
-
-impl From<Bug> for PredicateVerificationFailed {
-    fn from(bug: Bug) -> Self {
-        Self::Bug(bug)
     }
 }
 
@@ -316,254 +288,8 @@ impl From<PanicReason> for PredicateVerificationFailed {
     }
 }
 
-impl From<PanicOrBug> for PredicateVerificationFailed {
-    fn from(err: PanicOrBug) -> Self {
-        match err {
-            PanicOrBug::Panic(reason) => Self::from(reason),
-            PanicOrBug::Bug(bug) => Self::Bug(bug),
-        }
-    }
-}
-
-/// Traceable bug variants
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, strum::EnumMessage)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum BugVariant {
-    /// Context gas increase has overflow
-    #[strum(
-        message = "The context gas cannot overflow since it was created by a valid transaction and the total gas does not increase - hence, it always fits a word."
-    )]
-    ContextGasOverflow,
-
-    /// Context gas increase has underflow
-    #[strum(
-        message = "The context gas cannot underflow since any script should halt upon gas exhaustion."
-    )]
-    ContextGasUnderflow,
-
-    /// Global gas subtraction has underflow
-    #[strum(
-        message = "The gas consumption cannot exceed the gas context since it is capped by the transaction gas limit."
-    )]
-    GlobalGasUnderflow,
-
-    /// The global gas is less than the context gas.
-    #[strum(message = "The global gas cannot ever be less than the context gas. ")]
-    GlobalGasLessThanContext,
-
-    /// The stack point has overflow
-    #[strum(message = "The stack pointer cannot overflow under checked operations.")]
-    StackPointerOverflow,
-
-    /// Code size of a contract doesn't fit into a Word. This is prevented by tx size
-    /// limit.
-    #[strum(message = "Contract size doesn't fit into a word.")]
-    CodeSizeOverflow,
-
-    /// Refund cannot be computed in the current vm state.
-    #[strum(message = "Refund cannot be computed in the current vm state.")]
-    UncomputableRefund,
-
-    /// Receipts context is full, but there's an attempt to add more receipts.
-    #[strum(message = "Receipts context is full, cannot add new receipts.")]
-    ReceiptsCtxFull,
-
-    /// Witness index is out of bounds.
-    #[strum(message = "Witness index is out of bounds.")]
-    WitnessIndexOutOfBounds,
-
-    /// The witness subsection index is higher than the total number of parts.
-    #[strum(
-        message = "The witness subsection index is higher than the total number of parts."
-    )]
-    NextSubsectionIndexIsHigherThanTotalNumberOfParts,
-}
-
-impl fmt::Display for BugVariant {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use strum::EnumMessage;
-        if let Some(msg) = self.get_message() {
-            write!(f, "{}", msg)
-        } else {
-            write!(f, "{:?}", self)
-        }
-    }
-}
-
-/// VM encountered unexpected state. This is a bug.
-/// The execution must terminate since the VM is in an invalid state.
-///
-/// The bug it self is identified by the caller location.
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[must_use]
-pub struct Bug {
-    /// Source code location of the bug, in `path/to/file.rs:line:column` notation
-    location: String,
-
-    /// Type of bug
-    variant: BugVariant,
-
-    /// Additional error message for the bug, if it's caused by a runtime error
-    inner_message: Option<String>,
-
-    /// Optionally include a backtrace for the instruction triggering this bug.
-    /// This is only available when the `backtrace` feature is enabled.
-    #[cfg(feature = "backtrace")]
-    bt: backtrace::Backtrace,
-}
-
-impl Bug {
-    /// Construct a new bug with the specified variant, using caller location for
-    /// idenitfying the bug.
-    #[track_caller]
-    pub fn new(variant: BugVariant) -> Self {
-        let caller = core::panic::Location::caller();
-        let location = format!("{}:{}:{}", caller.file(), caller.line(), caller.column());
-        Self {
-            location,
-            variant,
-            inner_message: None,
-            #[cfg(feature = "backtrace")]
-            bt: backtrace::Backtrace::new(),
-        }
-    }
-
-    /// Set an additional error message.
-    pub fn with_message<E: ToString>(mut self, error: E) -> Self {
-        self.inner_message = Some(error.to_string());
-        self
-    }
-}
-
-impl PartialEq for Bug {
-    fn eq(&self, other: &Self) -> bool {
-        self.location == other.location
-    }
-}
-
-#[cfg(feature = "backtrace")]
-mod bt {
-    use super::*;
-    use backtrace::Backtrace;
-
-    impl Bug {
-        /// Backtrace data
-        pub const fn bt(&self) -> &Backtrace {
-            &self.bt
-        }
-    }
-}
-
-impl fmt::Display for Bug {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use percent_encoding::{
-            utf8_percent_encode,
-            NON_ALPHANUMERIC,
-        };
-
-        let issue_title = format!("Bug report: {:?} in {}", self.variant, self.location);
-
-        let issue_body = format!(
-            "Error: {:?} {}\nLocation: {}\nVersion: {} {}\n",
-            self.variant,
-            self.inner_message
-                .as_ref()
-                .map(|msg| format!("({msg})"))
-                .unwrap_or_default(),
-            self.location,
-            env!("CARGO_PKG_NAME"),
-            env!("CARGO_PKG_VERSION")
-        );
-
-        write!(
-            f,
-            concat!(
-                "Encountered a bug! Please report this using the following link: ",
-                "https://github.com/FuelLabs/fuel-vm/issues/new",
-                "?title={}",
-                "&body={}",
-                "\n\n",
-                "{:?} error in {}: {} {}\n",
-            ),
-            utf8_percent_encode(&issue_title, NON_ALPHANUMERIC),
-            utf8_percent_encode(&issue_body, NON_ALPHANUMERIC),
-            self.variant,
-            self.location,
-            self.variant,
-            self.inner_message
-                .as_ref()
-                .map(|msg| format!("({msg})"))
-                .unwrap_or_default(),
-        )?;
-
-        #[cfg(feature = "backtrace")]
-        {
-            write!(f, "\nBacktrace:\n{:?}\n", self.bt)?;
-        }
-
-        Ok(())
-    }
-}
-
-/// Runtime error description that should either be specified in the protocol or
-/// halt the execution.
-#[derive(Debug, Clone, PartialEq)]
-#[must_use]
-pub enum PanicOrBug {
-    /// VM panic
-    Panic(PanicReason),
-    /// Invalid interpreter state reached unexpectedly, this is a bug
-    Bug(Bug),
-}
-
-impl From<PanicReason> for PanicOrBug {
-    fn from(panic: PanicReason) -> Self {
-        Self::Panic(panic)
-    }
-}
-
-impl From<Bug> for PanicOrBug {
-    fn from(bug: Bug) -> Self {
-        Self::Bug(bug)
-    }
-}
-
-impl<StorageError> From<PanicOrBug> for RuntimeError<StorageError> {
-    fn from(value: PanicOrBug) -> Self {
-        match value {
-            PanicOrBug::Panic(reason) => Self::Recoverable(reason),
-            PanicOrBug::Bug(bug) => Self::Bug(bug),
-        }
-    }
-}
-
-impl<StorageError> From<PanicOrBug> for InterpreterError<StorageError> {
-    fn from(value: PanicOrBug) -> Self {
-        match value {
-            PanicOrBug::Panic(reason) => Self::Panic(reason),
-            PanicOrBug::Bug(bug) => Self::Bug(bug),
-        }
-    }
-}
-
 /// Result of a operation that doesn't access storage
-pub type SimpleResult<T> = Result<T, PanicOrBug>;
+pub type SimpleResult<T> = Result<T, PanicReason>;
 
 /// Result of a operation that accesses storage
 pub type IoResult<T, S> = Result<T, RuntimeError<S>>;
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn bug_report_message() {
-        let bug = Bug::new(BugVariant::ContextGasOverflow).with_message("Test message");
-        let text = format!("{}", bug);
-        assert!(text.contains(file!()));
-        assert!(text.contains("https://github.com/FuelLabs/fuel-vm/issues/new"));
-        assert!(text.contains("ContextGasOverflow"));
-        assert!(text.contains("Test message"));
-    }
-}

--- a/fuel-vm/src/interpreter/alu/tests.rs
+++ b/fuel-vm/src/interpreter/alu/tests.rs
@@ -7,7 +7,6 @@ use core::ops::Div;
 use fuel_asm::Imm12;
 use test_case::test_case;
 
-use crate::error::PanicOrBug;
 #[derive(Debug, PartialEq, Eq)]
 struct CommonInput {
     of: Word,
@@ -32,7 +31,7 @@ struct CommonInput {
 )]
 #[test_case(
     CommonInput { of: 0, err: 0, pc: 0 },
-    0b00, u64::MAX as u128, 1 => Err(PanicOrBug::Panic(PanicReason::ArithmeticOverflow));
+    0b00, u64::MAX as u128, 1 => Err(PanicReason::ArithmeticOverflow);
     "add u64::MAX 1 not wrapping"
 )]
 #[test_case(
@@ -79,7 +78,7 @@ fn test_add(
 )]
 #[test_case(
     CommonInput { of: 0, err: 0, pc: 0 },
-    0b0, 10, 0, true => Err(PanicOrBug::Panic(PanicReason::ArithmeticError));
+    0b0, 10, 0, true => Err(PanicReason::ArithmeticError);
     "div 10 0 error flag"
 )]
 #[test_case(
@@ -123,12 +122,12 @@ fn test_div(
 )]
 #[test_case(
     CommonInput { of: 0, err: 0, pc: 0 },
-    0b00, 10, u64::MAX - 100 => Err(PanicOrBug::Panic(PanicReason::ArithmeticOverflow));
+    0b00, 10, u64::MAX - 100 => Err(PanicReason::ArithmeticOverflow);
     "larger than 32 bit exp"
 )]
 #[test_case(
     CommonInput { of: 0, err: 0, pc: 0 },
-    0b00, 10, (u32::MAX as u64)+ 1 => Err(PanicOrBug::Panic(PanicReason::ArithmeticOverflow));
+    0b00, 10, (u32::MAX as u64)+ 1 => Err(PanicReason::ArithmeticOverflow);
     "just larger than 32 bit exp"
 )]
 #[test_case(

--- a/fuel-vm/src/interpreter/flow/jump_tests.rs
+++ b/fuel-vm/src/interpreter/flow/jump_tests.rs
@@ -1,12 +1,10 @@
 use super::*;
 use test_case::test_case;
 
-use crate::error::PanicOrBug;
-
 #[test_case(0, 0, 0 => Ok(0); "noop jump")]
 #[test_case(0, 0, 20 => Ok(80); "jump forwards")]
 #[test_case(0, 80, 10 => Ok(40); "jump backwards")]
-#[test_case(0, 40, VM_MAX_RAM => Err(PanicOrBug::Panic(PanicReason::MemoryOverflow)); "jump too far forward")]
+#[test_case(0, 40, VM_MAX_RAM => Err(PanicReason::MemoryOverflow); "jump too far forward")]
 fn test_absolute_jump(is: Word, mut pc: Word, j: Word) -> SimpleResult<Word> {
     JumpArgs::new(JumpMode::Absolute)
         .to_address(j)
@@ -16,7 +14,7 @@ fn test_absolute_jump(is: Word, mut pc: Word, j: Word) -> SimpleResult<Word> {
 
 #[test_case(0, 0, 20 => Ok(84); "jump from zero")]
 #[test_case(0, 80, 10 => Ok(124); "jump from nonzero")]
-#[test_case(0, 40, VM_MAX_RAM => Err(PanicOrBug::Panic(PanicReason::MemoryOverflow)); "jump too far forward")]
+#[test_case(0, 40, VM_MAX_RAM => Err(PanicReason::MemoryOverflow); "jump too far forward")]
 fn test_relative_forwards_jump(is: Word, mut pc: Word, j: Word) -> SimpleResult<Word> {
     JumpArgs::new(JumpMode::RelativeForwards)
         .to_address(j)
@@ -26,9 +24,9 @@ fn test_relative_forwards_jump(is: Word, mut pc: Word, j: Word) -> SimpleResult<
 
 #[test_case(0, 20, 4 => Ok(0); "jump to zero")]
 #[test_case(0, 80, 10 => Ok(36); "jump to nonzero")]
-#[test_case(0, 0, 0 => Err(PanicOrBug::Panic(PanicReason::MemoryOverflow)); "jump below zero from zero 0")]
-#[test_case(0, 0, 1 => Err(PanicOrBug::Panic(PanicReason::MemoryOverflow)); "jump below zero from zero 1")]
-#[test_case(0, 20, 50 => Err(PanicOrBug::Panic(PanicReason::MemoryOverflow)); "jump below zero from nonzero")]
+#[test_case(0, 0, 0 => Err(PanicReason::MemoryOverflow); "jump below zero from zero 0")]
+#[test_case(0, 0, 1 => Err(PanicReason::MemoryOverflow); "jump below zero from zero 1")]
+#[test_case(0, 20, 50 => Err(PanicReason::MemoryOverflow); "jump below zero from nonzero")]
 fn test_relative_backwards_jump(is: Word, mut pc: Word, j: Word) -> SimpleResult<Word> {
     JumpArgs::new(JumpMode::RelativeBackwards)
         .to_address(j)

--- a/fuel-vm/src/interpreter/flow/ret_tests.rs
+++ b/fuel-vm/src/interpreter/flow/ret_tests.rs
@@ -3,8 +3,6 @@ use alloc::{
     vec::Vec,
 };
 
-use crate::error::PanicOrBug;
-
 use super::*;
 
 #[test]
@@ -82,7 +80,7 @@ fn test_return() {
         &mut context,
     )
     .ret_data(Word::MAX, Word::MAX);
-    assert_eq!(r, Err(PanicOrBug::Panic(PanicReason::MemoryOverflow)));
+    assert_eq!(r, Err(PanicReason::MemoryOverflow));
 
     let r = input(
         &mut frames,
@@ -92,7 +90,7 @@ fn test_return() {
         &mut context,
     )
     .ret_data(VM_MAX_RAM, 1);
-    assert_eq!(r, Err(PanicOrBug::Panic(PanicReason::MemoryOverflow)));
+    assert_eq!(r, Err(PanicReason::MemoryOverflow));
 
     let r = input(
         &mut frames,
@@ -102,7 +100,7 @@ fn test_return() {
         &mut context,
     )
     .ret_data(0, VM_MAX_RAM + 1);
-    assert_eq!(r, Err(PanicOrBug::Panic(PanicReason::MemoryOverflow)));
+    assert_eq!(r, Err(PanicReason::MemoryOverflow));
 
     let r = input(
         &mut frames,

--- a/fuel-vm/src/interpreter/gas/tests.rs
+++ b/fuel-vm/src/interpreter/gas/tests.rs
@@ -12,9 +12,9 @@ struct GasChargeOutput {
     ggas: u64,
 }
 #[test_case(GasChargeInput{cgas: 0, ggas: 0, dependent_factor: 0} => Ok(GasChargeOutput{ cgas: 0, ggas: 0}); "zero")]
-#[test_case(GasChargeInput{cgas: 0, ggas: 0, dependent_factor: 1} => Err(PanicOrBug::Panic(PanicReason::OutOfGas)); "no gas")]
-#[test_case(GasChargeInput{cgas: 2, ggas: 0, dependent_factor: 1} => matches Err(PanicOrBug::Bug(_)); "global gas less than context")]
-#[test_case(GasChargeInput{cgas: 0, ggas: 2, dependent_factor: 1} => Err(PanicOrBug::Panic(PanicReason::OutOfGas)); "no call gas")]
+#[test_case(GasChargeInput{cgas: 0, ggas: 0, dependent_factor: 1} => Err(PanicReason::OutOfGas); "no gas")]
+#[test_case(GasChargeInput{cgas: 2, ggas: 0, dependent_factor: 1} => panics; "global gas less than context")]
+#[test_case(GasChargeInput{cgas: 0, ggas: 2, dependent_factor: 1} => Err(PanicReason::OutOfGas); "no call gas")]
 #[test_case(GasChargeInput{cgas: 1, ggas: 1, dependent_factor: 1} => Ok(GasChargeOutput{ cgas: 0, ggas: 0}); "just enough")]
 #[test_case(GasChargeInput{cgas: 10, ggas: 15, dependent_factor: 1} => Ok(GasChargeOutput{ cgas: 9, ggas: 14}); "heaps")]
 
@@ -86,13 +86,13 @@ struct DepGasChargeInput {
     DepGasChargeInput{
         input: GasChargeInput{cgas: 0, ggas: 1, dependent_factor: 0},
         gas_cost: DependentCost::from_units_per_gas(1, 1)
-    } => Err(PanicOrBug::Panic(PanicReason::OutOfGas)); "just base with no cgas"
+    } => Err(PanicReason::OutOfGas); "just base with no cgas"
 )]
 #[test_case(
     DepGasChargeInput{
         input: GasChargeInput{cgas: 5, ggas: 10, dependent_factor: 25},
         gas_cost: DependentCost::from_units_per_gas(1, 5)
-    } => Err(PanicOrBug::Panic(PanicReason::OutOfGas)); "unit with not enough cgas"
+    } => Err(PanicReason::OutOfGas); "unit with not enough cgas"
 )]
 fn test_dependent_gas_charge(input: DepGasChargeInput) -> SimpleResult<GasChargeOutput> {
     let DepGasChargeInput { input, gas_cost } = input;
@@ -150,7 +150,7 @@ fn test_dependent_gas_charge(input: DepGasChargeInput) -> SimpleResult<GasCharge
     DepGasChargeInput{
         input: GasChargeInput{cgas: 5, ggas: 10, dependent_factor: 25},
         gas_cost: DependentCost::from_units_per_gas(1, 4)
-    } => Err(PanicOrBug::Panic(PanicReason::OutOfGas)); "unit with not enough cgas"
+    } => Err(PanicReason::OutOfGas); "unit with not enough cgas"
 )]
 fn test_dependent_gas_charge_wihtout_base(
     input: DepGasChargeInput,

--- a/fuel-vm/src/interpreter/internal/message_tests.rs
+++ b/fuel-vm/src/interpreter/internal/message_tests.rs
@@ -5,10 +5,7 @@ use alloc::{
     vec::Vec,
 };
 
-use crate::{
-    consts::MEM_SIZE,
-    error::PanicOrBug,
-};
+use crate::consts::MEM_SIZE;
 
 use super::*;
 use fuel_tx::{
@@ -49,11 +46,11 @@ fn test_absolute_output_offset(
     ; "Output at 200 in memory"
 )]
 #[test_case(
-    MEM_SIZE - 1 => Err(PanicOrBug::Panic(PanicReason::MemoryOverflow))
+    MEM_SIZE - 1 => Err(PanicReason::MemoryOverflow)
     ; "Output at MEM_SIZE - 1 should overflow"
 )]
 #[test_case(
-    MEM_SIZE - 1 - 112 => Err(PanicOrBug::Panic(PanicReason::MemoryOverflow))
+    MEM_SIZE - 1 - 112 => Err(PanicReason::MemoryOverflow)
     ; "Output at MEM_SIZE - 1 - output_size should overflow"
 )]
 fn test_update_memory_output(tx_offset: usize) -> SimpleResult<MemoryInstance> {

--- a/fuel-vm/src/interpreter/memory/allocation_tests.rs
+++ b/fuel-vm/src/interpreter/memory/allocation_tests.rs
@@ -5,14 +5,12 @@ use alloc::vec;
 use super::*;
 use test_case::test_case;
 
-use crate::error::PanicOrBug;
-
 #[test_case(0, 0, 0 => Ok(0))]
-#[test_case(0, 0, 1 => Err(PanicOrBug::Panic(PanicReason::MemoryOverflow)); "Underflow")]
-#[test_case(10, 0, 11 => Err(PanicOrBug::Panic(PanicReason::MemoryOverflow)); "Underflow more")]
-#[test_case(12, 10, 3 => Err(PanicOrBug::Panic(PanicReason::MemoryGrowthOverlap)); "Into stack")]
+#[test_case(0, 0, 1 => Err(PanicReason::MemoryOverflow); "Underflow")]
+#[test_case(10, 0, 11 => Err(PanicReason::MemoryOverflow); "Underflow more")]
+#[test_case(12, 10, 3 => Err(PanicReason::MemoryGrowthOverlap); "Into stack")]
 #[test_case(10, 10, 0 => Ok(10); "No available memory")]
-#[test_case(15, 10, 6 => Err(PanicOrBug::Panic(PanicReason::MemoryGrowthOverlap)); "Insufficient memory")]
+#[test_case(15, 10, 6 => Err(PanicReason::MemoryGrowthOverlap); "Insufficient memory")]
 #[test_case(20, 10, 0 => Ok(20); "Zero allocation size")]
 #[test_case(20, 10, 10 => Ok(10); "Allocation size equal to available memory")]
 #[test_case(20, 10, 5 => Ok(15); "Allocation size smaller than available memory")]
@@ -33,10 +31,10 @@ fn test_malloc(mut hp: Word, sp: Word, a: Word) -> SimpleResult<Word> {
 }
 
 #[test_case(true, 1, 10 => Ok(()); "Can clear some bytes")]
-#[test_case(false, 1, 10 => Err(PanicOrBug::Panic(PanicReason::MemoryOwnership)); "No ownership")]
+#[test_case(false, 1, 10 => Err(PanicReason::MemoryOwnership); "No ownership")]
 #[test_case(true, 0, 10 => Ok(()); "Memory range starts at 0")]
 #[test_case(true, MEM_SIZE as Word - 10, 10 => Ok(()); "Memory range ends at last address")]
-#[test_case(true, 1, VM_MAX_RAM + 1 => Err(PanicOrBug::Panic(PanicReason::MemoryOverflow)); "Memory range size exceeds limit")]
+#[test_case(true, 1, VM_MAX_RAM + 1 => Err(PanicReason::MemoryOverflow); "Memory range size exceeds limit")]
 fn test_memclear(has_ownership: bool, a: Word, b: Word) -> SimpleResult<()> {
     let mut memory: MemoryInstance = vec![1u8; MEM_SIZE].try_into().unwrap();
     let mut pc = 4;
@@ -99,11 +97,11 @@ fn test_memcopy(has_ownership: bool, a: Word, b: Word, c: Word) -> SimpleResult<
 }
 
 #[test_case(1, 20, 10 => Ok(()); "Can compare some bytes")]
-#[test_case(MEM_SIZE as Word, 1, 2 => Err(PanicOrBug::Panic(PanicReason::MemoryOverflow)); "b+d > MAX_RAM")]
-#[test_case(1, MEM_SIZE as Word, 2 => Err(PanicOrBug::Panic(PanicReason::MemoryOverflow)); "c+d > MAX_RAM")]
-#[test_case(1, 1, VM_MAX_RAM + 1 => Err(PanicOrBug::Panic(PanicReason::MemoryOverflow)); "d > VM_MAX_RAM")]
-#[test_case(u64::MAX/2, 1, u64::MAX/2 + 1 => Err(PanicOrBug::Panic(PanicReason::MemoryOverflow)); "b+d overflows")]
-#[test_case(1, u64::MAX/2, u64::MAX/2 + 1 => Err(PanicOrBug::Panic(PanicReason::MemoryOverflow)); "c+d overflows")]
+#[test_case(MEM_SIZE as Word, 1, 2 => Err(PanicReason::MemoryOverflow); "b+d > MAX_RAM")]
+#[test_case(1, MEM_SIZE as Word, 2 => Err(PanicReason::MemoryOverflow); "c+d > MAX_RAM")]
+#[test_case(1, 1, VM_MAX_RAM + 1 => Err(PanicReason::MemoryOverflow); "d > VM_MAX_RAM")]
+#[test_case(u64::MAX/2, 1, u64::MAX/2 + 1 => Err(PanicReason::MemoryOverflow); "b+d overflows")]
+#[test_case(1, u64::MAX/2, u64::MAX/2 + 1 => Err(PanicReason::MemoryOverflow); "c+d overflows")]
 #[test_case(0, 0, 0 => Ok(()); "smallest input values")]
 #[test_case(0, VM_MAX_RAM/2, VM_MAX_RAM/2 => Ok(()); "maximum range of addressable memory")]
 fn test_memeq(b: Word, c: Word, d: Word) -> SimpleResult<()> {
@@ -127,10 +125,10 @@ fn test_memeq(b: Word, c: Word, d: Word) -> SimpleResult<()> {
 
 #[test_case(true, 20, 0, 40, 10 => Ok(()); "Can move sp up")]
 #[test_case(false, 20, 0, 40, 10 => Ok(()); "Can move sp down")]
-#[test_case(true, u64::MAX - 10, 0, u64::MAX, 20 => Err(PanicOrBug::Panic(PanicReason::MemoryOverflow)); "Panics on overflowing addition")]
-#[test_case(false, 10, 0, 11, 20 => Err(PanicOrBug::Panic(PanicReason::MemoryOverflow)); "Panics on underflowing subtraction")]
-#[test_case(false, 0, 0, u64::MAX, 1 => Err(PanicOrBug::Panic(PanicReason::MemoryOverflow)); "Panics on zero check for underflowing subtraction")]
-#[test_case(false, 8, 8, u64::MAX, 1 => Err(PanicOrBug::Panic(PanicReason::MemoryOverflow)); "Panics on sp < ssp")]
+#[test_case(true, u64::MAX - 10, 0, u64::MAX, 20 => Err(PanicReason::MemoryOverflow); "Panics on overflowing addition")]
+#[test_case(false, 10, 0, 11, 20 => Err(PanicReason::MemoryOverflow); "Panics on underflowing subtraction")]
+#[test_case(false, 0, 0, u64::MAX, 1 => Err(PanicReason::MemoryOverflow); "Panics on zero check for underflowing subtraction")]
+#[test_case(false, 8, 8, u64::MAX, 1 => Err(PanicReason::MemoryOverflow); "Panics on sp < ssp")]
 fn test_stack_pointer_overflow(
     add: bool,
     mut sp: Word,
@@ -167,11 +165,11 @@ fn test_stack_pointer_overflow(
 
 #[test_case(20, 20 => Ok(()); "Can load a byte")]
 #[test_case(0, 0 => Ok(()); "handles memory loading at address 0")]
-#[test_case(VM_MAX_RAM + 1, 0 => Err(PanicOrBug::Panic(PanicReason::MemoryOverflow)); "b > VM_MAX_RAM")]
+#[test_case(VM_MAX_RAM + 1, 0 => Err(PanicReason::MemoryOverflow); "b > VM_MAX_RAM")]
 #[test_case(VM_MAX_RAM - 1, 0 => Ok(()); "b eq VM_MAX_RAM - 1")]
-#[test_case(0, VM_MAX_RAM + 1 => Err(PanicOrBug::Panic(PanicReason::MemoryOverflow)); "c > VM_MAX_RAM")]
+#[test_case(0, VM_MAX_RAM + 1 => Err(PanicReason::MemoryOverflow); "c > VM_MAX_RAM")]
 #[test_case(0, VM_MAX_RAM - 1 => Ok(()); "c eq VM_MAX_RAM - 1")]
-#[test_case(u32::MAX as u64, u32::MAX as u64 => Err(PanicOrBug::Panic(PanicReason::MemoryOverflow)); "b + c overflow")]
+#[test_case(u32::MAX as u64, u32::MAX as u64 => Err(PanicReason::MemoryOverflow); "b + c overflow")]
 fn test_load_byte(b: Word, c: Word) -> SimpleResult<()> {
     let mut memory = vec![1u8; MEM_SIZE];
     memory[((b + c) as usize).min(MEM_SIZE - 1)] = 2;
@@ -188,7 +186,7 @@ fn test_load_byte(b: Word, c: Word) -> SimpleResult<()> {
 }
 
 #[test_case(20, Imm12::from(20) => Ok(()); "Can load a word")]
-#[test_case(VM_MAX_RAM, Imm12::from(1) => Err(PanicOrBug::Panic(PanicReason::MemoryOverflow)); "b + 8 * c gteq VM_MAX_RAM")]
+#[test_case(VM_MAX_RAM, Imm12::from(1) => Err(PanicReason::MemoryOverflow); "b + 8 * c gteq VM_MAX_RAM")]
 fn test_load_word(b: Word, c: Imm12) -> SimpleResult<()> {
     // create a mutable memory with size `MEM_SIZE`
     let mut memory: MemoryInstance = vec![1u8; MEM_SIZE].try_into().unwrap();
@@ -218,9 +216,9 @@ fn test_load_word(b: Word, c: Imm12) -> SimpleResult<()> {
 }
 
 #[test_case(true, 20, 30, 40 => Ok(()); "Can store a byte")]
-#[test_case(false, VM_MAX_RAM - 1, 100, 2 => Err(PanicOrBug::Panic(PanicReason::MemoryOverflow)); "Memory overflow on heap")]
-#[test_case(false, 0, 100, VM_MAX_RAM - 1 => Err(PanicOrBug::Panic(PanicReason::MemoryOwnership)); "Memory overflow on stack")]
-#[test_case(true, VM_MAX_RAM, 1, 1 => Err(PanicOrBug::Panic(PanicReason::MemoryOverflow)); "Memory overflow by address range")]
+#[test_case(false, VM_MAX_RAM - 1, 100, 2 => Err(PanicReason::MemoryOverflow); "Memory overflow on heap")]
+#[test_case(false, 0, 100, VM_MAX_RAM - 1 => Err(PanicReason::MemoryOwnership); "Memory overflow on stack")]
+#[test_case(true, VM_MAX_RAM, 1, 1 => Err(PanicReason::MemoryOverflow); "Memory overflow by address range")]
 fn test_store_byte(has_ownership: bool, a: Word, b: Word, c: Word) -> SimpleResult<()> {
     let mut memory: MemoryInstance = vec![1u8; MEM_SIZE].try_into().unwrap();
     let mut pc = 4;
@@ -274,7 +272,7 @@ fn test_store_byte_more(
         }
         Err(e) => {
             assert!(is_error);
-            assert_eq!(e, PanicOrBug::Panic(PanicReason::MemoryOverflow));
+            assert_eq!(e, PanicReason::MemoryOverflow);
         }
     }
 
@@ -282,7 +280,7 @@ fn test_store_byte_more(
 }
 
 #[test_case(true, 20, 30, Imm12::from(40) => Ok(()); "Can store a word")]
-#[test_case(false, 20, 30, Imm12::from(40) => Err(PanicOrBug::Panic(PanicReason::MemoryOwnership)); "Fails due to not having ownership of the range")]
+#[test_case(false, 20, 30, Imm12::from(40) => Err(PanicReason::MemoryOwnership); "Fails due to not having ownership of the range")]
 fn test_store_word(has_ownership: bool, a: Word, b: Word, c: Imm12) -> SimpleResult<()> {
     let mut memory: MemoryInstance = vec![1u8; MEM_SIZE].try_into().unwrap();
     let mut pc = 4;

--- a/fuel-vm/src/interpreter/memory/stack_tests.rs
+++ b/fuel-vm/src/interpreter/memory/stack_tests.rs
@@ -10,7 +10,6 @@ use fuel_asm::{
 use crate::{
     constraints::reg_key::*,
     consts::*,
-    error::PanicOrBug,
     interpreter::memory::{
         pop_selected_registers,
         push_selected_registers,
@@ -112,10 +111,7 @@ fn test_push_stack_overflow() {
         Imm24::new(1),
     );
 
-    assert_eq!(
-        result,
-        Err(PanicOrBug::Panic(PanicReason::MemoryGrowthOverlap))
-    );
+    assert_eq!(result, Err(PanicReason::MemoryGrowthOverlap));
 }
 
 #[test]
@@ -139,7 +135,7 @@ fn test_pop_from_empty_stack() {
         Imm24::new(0b111),
     );
 
-    assert_eq!(result, Err(PanicOrBug::Panic(PanicReason::MemoryOverflow)));
+    assert_eq!(result, Err(PanicReason::MemoryOverflow));
 }
 
 #[test]
@@ -163,5 +159,5 @@ fn test_pop_sp_overflow() {
         Imm24::new(0b111),
     );
 
-    assert_eq!(result, Err(PanicOrBug::Panic(PanicReason::MemoryOverflow)));
+    assert_eq!(result, Err(PanicReason::MemoryOverflow));
 }

--- a/fuel-vm/src/interpreter/post_execution.rs
+++ b/fuel-vm/src/interpreter/post_execution.rs
@@ -1,6 +1,4 @@
 use crate::prelude::{
-    Bug,
-    BugVariant,
     ExecutableTransaction,
     Interpreter,
     InterpreterStorage,
@@ -61,7 +59,7 @@ where
             base_asset_id,
             gas_price,
         )
-        .map_err(|e| Bug::new(BugVariant::UncomputableRefund).with_message(e))?;
+        .expect("Uncomputable refund");
 
         Ok(())
     }

--- a/fuel-vm/src/interpreter/receipts.rs
+++ b/fuel-vm/src/interpreter/receipts.rs
@@ -12,13 +12,7 @@ use fuel_types::{
     Bytes32,
 };
 
-use crate::{
-    error::SimpleResult,
-    prelude::{
-        Bug,
-        BugVariant,
-    },
-};
+use crate::error::SimpleResult;
 
 /// Receipts and the associated Merkle tree
 #[derive(Debug, Default, Clone)]
@@ -36,7 +30,7 @@ impl ReceiptsCtx {
     /// Returns a panic if the context is full.
     pub fn push(&mut self, receipt: Receipt) -> SimpleResult<()> {
         if self.receipts.len() == Self::MAX_RECEIPTS {
-            return Err(Bug::new(BugVariant::ReceiptsCtxFull).into())
+            unreachable!("Pushing to a full receipts context is a bug");
         }
 
         // Last two slots can be only used for ending the script,

--- a/fuel-vm/src/lib.rs
+++ b/fuel-vm/src/lib.rs
@@ -134,8 +134,6 @@ pub mod prelude {
         },
         context::Context,
         error::{
-            Bug,
-            BugVariant,
             InterpreterError,
             RuntimeError,
         },


### PR DESCRIPTION
Removes `Bug` and `BugVariant` types, opting to `expect` or `unreachable!` instead, as suggested in audit reports. Since we already catch the rust-level panics in fuel-core, we should move the reporting there. This way, we include all crashes and not just those where we had wrapped it in `Bug`.

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here
