### PR TITLE
Fixed charge functions to profile cost before charging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - [#781](https://github.com/FuelLabs/fuel-vm/pull/781): Added `base_asset_id` to checked metadata.
 
+### Changed
+- [#787](https://github.com/FuelLabs/fuel-vm/pull/787): Fixed charge functions to profile cost before charging.
+
 ### Fixed
 
 #### Breaking

--- a/fuel-vm/src/interpreter/gas.rs
+++ b/fuel-vm/src/interpreter/gas.rs
@@ -1,10 +1,7 @@
 use super::Interpreter;
 use crate::{
     constraints::reg_key::*,
-    error::{
-        PanicOrBug,
-        SimpleResult,
-    },
+    error::SimpleResult,
     prelude::{
         Bug,
         BugVariant,
@@ -81,20 +78,9 @@ pub(crate) fn dependent_gas_charge_without_base(
     gas_cost: DependentCost,
     arg: Word,
 ) -> SimpleResult<()> {
-    let cost =
-        dependent_gas_charge_without_base_inner(cgas.as_mut(), ggas, gas_cost, arg)?;
-    profiler.profile(cgas.as_ref(), cost);
-    Ok(())
-}
-
-fn dependent_gas_charge_without_base_inner(
-    cgas: RegMut<CGAS>,
-    ggas: RegMut<GGAS>,
-    gas_cost: DependentCost,
-    arg: Word,
-) -> Result<Word, PanicOrBug> {
     let cost = gas_cost.resolve_without_base(arg);
-    gas_charge_inner(cgas, ggas, cost).map(|_| cost)
+    profiler.profile(cgas.as_ref(), cost);
+    gas_charge_inner(cgas.as_mut(), ggas, cost)
 }
 
 pub(crate) fn dependent_gas_charge(
@@ -104,19 +90,9 @@ pub(crate) fn dependent_gas_charge(
     gas_cost: DependentCost,
     arg: Word,
 ) -> SimpleResult<()> {
-    let cost = dependent_gas_charge_inner(cgas.as_mut(), ggas, gas_cost, arg)?;
-    profiler.profile(cgas.as_ref(), cost);
-    Ok(())
-}
-
-fn dependent_gas_charge_inner(
-    cgas: RegMut<CGAS>,
-    ggas: RegMut<GGAS>,
-    gas_cost: DependentCost,
-    arg: Word,
-) -> Result<Word, PanicOrBug> {
     let cost = gas_cost.resolve(arg);
-    gas_charge_inner(cgas, ggas, cost).map(|_| cost)
+    profiler.profile(cgas.as_ref(), cost);
+    gas_charge_inner(cgas.as_mut(), ggas, cost)
 }
 
 pub(crate) fn gas_charge(

--- a/fuel-vm/src/interpreter/gas/tests.rs
+++ b/fuel-vm/src/interpreter/gas/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::error::PanicOrBug;
 use test_case::test_case;
 
 struct GasChargeInput {
@@ -103,11 +104,26 @@ fn test_dependent_gas_charge(input: DepGasChargeInput) -> SimpleResult<GasCharge
     } = input;
     let mut cgas = RegMut::new(&mut cgas);
     let mut ggas = RegMut::new(&mut ggas);
-    dependent_gas_charge_inner(cgas.as_mut(), ggas.as_mut(), gas_cost, dependent_factor)
-        .map(|_| GasChargeOutput {
-            cgas: *cgas,
-            ggas: *ggas,
-        })
+    let pc = 0;
+    let is = 0;
+    let profiler = ProfileGas {
+        pc: Reg::new(&pc),
+        is: Reg::new(&is),
+        current_contract: None,
+        profiler: &mut Profiler::default(),
+    };
+
+    dependent_gas_charge(
+        cgas.as_mut(),
+        ggas.as_mut(),
+        profiler,
+        gas_cost,
+        dependent_factor,
+    )
+    .map(|_| GasChargeOutput {
+        cgas: *cgas,
+        ggas: *ggas,
+    })
 }
 
 #[test_case(
@@ -161,11 +177,20 @@ fn test_dependent_gas_charge_wihtout_base(
         mut ggas,
         dependent_factor,
     } = input;
+    let pc = 0;
+    let is = 0;
+    let profiler = ProfileGas {
+        pc: Reg::new(&pc),
+        is: Reg::new(&is),
+        current_contract: None,
+        profiler: &mut Profiler::default(),
+    };
     let mut cgas = RegMut::new(&mut cgas);
     let mut ggas = RegMut::new(&mut ggas);
-    dependent_gas_charge_without_base_inner(
+    dependent_gas_charge_without_base(
         cgas.as_mut(),
         ggas.as_mut(),
+        profiler,
         gas_cost,
         dependent_factor,
     )


### PR DESCRIPTION
Changed the behavior of the gas charge functions.

Form:
1. Charge
2. Profile

To :
1. Profile
2. Charge

Because the `profile` function expects that it is called before `$cgas` is updated.

<img width="695" alt="image" src="https://github.com/FuelLabs/fuel-vm/assets/18346821/eddcbaa4-0888-4cc8-8a76-b99c767615fa">

Since we don't this code, it is not breaking behavior=)

### Before requesting review
- [x] I have reviewed the code myself
