### PR TITLE
use the correct gas units for wdop and wqop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+#### Breaking
+- [#765](https://github.com/FuelLabs/fuel-vm/pull/765): corrected the gas units for WDOP and WQOP
+
 ## [Version 0.53.0]
 
 ### Added

--- a/fuel-vm/src/interpreter/executors/instruction.rs
+++ b/fuel-vm/src/interpreter/executors/instruction.rs
@@ -193,16 +193,16 @@ where
                 self.alu_wideint_cmp_u128(a.into(), r!(b), r!(c), args)?;
             }
 
-            Instruction::WQCM(wdcm) => {
+            Instruction::WQCM(wqcm) => {
                 self.gas_charge(self.gas_costs().wqcm())?;
-                let (a, b, c, imm) = wdcm.unpack();
+                let (a, b, c, imm) = wqcm.unpack();
                 let args = wideint::CompareArgs::from_imm(imm)
                     .ok_or(PanicReason::InvalidImmediateValue)?;
                 self.alu_wideint_cmp_u256(a.into(), r!(b), r!(c), args)?;
             }
 
             Instruction::WDOP(wdop) => {
-                self.gas_charge(self.gas_costs().wdcm())?;
+                self.gas_charge(self.gas_costs().wdop())?;
                 let (a, b, c, imm) = wdop.unpack();
                 let args = wideint::MathArgs::from_imm(imm)
                     .ok_or(PanicReason::InvalidImmediateValue)?;
@@ -210,7 +210,7 @@ where
             }
 
             Instruction::WQOP(wqop) => {
-                self.gas_charge(self.gas_costs().wqcm())?;
+                self.gas_charge(self.gas_costs().wqop())?;
                 let (a, b, c, imm) = wqop.unpack();
                 let args = wideint::MathArgs::from_imm(imm)
                     .ok_or(PanicReason::InvalidImmediateValue)?;


### PR DESCRIPTION
closes https://github.com/FuelLabs/fuel-vm/issues/759

WDOP and WQOP used the incorrect gas units. WDOP will increase from 2 to 3, while WQCP will stay at 3.

This may affect the Rust SDK which sometimes run the VM locally for predicate estimation.

Testnet gas schedule for reference: https://github.com/FuelLabs/chain-configuration/blob/master/ignition/chain_config.json

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [x] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)

