### PR TITLE
Remove unnecessary look up for old values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - [#781](https://github.com/FuelLabs/fuel-vm/pull/781): Added `base_asset_id` to checked metadata.
 
+### Changed
+
+#### Breaking
+- [#783](https://github.com/FuelLabs/fuel-vm/pull/783): Remove unnecessary look up for old values by adding new methods to the `StorageMutate` trait.  The old `insert` and `remove` are now `replace` and `take`. The new `insert` and `remove` don't return a value.
+- [#783](https://github.com/FuelLabs/fuel-vm/pull/783): Renamed methods of `StorageWrite` trait from `write`, `replace`, `take` to `write_bytes`, `replace_bytes`, `take_bytes`.
+
 ## [Version 0.54.1]
 
 ### Changed

--- a/fuel-merkle/src/common/storage_map.rs
+++ b/fuel-merkle/src/common/storage_map.rs
@@ -72,22 +72,18 @@ where
     Type::Key: Eq + core::hash::Hash,
     Type::OwnedKey: Eq + core::hash::Hash + core::borrow::Borrow<Type::Key>,
 {
-    fn insert(
+    fn replace(
         &mut self,
         key: &Type::Key,
         value: &Type::Value,
     ) -> Result<Option<Type::OwnedValue>, Self::Error> {
-        let previous = self.map.remove(key);
-
-        self.map
+        let previous = self
+            .map
             .insert(key.to_owned().into(), value.to_owned().into());
         Ok(previous)
     }
 
-    fn remove(
-        &mut self,
-        key: &Type::Key,
-    ) -> Result<Option<Type::OwnedValue>, Self::Error> {
+    fn take(&mut self, key: &Type::Key) -> Result<Option<Type::OwnedValue>, Self::Error> {
         let value = self.map.remove(key);
         Ok(value)
     }
@@ -156,7 +152,7 @@ mod test {
         let mut store = StorageMap::<TestTable>::new();
         let _ = store.insert(&key, &TestValue(0));
 
-        assert_eq!(store.remove(&key).unwrap(), Some(TestValue(0)));
+        assert_eq!(store.take(&key).unwrap(), Some(TestValue(0)));
     }
 
     #[test]
@@ -164,7 +160,7 @@ mod test {
         let invalid_key = TestKey(0);
         let mut store = StorageMap::<TestTable>::new();
 
-        assert_eq!(store.remove(&invalid_key).unwrap(), None);
+        assert_eq!(store.take(&invalid_key).unwrap(), None);
     }
 
     #[test]

--- a/fuel-merkle/src/sparse/in_memory.rs
+++ b/fuel-merkle/src/sparse/in_memory.rs
@@ -95,7 +95,11 @@ impl MerkleTree {
         }
 
         impl StorageMutate<NodesTable> for EmptyStorage {
-            fn insert(
+            fn insert(&mut self, _: &Bytes32, _: &Primitive) -> Result<(), Self::Error> {
+                Ok(())
+            }
+
+            fn replace(
                 &mut self,
                 _: &Bytes32,
                 _: &Primitive,
@@ -103,7 +107,11 @@ impl MerkleTree {
                 Ok(None)
             }
 
-            fn remove(&mut self, _: &Bytes32) -> Result<Option<Primitive>, Self::Error> {
+            fn remove(&mut self, _: &Bytes32) -> Result<(), Self::Error> {
+                Ok(())
+            }
+
+            fn take(&mut self, _: &Bytes32) -> Result<Option<Primitive>, Self::Error> {
                 Ok(None)
             }
         }
@@ -148,13 +156,26 @@ impl MerkleTree {
                 &mut self,
                 key: &Bytes32,
                 value: &Primitive,
+            ) -> Result<(), Self::Error> {
+                self.storage.push((*key, *value));
+                Ok(())
+            }
+
+            fn replace(
+                &mut self,
+                key: &Bytes32,
+                value: &Primitive,
             ) -> Result<Option<Primitive>, Self::Error> {
                 self.storage.push((*key, *value));
                 Ok(None)
             }
 
-            fn remove(&mut self, _: &Bytes32) -> Result<Option<Primitive>, Self::Error> {
+            fn remove(&mut self, _: &Bytes32) -> Result<(), Self::Error> {
                 unimplemented!("Remove operation is not supported")
+            }
+
+            fn take(&mut self, _: &Bytes32) -> Result<Option<Primitive>, Self::Error> {
+                unimplemented!("Take operation is not supported")
             }
         }
 

--- a/fuel-merkle/src/storage.rs
+++ b/fuel-merkle/src/storage.rs
@@ -14,12 +14,8 @@ pub trait StorageInspectInfallible<Type: Mappable> {
 }
 
 pub trait StorageMutateInfallible<Type: Mappable> {
-    fn insert(
-        &mut self,
-        key: &Type::Key,
-        value: &Type::Value,
-    ) -> Option<Type::OwnedValue>;
-    fn remove(&mut self, key: &Type::Key) -> Option<Type::OwnedValue>;
+    fn insert(&mut self, key: &Type::Key, value: &Type::Value);
+    fn remove(&mut self, key: &Type::Key);
 }
 
 impl<S, Type> StorageInspectInfallible<Type> for S
@@ -43,16 +39,12 @@ where
     S: StorageMutate<Type, Error = Infallible>,
     Type: Mappable,
 {
-    fn insert(
-        &mut self,
-        key: &Type::Key,
-        value: &Type::Value,
-    ) -> Option<Type::OwnedValue> {
+    fn insert(&mut self, key: &Type::Key, value: &Type::Value) {
         <Self as StorageMutate<Type>>::insert(self, key, value)
             .expect("Expected insert() to be infallible")
     }
 
-    fn remove(&mut self, key: &Type::Key) -> Option<Type::OwnedValue> {
+    fn remove(&mut self, key: &Type::Key) {
         <Self as StorageMutate<Type>>::remove(self, key)
             .expect("Expected remove() to be infallible")
     }

--- a/fuel-storage/src/impls.rs
+++ b/fuel-storage/src/impls.rs
@@ -56,15 +56,24 @@ impl<'a, T: StorageMutate<Type> + ?Sized, Type: Mappable> StorageMutate<Type>
         &mut self,
         key: &Type::Key,
         value: &Type::Value,
-    ) -> Result<Option<Type::OwnedValue>, Self::Error> {
+    ) -> Result<(), Self::Error> {
         <T as StorageMutate<Type>>::insert(self, key, value)
     }
 
-    fn remove(
+    fn replace(
         &mut self,
         key: &Type::Key,
+        value: &Type::Value,
     ) -> Result<Option<Type::OwnedValue>, Self::Error> {
+        <T as StorageMutate<Type>>::replace(self, key, value)
+    }
+
+    fn remove(&mut self, key: &Type::Key) -> Result<(), Self::Error> {
         <T as StorageMutate<Type>>::remove(self, key)
+    }
+
+    fn take(&mut self, key: &Type::Key) -> Result<Option<Type::OwnedValue>, Self::Error> {
+        <T as StorageMutate<Type>>::take(self, key)
     }
 }
 
@@ -127,20 +136,20 @@ impl<'a, T: StorageRead<Type> + StorageSize<Type> + ?Sized, Type: Mappable>
 impl<'a, T: StorageWrite<Type> + ?Sized, Type: Mappable> StorageWrite<Type>
     for &'a mut T
 {
-    fn write(&mut self, key: &Type::Key, buf: &[u8]) -> Result<usize, Self::Error> {
-        <T as StorageWrite<Type>>::write(self, key, buf)
+    fn write_bytes(&mut self, key: &Type::Key, buf: &[u8]) -> Result<usize, Self::Error> {
+        <T as StorageWrite<Type>>::write_bytes(self, key, buf)
     }
 
-    fn replace(
+    fn replace_bytes(
         &mut self,
         key: &Type::Key,
         buf: &[u8],
     ) -> Result<(usize, Option<Vec<u8>>), Self::Error> {
-        <T as StorageWrite<Type>>::replace(self, key, buf)
+        <T as StorageWrite<Type>>::replace_bytes(self, key, buf)
     }
 
-    fn take(&mut self, key: &Type::Key) -> Result<Option<Vec<u8>>, Self::Error> {
-        <T as StorageWrite<Type>>::take(self, key)
+    fn take_bytes(&mut self, key: &Type::Key) -> Result<Option<Vec<u8>>, Self::Error> {
+        <T as StorageWrite<Type>>::take_bytes(self, key)
     }
 }
 
@@ -213,19 +222,33 @@ impl<'a, T: StorageInspect<Type>, Type: Mappable> StorageMut<'a, T, Type> {
     }
 }
 
-impl<'a, T: StorageMutate<Type>, Type: Mappable> StorageMut<'a, T, Type> {
+impl<'a, T, Type> StorageMut<'a, T, Type>
+where
+    T: StorageMutate<Type>,
+    Type: Mappable,
+{
     #[inline(always)]
-    pub fn insert(
+    pub fn insert(self, key: &Type::Key, value: &Type::Value) -> Result<(), T::Error> {
+        StorageMutate::insert(self.0, key, value)
+    }
+
+    #[inline(always)]
+    pub fn replace(
         self,
         key: &Type::Key,
         value: &Type::Value,
     ) -> Result<Option<Type::OwnedValue>, T::Error> {
-        self.0.insert(key, value)
+        StorageMutate::replace(self.0, key, value)
     }
 
     #[inline(always)]
-    pub fn remove(self, key: &Type::Key) -> Result<Option<Type::OwnedValue>, T::Error> {
-        self.0.remove(key)
+    pub fn remove(self, key: &Type::Key) -> Result<(), T::Error> {
+        StorageMutate::remove(self.0, key)
+    }
+
+    #[inline(always)]
+    pub fn take(self, key: &Type::Key) -> Result<Option<Type::OwnedValue>, T::Error> {
+        StorageMutate::take(self.0, key)
     }
 }
 
@@ -239,14 +262,22 @@ impl<'a, T, Type: Mappable> StorageMut<'a, T, Type> {
     }
 }
 
-impl<'a, T: StorageWrite<Type>, Type: Mappable> StorageMut<'a, T, Type> {
+impl<'a, T, Type> StorageMut<'a, T, Type>
+where
+    Type: Mappable,
+    T: StorageWrite<Type>,
+{
     #[inline(always)]
-    pub fn write(&mut self, key: &Type::Key, buf: &[u8]) -> Result<usize, T::Error> {
-        self.0.write(key, buf)
+    pub fn write_bytes(
+        &mut self,
+        key: &Type::Key,
+        buf: &[u8],
+    ) -> Result<usize, T::Error> {
+        StorageWrite::write_bytes(self.0, key, buf)
     }
 
     #[inline(always)]
-    pub fn replace(
+    pub fn replace_bytes(
         &mut self,
         key: &Type::Key,
         buf: &[u8],
@@ -254,11 +285,11 @@ impl<'a, T: StorageWrite<Type>, Type: Mappable> StorageMut<'a, T, Type> {
     where
         T: StorageSize<Type>,
     {
-        self.0.replace(key, buf)
+        StorageWrite::replace_bytes(self.0, key, buf)
     }
 
     #[inline(always)]
-    pub fn take(&mut self, key: &Type::Key) -> Result<Option<Vec<u8>>, T::Error> {
-        self.0.take(key)
+    pub fn take_bytes(&mut self, key: &Type::Key) -> Result<Option<Vec<u8>>, T::Error> {
+        StorageWrite::take_bytes(self.0, key)
     }
 }

--- a/fuel-storage/src/lib.rs
+++ b/fuel-storage/src/lib.rs
@@ -73,23 +73,34 @@ pub trait StorageInspect<Type: Mappable> {
 /// Generic should implement [`Mappable`] trait with all storage type information.
 pub trait StorageMutate<Type: Mappable>: StorageInspect<Type> {
     /// Append `Key->Value` mapping to the storage.
+    fn insert(
+        &mut self,
+        key: &Type::Key,
+        value: &Type::Value,
+    ) -> Result<(), Self::Error> {
+        self.replace(key, value).map(|_| ())
+    }
+
+    /// Append `Key->Value` mapping to the storage.
     ///
     /// If `Key` was already mappped to a value, return the replaced value as
     /// `Ok(Some(Value))`. Return `Ok(None)` otherwise.
-    fn insert(
+    fn replace(
         &mut self,
         key: &Type::Key,
         value: &Type::Value,
     ) -> Result<Option<Type::OwnedValue>, Self::Error>;
 
     /// Remove `Key->Value` mapping from the storage.
+    fn remove(&mut self, key: &Type::Key) -> Result<(), Self::Error> {
+        self.take(key).map(|_| ())
+    }
+
+    /// Remove `Key->Value` mapping from the storage.
     ///
     /// Return `Ok(Some(Value))` if the value was present. If the key wasn't found, return
     /// `Ok(None)`.
-    fn remove(
-        &mut self,
-        key: &Type::Key,
-    ) -> Result<Option<Type::OwnedValue>, Self::Error>;
+    fn take(&mut self, key: &Type::Key) -> Result<Option<Type::OwnedValue>, Self::Error>;
 }
 
 /// Base storage trait for Fuel infrastructure.
@@ -133,27 +144,27 @@ pub trait StorageRead<Type: Mappable>: StorageInspect<Type> + StorageSize<Type> 
 /// This trait should skip any serialization and simply copy the raw bytes
 /// to the storage.
 pub trait StorageWrite<Type: Mappable>: StorageMutate<Type> {
-    /// Write the value to the given key from the provided buffer.
+    /// Write the bytes to the given key from the provided buffer.
     ///
     /// Does not perform any serialization.
     ///
     /// Returns the number of bytes written.
-    fn write(&mut self, key: &Type::Key, buf: &[u8]) -> Result<usize, Self::Error>;
+    fn write_bytes(&mut self, key: &Type::Key, buf: &[u8]) -> Result<usize, Self::Error>;
 
-    /// Write the value to the given key from the provided buffer and
-    /// return the previous value if it existed.
+    /// Write the bytes to the given key from the provided buffer and
+    /// return the previous bytes if it existed.
     ///
     /// Does not perform any serialization.
     ///
     /// Returns the number of bytes written and the previous value if it existed.
-    fn replace(
+    fn replace_bytes(
         &mut self,
         key: &Type::Key,
         buf: &[u8],
     ) -> Result<(usize, Option<Vec<u8>>), Self::Error>;
 
-    /// Removes a value from the storage and returning it without deserializing it.
-    fn take(&mut self, key: &Type::Key) -> Result<Option<Vec<u8>>, Self::Error>;
+    /// Removes a bytes from the storage and returning it without deserializing it.
+    fn take_bytes(&mut self, key: &Type::Key) -> Result<Option<Vec<u8>>, Self::Error>;
 }
 
 /// Returns the merkle root for the `StorageType` per merkle `Key`. Per one storage, it is

--- a/fuel-vm/src/interpreter/blockchain.rs
+++ b/fuel-vm/src/interpreter/blockchain.rs
@@ -694,8 +694,7 @@ where
             .checked_sub(a)
             .ok_or(PanicReason::NotEnoughBalance)?;
 
-        let _ = self
-            .storage
+        self.storage
             .contract_asset_id_balance_insert(&contract_id, &asset_id, balance)
             .map_err(RuntimeError::Storage)?;
 
@@ -735,7 +734,7 @@ where
 
         let old_value = self
             .storage
-            .contract_asset_id_balance_insert(&contract_id, &asset_id, balance)
+            .contract_asset_id_balance_replace(&contract_id, &asset_id, balance)
             .map_err(RuntimeError::Storage)?;
 
         if old_value.is_none() {
@@ -1054,8 +1053,8 @@ pub(crate) fn state_write_word<S: InterpreterStorage>(
     let mut value = Bytes32::zeroed();
     value.as_mut()[..WORD_SIZE].copy_from_slice(&c.to_be_bytes());
 
-    let (_size, prev) = storage
-        .contract_state_insert(&contract, &key, value.as_ref())
+    let prev = storage
+        .contract_state_replace(&contract, &key, value.as_ref())
         .map_err(RuntimeError::Storage)?;
 
     *created_new = prev.is_none() as Word;

--- a/fuel-vm/src/interpreter/blockchain/other_tests.rs
+++ b/fuel-vm/src/interpreter/blockchain/other_tests.rs
@@ -37,7 +37,7 @@ fn test_burn(
     let initialize = initialize.into();
     if let Some(initialize) = initialize {
         let old_balance = storage
-            .contract_asset_id_balance_insert(&contract_id, &asset_id, initialize)
+            .contract_asset_id_balance_replace(&contract_id, &asset_id, initialize)
             .unwrap();
         assert!(old_balance.is_none());
     }
@@ -115,7 +115,7 @@ fn test_mint(
     let initialize = initialize.into();
     if let Some(initialize) = initialize {
         let old_balance = storage
-            .contract_asset_id_balance_insert(&contract_id, &asset_id, initialize)
+            .contract_asset_id_balance_replace(&contract_id, &asset_id, initialize)
             .unwrap();
         assert!(old_balance.is_none());
     }
@@ -221,7 +221,7 @@ fn test_code_size() {
     let mut memory: MemoryInstance = vec![1u8; MEM_SIZE].try_into().unwrap();
     memory[0..ContractId::LEN].copy_from_slice(contract_id.as_slice());
     StorageAsMut::storage::<ContractsRawCode>(&mut storage)
-        .write(&ContractId::from([3u8; 32]), &[1u8; 100])
+        .write_bytes(&ContractId::from([3u8; 32]), &[1u8; 100])
         .unwrap();
     let mut pc = 4;
     let is = 0;

--- a/fuel-vm/src/interpreter/blockchain/smo_tests.rs
+++ b/fuel-vm/src/interpreter/blockchain/smo_tests.rs
@@ -217,7 +217,7 @@ fn test_smo(
     let mut receipts = Default::default();
     let mut storage = MemoryStorage::default();
     let old_balance = storage
-        .contract_asset_id_balance_insert(
+        .contract_asset_id_balance_replace(
             &ContractId::default(),
             &base_asset_id,
             initial_balance,

--- a/fuel-vm/src/interpreter/contract.rs
+++ b/fuel-vm/src/interpreter/contract.rs
@@ -426,7 +426,7 @@ where
         .ok_or(PanicReason::BalanceOverflow)?;
 
     let old_value = storage
-        .contract_asset_id_balance_insert(contract, asset_id, balance)
+        .contract_asset_id_balance_replace(contract, asset_id, balance)
         .map_err(RuntimeError::Storage)?;
 
     Ok((balance, old_value.is_none()))
@@ -446,7 +446,7 @@ where
     let balance = balance
         .checked_sub(amount)
         .ok_or(PanicReason::NotEnoughBalance)?;
-    let _ = storage
+    storage
         .contract_asset_id_balance_insert(contract, asset_id, balance)
         .map_err(RuntimeError::Storage)?;
     Ok(balance)

--- a/fuel-vm/src/interpreter/flow/tests.rs
+++ b/fuel-vm/src/interpreter/flow/tests.rs
@@ -353,12 +353,12 @@ fn test_prepare_call(input: Input) -> Result<Output, RuntimeError<Infallible>> {
     let mut storage = MemoryStorage::default();
     for (id, code) in storage_contract {
         StorageAsMut::storage::<ContractsRawCode>(&mut storage)
-            .write(&id, code.as_ref())
+            .write_bytes(&id, code.as_ref())
             .unwrap();
     }
     for (a, n) in storage_balance.iter() {
         let old_balance = storage
-            .contract_asset_id_balance_insert(&ContractId::default(), a, *n)
+            .contract_asset_id_balance_replace(&ContractId::default(), a, *n)
             .unwrap();
         assert!(old_balance.is_none());
     }

--- a/fuel-vm/src/storage/interpreter.rs
+++ b/fuel-vm/src/storage/interpreter.rs
@@ -207,7 +207,7 @@ pub trait InterpreterStorage:
         Ok(())
     }
 
-    /// Insert a key-value mapping in a contract storage.
+    /// Insert a key-value mapping into a contract storage.
     fn contract_state_replace(
         &mut self,
         contract: &ContractId,

--- a/fuel-vm/src/storage/interpreter.rs
+++ b/fuel-vm/src/storage/interpreter.rs
@@ -174,7 +174,7 @@ pub trait InterpreterStorage:
         &mut self,
         id: &ContractId,
         contract: &Contract,
-    ) -> Result<Option<Contract>, Self::DataError> {
+    ) -> Result<(), Self::DataError> {
         StorageMutate::<ContractsRawCode>::insert(self, id, contract.as_ref())
     }
 
@@ -198,24 +198,28 @@ pub trait InterpreterStorage:
         contract: &ContractId,
         key: &Bytes32,
         value: &[u8],
-    ) -> Result<(usize, Option<Vec<u8>>), Self::DataError> {
-        let result = StorageWrite::<ContractsState>::replace(
+    ) -> Result<(), Self::DataError> {
+        StorageWrite::<ContractsState>::write_bytes(
             self,
             &(contract, key).into(),
             value,
         )?;
-        Ok(result)
+        Ok(())
     }
 
-    /// Remove a key-value mapping from a contract storage.
-    fn contract_state_remove(
+    /// Insert a key-value mapping in a contract storage.
+    fn contract_state_replace(
         &mut self,
         contract: &ContractId,
         key: &Bytes32,
-    ) -> Result<Option<ContractsStateData>, Self::DataError> {
-        let result = StorageWrite::<ContractsState>::take(self, &(contract, key).into())?
-            .map(Into::into);
-        Ok(result)
+        value: &[u8],
+    ) -> Result<Option<Vec<u8>>, Self::DataError> {
+        let (_, prev) = StorageWrite::<ContractsState>::replace_bytes(
+            self,
+            &(contract, key).into(),
+            value,
+        )?;
+        Ok(prev)
     }
 
     /// Fetch a range of values from a key-value mapping in a contract storage.
@@ -266,14 +270,28 @@ pub trait ContractsAssetsStorage: StorageMutate<ContractsAssets> {
     }
 
     /// Update the balance of an asset ID in a contract storage.
-    /// Returns the old balance, if any.
     fn contract_asset_id_balance_insert(
         &mut self,
         contract: &ContractId,
         asset_id: &AssetId,
         value: Word,
-    ) -> Result<Option<Word>, Self::Error> {
+    ) -> Result<(), Self::Error> {
         StorageMutate::<ContractsAssets>::insert(
+            self,
+            &(contract, asset_id).into(),
+            &value,
+        )
+    }
+
+    /// Update the balance of an asset ID in a contract storage.
+    /// Returns the old balance, if any.
+    fn contract_asset_id_balance_replace(
+        &mut self,
+        contract: &ContractId,
+        asset_id: &AssetId,
+        value: Word,
+    ) -> Result<Option<Word>, Self::Error> {
+        StorageMutate::<ContractsAssets>::replace(
             self,
             &(contract, asset_id).into(),
             &value,

--- a/fuel-vm/src/storage/memory.rs
+++ b/fuel-vm/src/storage/memory.rs
@@ -205,7 +205,7 @@ impl StorageInspect<ContractsRawCode> for MemoryStorage {
 }
 
 impl StorageMutate<ContractsRawCode> for MemoryStorage {
-    fn insert(
+    fn replace(
         &mut self,
         key: &ContractId,
         value: &[u8],
@@ -213,19 +213,19 @@ impl StorageMutate<ContractsRawCode> for MemoryStorage {
         Ok(self.memory.contracts.insert(*key, value.into()))
     }
 
-    fn remove(&mut self, key: &ContractId) -> Result<Option<Contract>, Infallible> {
+    fn take(&mut self, key: &ContractId) -> Result<Option<Contract>, Infallible> {
         Ok(self.memory.contracts.remove(key))
     }
 }
 
 impl StorageWrite<ContractsRawCode> for MemoryStorage {
-    fn write(&mut self, key: &ContractId, buf: &[u8]) -> Result<usize, Infallible> {
+    fn write_bytes(&mut self, key: &ContractId, buf: &[u8]) -> Result<usize, Infallible> {
         let size = buf.len();
         self.memory.contracts.insert(*key, Contract::from(buf));
         Ok(size)
     }
 
-    fn replace(
+    fn replace_bytes(
         &mut self,
         key: &ContractId,
         buf: &[u8],
@@ -239,7 +239,7 @@ impl StorageWrite<ContractsRawCode> for MemoryStorage {
         Ok((size, prev))
     }
 
-    fn take(&mut self, key: &ContractId) -> Result<Option<Vec<u8>>, Self::Error> {
+    fn take_bytes(&mut self, key: &ContractId) -> Result<Option<Vec<u8>>, Self::Error> {
         let prev = self.memory.contracts.remove(key).map(Into::into);
         Ok(prev)
     }
@@ -292,7 +292,7 @@ impl StorageInspect<UploadedBytecodes> for MemoryStorage {
 }
 
 impl StorageMutate<UploadedBytecodes> for MemoryStorage {
-    fn insert(
+    fn replace(
         &mut self,
         key: &<UploadedBytecodes as Mappable>::Key,
         value: &<UploadedBytecodes as Mappable>::Value,
@@ -303,7 +303,7 @@ impl StorageMutate<UploadedBytecodes> for MemoryStorage {
             .insert(*key, value.clone()))
     }
 
-    fn remove(
+    fn take(
         &mut self,
         key: &<UploadedBytecodes as Mappable>::Key,
     ) -> Result<Option<UploadedBytecode>, Infallible> {
@@ -330,7 +330,7 @@ impl StorageInspect<ContractsAssets> for MemoryStorage {
 }
 
 impl StorageMutate<ContractsAssets> for MemoryStorage {
-    fn insert(
+    fn replace(
         &mut self,
         key: &<ContractsAssets as Mappable>::Key,
         value: &Word,
@@ -338,7 +338,7 @@ impl StorageMutate<ContractsAssets> for MemoryStorage {
         Ok(self.memory.balances.insert(*key, *value))
     }
 
-    fn remove(
+    fn take(
         &mut self,
         key: &<ContractsAssets as Mappable>::Key,
     ) -> Result<Option<Word>, Infallible> {
@@ -366,7 +366,7 @@ impl StorageInspect<ContractsState> for MemoryStorage {
 }
 
 impl StorageMutate<ContractsState> for MemoryStorage {
-    fn insert(
+    fn replace(
         &mut self,
         key: &<ContractsState as Mappable>::Key,
         value: &<ContractsState as Mappable>::Value,
@@ -374,7 +374,7 @@ impl StorageMutate<ContractsState> for MemoryStorage {
         Ok(self.memory.contract_state.insert(*key, value.into()))
     }
 
-    fn remove(
+    fn take(
         &mut self,
         key: &<ContractsState as Mappable>::Key,
     ) -> Result<Option<ContractsStateData>, Infallible> {
@@ -383,7 +383,7 @@ impl StorageMutate<ContractsState> for MemoryStorage {
 }
 
 impl StorageWrite<ContractsState> for MemoryStorage {
-    fn write(
+    fn write_bytes(
         &mut self,
         key: &<ContractsState as Mappable>::Key,
         buf: &[u8],
@@ -395,7 +395,7 @@ impl StorageWrite<ContractsState> for MemoryStorage {
         Ok(size)
     }
 
-    fn replace(
+    fn replace_bytes(
         &mut self,
         key: &<ContractsState as Mappable>::Key,
         buf: &[u8],
@@ -412,7 +412,7 @@ impl StorageWrite<ContractsState> for MemoryStorage {
         Ok((size, prev))
     }
 
-    fn take(
+    fn take_bytes(
         &mut self,
         key: &<ContractsState as Mappable>::Key,
     ) -> Result<Option<Vec<u8>>, Self::Error> {
@@ -579,7 +579,7 @@ impl InterpreterStorage for MemoryStorage {
             if !storage.contains_key(&key)? {
                 unset_count += 1;
             }
-            storage.write(&key, value)?;
+            storage.write_bytes(&key, value)?;
             Ok::<_, Self::DataError>(())
         })?;
         Ok(unset_count)

--- a/fuel-vm/src/storage/predicate.rs
+++ b/fuel-vm/src/storage/predicate.rs
@@ -76,7 +76,7 @@ impl<Type: Mappable> StorageInspect<Type> for PredicateStorage {
 }
 
 impl<Type: Mappable> StorageMutate<Type> for PredicateStorage {
-    fn insert(
+    fn replace(
         &mut self,
         _key: &Type::Key,
         _value: &Type::Value,
@@ -84,7 +84,7 @@ impl<Type: Mappable> StorageMutate<Type> for PredicateStorage {
         Err(StorageUnavailable)
     }
 
-    fn remove(
+    fn take(
         &mut self,
         _key: &Type::Key,
     ) -> Result<Option<Type::OwnedValue>, StorageUnavailable> {
@@ -119,7 +119,7 @@ impl StorageRead<ContractsRawCode> for PredicateStorage {
 }
 
 impl StorageWrite<ContractsRawCode> for PredicateStorage {
-    fn write(
+    fn write_bytes(
         &mut self,
         _key: &<ContractsRawCode as Mappable>::Key,
         _buf: &[u8],
@@ -127,7 +127,7 @@ impl StorageWrite<ContractsRawCode> for PredicateStorage {
         Err(StorageUnavailable)
     }
 
-    fn replace(
+    fn replace_bytes(
         &mut self,
         _key: &<ContractsRawCode as Mappable>::Key,
         _buf: &[u8],
@@ -135,7 +135,7 @@ impl StorageWrite<ContractsRawCode> for PredicateStorage {
         Err(StorageUnavailable)
     }
 
-    fn take(
+    fn take_bytes(
         &mut self,
         _key: &<ContractsRawCode as Mappable>::Key,
     ) -> Result<Option<Vec<u8>>, Self::Error> {
@@ -170,7 +170,7 @@ impl StorageRead<ContractsState> for PredicateStorage {
 }
 
 impl StorageWrite<ContractsState> for PredicateStorage {
-    fn write(
+    fn write_bytes(
         &mut self,
         _key: &<ContractsState as Mappable>::Key,
         _buf: &[u8],
@@ -178,7 +178,7 @@ impl StorageWrite<ContractsState> for PredicateStorage {
         Err(StorageUnavailable)
     }
 
-    fn replace(
+    fn replace_bytes(
         &mut self,
         _key: &<ContractsState as Mappable>::Key,
         _buf: &[u8],
@@ -186,7 +186,7 @@ impl StorageWrite<ContractsState> for PredicateStorage {
         Err(StorageUnavailable)
     }
 
-    fn take(
+    fn take_bytes(
         &mut self,
         _key: &<ContractsState as Mappable>::Key,
     ) -> Result<Option<Vec<u8>>, Self::Error> {


### PR DESCRIPTION
The change adds new `replace` and `take` methods into the `StorageMutate` traits. These new methods work as the old ones. Old methods were changed to not return the value.

Most of all, places that were using `insert` and `remove` don't need an old value. This helps to remove unnecessary lookups to the storage. An example is the Sparse Merkle tree. It only inserts new nodes and removes old nodes without handling the old values since it is not important for the tree.

I helped to decrease lookups to the storage in the testnet by 30%.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog

### Before requesting review
- [x] I have reviewed the code myself
