### PR TITLE
Removed redundant `self.receipts.root()` call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 #### Breaking
 - [#765](https://github.com/FuelLabs/fuel-vm/pull/765): corrected the gas units for WDOP and WQOP
 
+### Removed
+- [#772](https://github.com/FuelLabs/fuel-vm/pull/772): Removed redundant `self.receipts.root()` call.
+
 ## [Version 0.53.0]
 
 ### Added

--- a/fuel-vm/src/interpreter/executors/main.rs
+++ b/fuel-vm/src/interpreter/executors/main.rs
@@ -844,11 +844,6 @@ where
                 self.debugger_set_last_state(program);
             }
 
-            if let Some(script) = self.tx.as_script_mut() {
-                let receipts_root = self.receipts.root();
-                *script.receipts_root_mut() = receipts_root;
-            }
-
             let revert = matches!(program, ProgramState::Revert(_));
             let gas_price = self.gas_price();
             Self::finalize_outputs(


### PR DESCRIPTION
We call the same logic in the `post_execute`
<img width="994" alt="image" src="https://github.com/FuelLabs/fuel-vm/assets/18346821/34395bf9-486e-4834-8d64-29d2b07227f3">
<img width="625" alt="image" src="https://github.com/FuelLabs/fuel-vm/assets/18346821/e312d4c9-68d1-40d2-a96b-598600a40289">

### Before requesting review
- [x] I have reviewed the code myself