### PR TITLE
Require `ContractCreated` output in the `Create` transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - [#781](https://github.com/FuelLabs/fuel-vm/pull/781): Added `base_asset_id` to checked metadata.
 
+### Fixed
+
+#### Breaking
+- [#785](https://github.com/FuelLabs/fuel-vm/pull/785): Require `ContractCreated` output in the `Create` transaction. The `TransactionBuilder<Create>` has a `add_contract_created` method to simplify the creation of the `ContractCreated` output for tests.
+
 ## [Version 0.54.1]
 
 ### Changed

--- a/fuel-tx/src/builder.rs
+++ b/fuel-tx/src/builder.rs
@@ -16,6 +16,7 @@ use crate::{
     },
     ConsensusParameters,
     ContractParameters,
+    CreateMetadata,
     FeeParameters,
     GasCosts,
     Input,
@@ -42,6 +43,7 @@ use crate::{
 use crate::{
     field::{
         MaxFeeLimit,
+        Outputs,
         WitnessLimit,
     },
     policies::Policies,
@@ -166,6 +168,17 @@ impl TransactionBuilder<Create> {
         tx.witnesses_mut().push(bytecode);
 
         Self::with_tx(tx)
+    }
+
+    pub fn add_contract_created(&mut self) -> &mut Self {
+        let create_metadata = CreateMetadata::compute(&self.tx)
+            .expect("Should be able to compute metadata");
+
+        self.tx.outputs_mut().push(Output::contract_created(
+            create_metadata.contract_id,
+            create_metadata.state_root,
+        ));
+        self
     }
 }
 

--- a/fuel-tx/src/lib.rs
+++ b/fuel-tx/src/lib.rs
@@ -90,6 +90,7 @@ pub use transaction::{
     ConsensusParameters,
     ContractParameters,
     Create,
+    CreateMetadata,
     DependentCost,
     Executable,
     FeeParameters,

--- a/fuel-tx/src/transaction/types.rs
+++ b/fuel-tx/src/transaction/types.rs
@@ -17,6 +17,7 @@ pub use chargeable_transaction::{
 pub use create::{
     Create,
     CreateBody,
+    CreateMetadata,
 };
 pub use mint::Mint;
 pub use script::{

--- a/fuel-tx/src/transaction/types/create.rs
+++ b/fuel-tx/src/transaction/types/create.rs
@@ -246,6 +246,10 @@ impl UniqueFormatValidityChecks for Create {
                 _ => Ok(()),
             })?;
 
+        if !contract_created {
+            return Err(ValidityError::TransactionOutputDoesntContainContractCreated);
+        }
+
         Ok(())
     }
 }

--- a/fuel-tx/src/transaction/validity/error.rs
+++ b/fuel-tx/src/transaction/validity/error.rs
@@ -174,4 +174,6 @@ pub enum ValidityError {
     SerializedWitnessTooLarge {
         index: usize,
     },
+    /// The `Create` transaction doesn't contain `Output::ContractCreated`.
+    TransactionOutputDoesntContainContractCreated,
 }

--- a/fuel-vm/src/interpreter/executors/main/tests.rs
+++ b/fuel-vm/src/interpreter/executors/main/tests.rs
@@ -152,6 +152,7 @@ fn valid_create_tx() -> Checked<Create> {
     TransactionBuilder::create(witness, salt, vec![])
         .max_fee_limit(arb_max_fee)
         .add_random_fee_input()
+        .add_contract_created()
         .finalize_checked_basic(Default::default())
 }
 

--- a/fuel-vm/src/tests/blockchain.rs
+++ b/fuel-vm/src/tests/blockchain.rs
@@ -69,17 +69,12 @@ fn deploy_contract<M>(
 ) where
     M: Memory,
 {
-    let code_root = Contract::root_from_code(contract.as_ref());
-    let state_root = Contract::initial_state_root(storage_slots.iter());
-    let contract_id =
-        Contract::from(contract.as_ref()).id(&salt, &code_root, &state_root);
-
     let tx_params = TxParameters::default();
     let height = Default::default();
     let contract_deployer = TransactionBuilder::create(contract, salt, storage_slots)
         .with_tx_params(tx_params)
-        .add_output(Output::contract_created(contract_id, state_root))
         .add_random_fee_input()
+        .add_contract_created()
         .finalize_checked(height);
 
     client
@@ -598,8 +593,7 @@ where
     let contract_id = contract.id(&salt, &contract_root, &state_root);
 
     let input0 = Input::contract(rng.gen(), rng.gen(), rng.gen(), rng.gen(), contract_id);
-    let output0 = Output::contract_created(contract_id, state_root);
-    let output1 = Output::contract(0, rng.gen(), rng.gen());
+    let output0 = Output::contract(0, rng.gen(), rng.gen());
 
     let consensus_params = ConsensusParameters::standard();
 
@@ -607,7 +601,7 @@ where
         TransactionBuilder::create(target_contract_witness.clone(), salt, vec![])
             .maturity(maturity)
             .add_random_fee_input()
-            .add_output(output0)
+            .add_contract_created()
             .finalize()
             .into_checked(height, &consensus_params)
             .expect("failed to check tx");
@@ -669,7 +663,7 @@ where
     .maturity(maturity)
     .add_input(input0.clone())
     .add_random_fee_input()
-    .add_output(output1)
+    .add_output(output0)
     .finalize()
     .into_checked(height, &consensus_params)
     .expect("failed to check tx");
@@ -686,7 +680,7 @@ where
             .maturity(maturity)
             .add_input(input0)
             .add_random_fee_input()
-            .add_output(output1)
+            .add_output(output0)
             .finalize()
             .into_checked(height, &consensus_params)
             .expect("failed to check tx");
@@ -741,12 +735,10 @@ fn ldc_reason_helper(cmd: Vec<Instruction>, expected_reason: PanicReason) {
     let state_root = Contract::default_state_root();
     let contract_id = contract.id(&salt, &contract_root, &state_root);
 
-    let output0 = Output::contract_created(contract_id, state_root);
-
     let tx_create_target = TransactionBuilder::create(program, salt, vec![])
         .maturity(maturity)
         .add_random_fee_input()
-        .add_output(output0)
+        .add_contract_created()
         .finalize()
         .into_checked(height, &consensus_params)
         .expect("failed to check tx");
@@ -2125,15 +2117,13 @@ fn various_ldc_issues_poc() {
     let target_contract_id =
         target_contract.id(&salt, &target_contract_root, &target_state_root);
 
-    let output0 = Output::contract_created(target_contract_id, target_state_root);
-
     let consensus_params = ConsensusParameters::standard();
 
     let tx_create_target =
         TransactionBuilder::create(target_program.clone(), salt, vec![])
             .maturity(maturity)
             .add_random_fee_input()
-            .add_output(output0)
+            .add_contract_created()
             .finalize()
             .into_checked(height, &consensus_params)
             .expect("failed to check tx");
@@ -2198,16 +2188,13 @@ fn various_ldc_issues_poc() {
     let loader_state_root = Contract::default_state_root();
     let loader_contract_id =
         loader_contract.id(&salt, &loader_contract_root, &loader_state_root);
-
-    let output0 = Output::contract_created(loader_contract_id, loader_state_root);
-
     let consensus_params = ConsensusParameters::standard();
 
     let tx_create_loader =
         TransactionBuilder::create(loader_program.clone(), salt, vec![])
             .maturity(maturity)
             .add_random_fee_input()
-            .add_output(output0)
+            .add_contract_created()
             .finalize()
             .into_checked(height, &consensus_params)
             .expect("failed to check tx");

--- a/fuel-vm/src/tests/metadata.rs
+++ b/fuel-vm/src/tests/metadata.rs
@@ -83,12 +83,11 @@ fn metadata() {
     let contract_root = contract.root();
     let state_root = Contract::default_state_root();
     let contract_metadata = contract.id(&salt, &contract_root, &state_root);
-    let output = Output::contract_created(contract_metadata, state_root);
 
     let tx = TransactionBuilder::create(program, salt, vec![])
         .maturity(maturity)
         .add_random_fee_input()
-        .add_output(output)
+        .add_contract_created()
         .finalize()
         .into_checked(height, &consensus_params)
         .expect("failed to check tx");
@@ -134,13 +133,10 @@ fn metadata() {
     let contract_root = contract.root();
     let state_root = Contract::default_state_root();
     let contract_call = contract.id(&salt, &contract_root, &state_root);
-
-    let output = Output::contract_created(contract_call, state_root);
-
     let tx = TransactionBuilder::create(program, salt, vec![])
         .maturity(maturity)
         .add_random_fee_input()
-        .add_output(output)
+        .add_contract_created()
         .finalize()
         .into_checked(height, &consensus_params)
         .expect("failed to check tx");
@@ -386,7 +382,6 @@ fn get_transaction_fields() {
         Contract::from(contract.as_ref()).id(&salt, &code_root, &state_root);
 
     let tx = TransactionBuilder::create(contract, salt, storage_slots)
-        .add_output(Output::contract_created(contract_id, state_root))
         .add_unsigned_coin_input(
             SecretKey::random(rng),
             rng.gen(),
@@ -394,6 +389,7 @@ fn get_transaction_fields() {
             AssetId::zeroed(),
             rng.gen(),
         )
+        .add_contract_created()
         .finalize_checked(height);
 
     client.deploy(tx).unwrap();

--- a/fuel-vm/src/tests/validation.rs
+++ b/fuel-vm/src/tests/validation.rs
@@ -122,10 +122,7 @@ fn malleable_fields_do_not_affect_validity_of_create() {
             predicate_bytecode,
             predicate_data,
         ))
-        .add_output(Output::contract_created(
-            Contract::EMPTY_CONTRACT_ID,
-            Default::default(),
-        ))
+        .add_contract_created()
         .add_output(Output::change(
             Default::default(),
             Default::default(),

--- a/fuel-vm/src/util.rs
+++ b/fuel-vm/src/util.rs
@@ -445,7 +445,7 @@ pub mod test_helpers {
                 .max_fee_limit(self.max_fee_limit)
                 .maturity(Default::default())
                 .add_random_fee_input()
-                .add_output(Output::contract_created(contract_id, storage_root))
+                .add_contract_created()
                 .finalize()
                 .into_checked(self.block_height, &self.consensus_params)
                 .expect("failed to check tx");
@@ -648,8 +648,8 @@ pub mod test_helpers {
         let contract_deployer = TransactionBuilder::create(contract, salt, storage_slots)
             .max_fee_limit(zero_fee_limit)
             .with_tx_params(tx_params)
-            .add_output(Output::contract_created(contract_id, state_root))
             .add_random_fee_input()
+            .add_contract_created()
             .finalize_checked(height);
 
         client


### PR DESCRIPTION
Specification requires to have one and only one `ContractCreated`=) We forgot to check that we have at least one=D

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests

### Before requesting review
- [x] I have reviewed the code myself
