### PR TITLE
Fixed the CCP opcode to charge for the length of the input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - [#781](https://github.com/FuelLabs/fuel-vm/pull/781): Added `base_asset_id` to checked metadata.
 
+### Fixed
+
+#### Breaking
+- [#786](https://github.com/FuelLabs/fuel-vm/pull/786): Fixed the CCP opcode to charge for the length from the input arguments.
+
 ## [Version 0.54.1]
 
 ### Changed

--- a/fuel-vm/src/interpreter/blockchain.rs
+++ b/fuel-vm/src/interpreter/blockchain.rs
@@ -801,6 +801,7 @@ where
         let contract = super::contract::contract(self.storage, &contract_id)?;
         let contract_bytes = contract.as_ref().as_ref();
         let contract_len = contract_bytes.len();
+        let charge_len = core::cmp::max(contract_len as u64, length);
         let profiler = ProfileGas {
             pc: self.pc.as_ref(),
             is: self.is,
@@ -812,7 +813,7 @@ where
             self.ggas,
             profiler,
             self.gas_cost,
-            contract_len as u64,
+            charge_len,
         )?;
 
         // Owner checks already performed above


### PR DESCRIPTION
The attacker can manipulate input `length` and `contract_len`(by deploying the corresponding contract) and cause memory clear or contract and to be cheap.

We need to charge for the maximum possible value. It will incentivize the caller of the CPP to use the same `length` and `contract_len`.

### Before requesting review
- [x] I have reviewed the code myself
