### PR TITLE
Release v0.54.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.54.0]
+
 ### Added
 
 - [#770](https://github.com/FuelLabs/fuel-vm/pull/770): Cache contract inputs in the VM.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,17 +17,17 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.53.0"
+version = "0.54.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.53.0", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.53.0", path = "fuel-crypto", default-features = false }
-fuel-derive = { version = "0.53.0", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.53.0", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.53.0", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.53.0", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.53.0", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.53.0", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.54.0", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.54.0", path = "fuel-crypto", default-features = false }
+fuel-derive = { version = "0.54.0", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.54.0", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.54.0", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.54.0", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.54.0", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.54.0", path = "fuel-vm", default-features = false }
 bitflags = "2"
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
## Version v0.54.0

### Added

- [#770](https://github.com/FuelLabs/fuel-vm/pull/770): Cache contract inputs in the VM.

### Changed
- [#768](https://github.com/FuelLabs/fuel-vm/pull/768): Charge for LDC opcode before loading the contract into memory.

- [#771](https://github.com/FuelLabs/fuel-vm/pull/771): Take into account spent gas during synchronous predicates estimation.

#### Breaking
- [#769](https://github.com/FuelLabs/fuel-vm/pull/769): Use `DependentCost` for `CFE` and `CFEI` opcodes.
- [#767](https://github.com/FuelLabs/fuel-vm/pull/767): Fixed no zeroing malleable fields for `Create` transaction.
- [#765](https://github.com/FuelLabs/fuel-vm/pull/765): Corrected the gas units for WDOP and WQOP.

### Removed
- [#772](https://github.com/FuelLabs/fuel-vm/pull/772): Removed redundant `self.receipts.root()` call.

## What's Changed
* use the correct gas units for wdop and wqop by @Voxelot in https://github.com/FuelLabs/fuel-vm/pull/765
* Fixed no zeroing malleable fields for `Create` transaction by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/767
* Removed redundant `self.receipts.root()` call by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/772
* Charge for LDC opcode before loading the contract into memory by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/768
* Use `DependentCost` for `CFE` and `CFEI` opcodes by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/769
* Cache contract inputs in the VM by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/770
* Take into account spent gas during synchronous predicates estimation by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/771
* Removed dead code from the codebase by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/774


**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.53.0...v0.54.0