### PR TITLE
Make SubAssetId its own type instead of using Bytes32

### DIFF
--- a/fuel-tx/src/lib.rs
+++ b/fuel-tx/src/lib.rs
@@ -27,6 +27,7 @@ pub use fuel_asm::{
     PanicInstruction,
     PanicReason,
 };
+use fuel_types::SubAssetId;
 pub use fuel_types::{
     Address,
     AssetId,
@@ -131,14 +132,14 @@ pub use contract::Contract;
 /// Trait extends the functionality of the `ContractId` type.
 pub trait ContractIdExt {
     /// Creates an `AssetId` from the `ContractId` and `sub_id`.
-    fn asset_id(&self, sub_id: &Bytes32) -> AssetId;
+    fn asset_id(&self, sub_id: &SubAssetId) -> AssetId;
 
     /// Creates an `AssetId` from the `ContractId` and the default 0x00..000 `sub_id`.
     fn default_asset(&self) -> AssetId;
 }
 
 impl ContractIdExt for ContractId {
-    fn asset_id(&self, sub_id: &Bytes32) -> AssetId {
+    fn asset_id(&self, sub_id: &SubAssetId) -> AssetId {
         let hasher = fuel_crypto::Hasher::default();
         AssetId::new(
             *hasher
@@ -149,6 +150,6 @@ impl ContractIdExt for ContractId {
     }
 
     fn default_asset(&self) -> AssetId {
-        self.asset_id(&Bytes32::zeroed())
+        self.asset_id(&SubAssetId::zeroed())
     }
 }

--- a/fuel-tx/src/receipt.rs
+++ b/fuel-tx/src/receipt.rs
@@ -15,6 +15,7 @@ use fuel_types::{
     ContractId,
     MessageId,
     Nonce,
+    SubAssetId,
     Word,
 };
 
@@ -139,14 +140,14 @@ pub enum Receipt {
         data: Option<Vec<u8>>,
     },
     Mint {
-        sub_id: Bytes32,
+        sub_id: SubAssetId,
         contract_id: ContractId,
         val: Word,
         pc: Word,
         is: Word,
     },
     Burn {
-        sub_id: Bytes32,
+        sub_id: SubAssetId,
         contract_id: ContractId,
         val: Word,
         pc: Word,
@@ -403,7 +404,7 @@ impl Receipt {
     }
 
     pub fn mint(
-        sub_id: Bytes32,
+        sub_id: SubAssetId,
         contract_id: ContractId,
         val: Word,
         pc: Word,
@@ -419,7 +420,7 @@ impl Receipt {
     }
 
     pub fn burn(
-        sub_id: Bytes32,
+        sub_id: SubAssetId,
         contract_id: ContractId,
         val: Word,
         pc: Word,
@@ -453,7 +454,7 @@ impl Receipt {
         })
     }
 
-    pub const fn sub_id(&self) -> Option<&Bytes32> {
+    pub const fn sub_id(&self) -> Option<&SubAssetId> {
         match self {
             Self::Mint { sub_id, .. } => Some(sub_id),
             Self::Burn { sub_id, .. } => Some(sub_id),

--- a/fuel-types/src/array_types.rs
+++ b/fuel-types/src/array_types.rs
@@ -344,6 +344,7 @@ macro_rules! key_methods {
 
 key!(Address, 32);
 key!(AssetId, 32);
+key!(SubAssetId, 32);
 key!(ContractId, 32);
 key!(Bytes4, 4);
 key!(Bytes8, 8);

--- a/fuel-vm/src/interpreter/blockchain.rs
+++ b/fuel-vm/src/interpreter/blockchain.rs
@@ -57,14 +57,17 @@ use fuel_tx::{
     Receipt,
 };
 use fuel_types::{
-    bytes,
-    bytes::padded_len_word,
+    bytes::{
+        self,
+        padded_len_word,
+    },
     Address,
     AssetId,
     BlockHeight,
     Bytes32,
     ContractId,
     RegisterId,
+    SubAssetId,
     Word,
 };
 
@@ -686,7 +689,7 @@ where
 {
     pub(crate) fn burn(self, a: Word, b: Word) -> IoResult<(), S::Error> {
         let contract_id = internal_contract(self.context, self.fp, self.memory)?;
-        let sub_id = Bytes32::new(self.memory.read_bytes(b)?);
+        let sub_id = SubAssetId::new(self.memory.read_bytes(b)?);
         let asset_id = contract_id.asset_id(&sub_id);
 
         let balance = balance(self.storage, &contract_id, &asset_id)?;
@@ -727,7 +730,7 @@ where
 {
     pub(crate) fn mint(self, a: Word, b: Word) -> Result<(), RuntimeError<S::Error>> {
         let contract_id = internal_contract(self.context, self.fp, self.memory)?;
-        let sub_id = Bytes32::new(self.memory.read_bytes(b)?);
+        let sub_id = SubAssetId::new(self.memory.read_bytes(b)?);
         let asset_id = contract_id.asset_id(&sub_id);
 
         let balance = balance(self.storage, &contract_id, &asset_id)?;

--- a/fuel-vm/src/interpreter/blockchain/other_tests.rs
+++ b/fuel-vm/src/interpreter/blockchain/other_tests.rs
@@ -32,7 +32,7 @@ fn test_burn(
     memory[0..ContractId::LEN].copy_from_slice(contract_id.as_slice());
     memory[ContractId::LEN..ContractId::LEN + Bytes32::LEN]
         .copy_from_slice(sub_id.as_slice());
-    let sub_id = Bytes32::from(sub_id);
+    let sub_id = SubAssetId::from(sub_id);
     let asset_id = contract_id.asset_id(&sub_id);
     let initialize = initialize.into();
     if let Some(initialize) = initialize {
@@ -110,7 +110,7 @@ fn test_mint(
     memory[0..ContractId::LEN].copy_from_slice(contract_id.as_slice());
     memory[ContractId::LEN..ContractId::LEN + Bytes32::LEN]
         .copy_from_slice(sub_id.as_slice());
-    let sub_id = Bytes32::from(sub_id);
+    let sub_id = SubAssetId::from(sub_id);
     let asset_id = contract_id.asset_id(&sub_id);
     let initialize = initialize.into();
     if let Some(initialize) = initialize {

--- a/fuel-vm/src/tests/contract.rs
+++ b/fuel-vm/src/tests/contract.rs
@@ -16,7 +16,10 @@ use fuel_tx::{
     ConsensusParameters,
     Witness,
 };
-use fuel_types::canonical::Serialize;
+use fuel_types::{
+    canonical::Serialize,
+    SubAssetId,
+};
 use rand::{
     rngs::StdRng,
     Rng,
@@ -115,7 +118,7 @@ fn mint_burn() {
 
     let contract_id = test_context.setup_contract(program, None, None).contract_id;
 
-    let asset_id = contract_id.asset_id(&Bytes32::zeroed());
+    let asset_id = contract_id.asset_id(&SubAssetId::zeroed());
 
     let (script_call, _) = script_with_data_offset!(
         data_offset,


### PR DESCRIPTION
Draft PR to show the idea of adding a `SubAssetId` newtype. Contains no functional changes. Not sure if this breaks too much stuff for this to be worth it.


## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests

### Before requesting review
- [x] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
