### PR TITLE
grow_stack and empty $hp range write fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 #### Breaking
 - [#783](https://github.com/FuelLabs/fuel-vm/pull/783): Remove unnecessary look up for old values by adding new methods to the `StorageMutate` trait.  The old `insert` and `remove` are now `replace` and `take`. The new `insert` and `remove` don't return a value.
 - [#783](https://github.com/FuelLabs/fuel-vm/pull/783): Renamed methods of `StorageWrite` trait from `write`, `replace`, `take` to `write_bytes`, `replace_bytes`, `take_bytes`.
+- [#788](https://github.com/FuelLabs/fuel-vm/pull/788): Fix truncating `sp` to `MEM_SIZE` in `grow_stack`, and allow empty writes to zero-length ranges at `$hp`.
 
 ### Fixed
 

--- a/fuel-vm/src/interpreter/memory.rs
+++ b/fuel-vm/src/interpreter/memory.rs
@@ -977,11 +977,10 @@ impl OwnershipRegisters {
 
     /// Empty range is owned iff the range.start is owned
     pub(crate) fn has_ownership_heap(&self, range: &Range<Word>) -> bool {
-        // TODO implement fp->hp and (addr, size) validations
-        // fp->hp
-        // it means $hp from the previous context, i.e. what's saved in the
-        // "Saved registers from previous context" of the call frame at
-        // $fp`
+        if range.is_empty() && range.start == self.hp {
+            return true
+        }
+
         if range.start < self.hp {
             return false
         }

--- a/fuel-vm/src/interpreter/memory.rs
+++ b/fuel-vm/src/interpreter/memory.rs
@@ -146,7 +146,12 @@ impl MemoryInstance {
     /// Grows the stack to be at least `new_sp` bytes.
     pub fn grow_stack(&mut self, new_sp: Word) -> Result<(), PanicReason> {
         #[allow(clippy::cast_possible_truncation)] // Safety: MEM_SIZE is usize
-        let new_sp = new_sp.min(MEM_SIZE as Word) as usize;
+        if new_sp > VM_MAX_RAM {
+            return Err(PanicReason::MemoryOverflow);
+        }
+        #[allow(clippy::cast_possible_truncation)] // Safety: VM_MAX_RAM is usize
+        let new_sp = new_sp as usize;
+
         if new_sp > self.stack.len() {
             if new_sp > self.hp {
                 return Err(PanicReason::MemoryGrowthOverlap)

--- a/fuel-vm/src/interpreter/memory/tests.rs
+++ b/fuel-vm/src/interpreter/memory/tests.rs
@@ -164,6 +164,14 @@ fn stack_alloc_ownership() {
     OwnershipRegisters::test(0..20, 40..50),
     20..41 => false; "start exclusive and end inclusive"
 )]
+#[test_case(
+    OwnershipRegisters::test(0..0, VM_MAX_RAM..VM_MAX_RAM),
+    MEM_SIZE..MEM_SIZE => true; "empty range at $hp (VM_MAX_RAM) should be allowed"
+)]
+#[test_case(
+    OwnershipRegisters::test(0..0, 100..VM_MAX_RAM),
+    100..100 => true; "empty range at $hp (not VM_MAX_RAM) should be allowed"
+)]
 fn test_ownership(reg: OwnershipRegisters, range: Range<usize>) -> bool {
     reg.verify_ownership(&MemoryRange::new(range.start, range.len()))
         .is_ok()


### PR DESCRIPTION
Fixes two minor bugs in the memory implementation:
- `grow_stack` was silently truncating the `sp` to `MEM_SIZE` even if it was above that
- Empty ranges at `$hp` would fail ownership check, even if they really should pass

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
 * The `grow_stack` case is not tested, as it's not really reachable externally.
- [ ] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
