### PR TITLE
Optimized storage lookups for side nodes in the SMT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - [#781](https://github.com/FuelLabs/fuel-vm/pull/781): Added `base_asset_id` to checked metadata.
 
+### Changed
+- [#784](https://github.com/FuelLabs/fuel-vm/pull/784): Avoid storage lookups for side nodes in the SMT.
+
 ## [Version 0.54.1]
 
 ### Changed

--- a/fuel-merkle/src/common/node.rs
+++ b/fuel-merkle/src/common/node.rs
@@ -24,9 +24,17 @@ pub trait Node {
 
 pub trait ParentNode: Sized + Node {
     type Error;
+    type ChildKey;
 
+    fn key(&self) -> Self::ChildKey;
     fn left_child(&self) -> ChildResult<Self>;
+    fn left_child_key(
+        &self,
+    ) -> Result<Self::ChildKey, ChildError<Self::Key, Self::Error>>;
     fn right_child(&self) -> ChildResult<Self>;
+    fn right_child_key(
+        &self,
+    ) -> Result<Self::ChildKey, ChildError<Self::Key, Self::Error>>;
 }
 
 #[allow(type_alias_bounds)]

--- a/fuel-merkle/src/common/node.rs
+++ b/fuel-merkle/src/common/node.rs
@@ -28,17 +28,16 @@ pub trait ParentNode: Sized + Node {
 
     fn key(&self) -> Self::ChildKey;
     fn left_child(&self) -> ChildResult<Self>;
-    fn left_child_key(
-        &self,
-    ) -> Result<Self::ChildKey, ChildError<Self::Key, Self::Error>>;
+    fn left_child_key(&self) -> ChildKeyResult<Self>;
     fn right_child(&self) -> ChildResult<Self>;
-    fn right_child_key(
-        &self,
-    ) -> Result<Self::ChildKey, ChildError<Self::Key, Self::Error>>;
+    fn right_child_key(&self) -> ChildKeyResult<Self>;
 }
 
 #[allow(type_alias_bounds)]
 pub type ChildResult<T: ParentNode> = Result<T, ChildError<T::Key, T::Error>>;
+#[allow(type_alias_bounds)]
+pub type ChildKeyResult<T: ParentNode> =
+    Result<T::ChildKey, ChildError<T::Key, T::Error>>;
 
 #[derive(Debug, Clone, derive_more::Display)]
 pub enum ChildError<Key, E>

--- a/fuel-merkle/src/common/path_iterator.rs
+++ b/fuel-merkle/src/common/path_iterator.rs
@@ -1,6 +1,6 @@
 use crate::common::{
     node::{
-        ChildError,
+        ChildKeyResult,
         ChildResult,
         ParentNode,
     },
@@ -84,10 +84,7 @@ use crate::common::{
 /// 12`.
 pub struct PathIter<T: ParentNode> {
     leaf_key: T::Key,
-    current: Option<(
-        ChildResult<T>,
-        Result<T::ChildKey, ChildError<T::Key, T::Error>>,
-    )>,
+    current: Option<(ChildResult<T>, ChildKeyResult<T>)>,
     current_offset: u32,
 }
 
@@ -158,10 +155,7 @@ where
     T: ParentNode,
     T::Key: Path,
 {
-    type Item = (
-        ChildResult<T>,
-        Result<T::ChildKey, ChildError<T::Key, T::Error>>,
-    );
+    type Item = (ChildResult<T>, ChildKeyResult<T>);
 
     fn next(&mut self) -> Option<Self::Item> {
         let value = self.current.take();
@@ -223,7 +217,7 @@ where
 mod test {
     use crate::common::{
         node::{
-            ChildError,
+            ChildKeyResult,
             ChildResult,
             Node,
             ParentNode,
@@ -310,9 +304,7 @@ mod test {
             Ok(TestNode::child(self, -1))
         }
 
-        fn left_child_key(
-            &self,
-        ) -> Result<Self::ChildKey, ChildError<Self::Key, Self::Error>> {
+        fn left_child_key(&self) -> ChildKeyResult<Self> {
             self.left_child().map(|node| node.in_order_index())
         }
 
@@ -320,9 +312,7 @@ mod test {
             Ok(TestNode::child(self, 1))
         }
 
-        fn right_child_key(
-            &self,
-        ) -> Result<Self::ChildKey, ChildError<Self::Key, Self::Error>> {
+        fn right_child_key(&self) -> ChildKeyResult<Self> {
             self.right_child().map(|node| node.in_order_index())
         }
     }

--- a/fuel-merkle/src/common/position.rs
+++ b/fuel-merkle/src/common/position.rs
@@ -313,7 +313,12 @@ pub enum GetNodeError {
 }
 
 impl ParentNode for Position {
+    type ChildKey = u64;
     type Error = Infallible;
+
+    fn key(&self) -> Self::ChildKey {
+        self.in_order_index()
+    }
 
     fn left_child(&self) -> ChildResult<Self> {
         match self.child(Side::Left) {
@@ -323,12 +328,24 @@ impl ParentNode for Position {
         }
     }
 
+    fn left_child_key(
+        &self,
+    ) -> Result<Self::ChildKey, ChildError<Self::Key, Self::Error>> {
+        ParentNode::left_child(self).map(|child| child.in_order_index())
+    }
+
     fn right_child(&self) -> ChildResult<Self> {
         match self.child(Side::Right) {
             Ok(child) => Ok(child),
             Err(GetNodeError::IsLeaf) => Err(ChildError::NodeIsLeaf),
             Err(GetNodeError::CannotExist) => Err(ChildError::ChildCannotExist),
         }
+    }
+
+    fn right_child_key(
+        &self,
+    ) -> Result<Self::ChildKey, ChildError<Self::Key, Self::Error>> {
+        ParentNode::right_child(self).map(|child| child.in_order_index())
     }
 }
 

--- a/fuel-merkle/src/common/position.rs
+++ b/fuel-merkle/src/common/position.rs
@@ -1,5 +1,6 @@
 use crate::common::{
     node::{
+        ChildKeyResult,
         Node,
         ParentNode,
     },
@@ -328,9 +329,7 @@ impl ParentNode for Position {
         }
     }
 
-    fn left_child_key(
-        &self,
-    ) -> Result<Self::ChildKey, ChildError<Self::Key, Self::Error>> {
+    fn left_child_key(&self) -> ChildKeyResult<Self> {
         ParentNode::left_child(self).map(|child| child.in_order_index())
     }
 
@@ -342,9 +341,7 @@ impl ParentNode for Position {
         }
     }
 
-    fn right_child_key(
-        &self,
-    ) -> Result<Self::ChildKey, ChildError<Self::Key, Self::Error>> {
+    fn right_child_key(&self) -> ChildKeyResult<Self> {
         ParentNode::right_child(self).map(|child| child.in_order_index())
     }
 }

--- a/fuel-merkle/src/common/position_path.rs
+++ b/fuel-merkle/src/common/position_path.rs
@@ -72,12 +72,14 @@ impl Iterator for PositionPathIter {
         // Find the next set of path and side positions by iterating from the
         // given root position to the given leaf position and evaluating each
         // position against the tree described by the leaves count.
-        for (path, mut side) in self.path_iter.by_ref().map(|(path, side)| {
+        let iter = self.path_iter.by_ref().map(|(path, side)| {
             // SAFETY: Path iteration over positions is infallible. Path
             // positions and side positions are both guaranteed to be valid in
             // this context.
             (path.unwrap(), side.unwrap())
-        }) {
+        });
+        for (path, side) in iter {
+            let mut side = Position::from_in_order_index(side);
             // To determine if the position is in the tree, we observe that the
             // highest in-order index belongs to the tree's rightmost leaf
             // position (as defined by the `leaves_count` parameter) and that

--- a/fuel-merkle/src/sparse/merkle_tree/node.rs
+++ b/fuel-merkle/src/sparse/merkle_tree/node.rs
@@ -33,6 +33,7 @@ use crate::{
     },
 };
 
+use crate::common::node::ChildKeyResult;
 use core::{
     fmt,
     marker::PhantomData,
@@ -448,9 +449,7 @@ where
             .map_err(StorageNodeError::DeserializeError)?)
     }
 
-    fn left_child_key(
-        &self,
-    ) -> Result<Self::ChildKey, ChildError<Self::Key, Self::Error>> {
+    fn left_child_key(&self) -> ChildKeyResult<Self> {
         if self.is_leaf() {
             return Err(ChildError::NodeIsLeaf)
         }
@@ -477,9 +476,7 @@ where
             .map_err(StorageNodeError::DeserializeError)?)
     }
 
-    fn right_child_key(
-        &self,
-    ) -> Result<Self::ChildKey, ChildError<Self::Key, Self::Error>> {
+    fn right_child_key(&self) -> ChildKeyResult<Self> {
         if self.is_leaf() {
             return Err(ChildError::NodeIsLeaf)
         }


### PR DESCRIPTION
During debugging high storage access in the testnet, I realized that we request left and right children during iteration over the SMT.

<img width="371" alt="image" src="https://github.com/FuelLabs/fuel-vm/assets/18346821/7048df2b-5f4b-4d02-8b68-005f11b3b34b">

While we only need path nodes. When we construct the node back, we can use the same path node to decide who is the right child and who is the left child. In this case we reduce number of storage lookups in two times.

## Checklist
- [x] New behavior is reflected in tests

### Before requesting review
- [x] I have reviewed the code myself