### PR TITLE
Prepare release for v0.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.53.0]
+
 ### Added
 
 - [#751](https://github.com/FuelLabs/fuel-vm/pull/751):  Improve test coverage.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,17 +17,17 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.52.0"
+version = "0.53.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.52.0", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.52.0", path = "fuel-crypto", default-features = false }
-fuel-derive = { version = "0.52.0", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.52.0", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.52.0", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.52.0", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.52.0", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.52.0", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.53.0", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.53.0", path = "fuel-crypto", default-features = false }
+fuel-derive = { version = "0.53.0", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.53.0", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.53.0", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.53.0", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.53.0", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.53.0", path = "fuel-vm", default-features = false }
 bitflags = "2"
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
## Version v0.53.0

### Added

- [#751](https://github.com/FuelLabs/fuel-vm/pull/751):  Improve test coverage.

### Changed

- [#753](https://github.com/FuelLabs/fuel-vm/pull/753): Fix an ownership check bug in `CCP` instruction.
