### PR TITLE
Release v0.55.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
         run: cargo install wasm-bindgen-cli wasm-opt
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 8.6.9
 
@@ -296,7 +296,7 @@ jobs:
         run: cargo install wasm-bindgen-cli wasm-opt
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 8.6.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.55.0]
+
 ### Added
 - [#781](https://github.com/FuelLabs/fuel-vm/pull/781): Added `base_asset_id` to checked metadata.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,17 +17,17 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.54.1"
+version = "0.55.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.54.1", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.54.1", path = "fuel-crypto", default-features = false }
-fuel-derive = { version = "0.54.1", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.54.1", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.54.1", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.54.1", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.54.1", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.54.1", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.55.0", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.55.0", path = "fuel-crypto", default-features = false }
+fuel-derive = { version = "0.55.0", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.55.0", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.55.0", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.55.0", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.55.0", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.55.0", path = "fuel-vm", default-features = false }
 bitflags = "2"
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
## Version v0.55.0

### Added
- [#781](https://github.com/FuelLabs/fuel-vm/pull/781): Added `base_asset_id` to checked metadata.

### Changed
- [#784](https://github.com/FuelLabs/fuel-vm/pull/784): Avoid storage lookups for side nodes in the SMT.
- [#787](https://github.com/FuelLabs/fuel-vm/pull/787): Fixed charge functions to profile cost before charging.

#### Breaking
- [#783](https://github.com/FuelLabs/fuel-vm/pull/783): Remove unnecessary look up for old values by adding new methods to the `StorageMutate` trait.  The old `insert` and `remove` are now `replace` and `take`. The new `insert` and `remove` don't return a value.
- [#783](https://github.com/FuelLabs/fuel-vm/pull/783): Renamed methods of `StorageWrite` trait from `write`, `replace`, `take` to `write_bytes`, `replace_bytes`, `take_bytes`.
- [#788](https://github.com/FuelLabs/fuel-vm/pull/788): Fix truncating `sp` to `MEM_SIZE` in `grow_stack`, and allow empty writes to zero-length ranges at `$hp`.

### Fixed

#### Breaking
- [#789](https://github.com/FuelLabs/fuel-vm/pull/789): Avoid conversion into `usize` type and use `u32` or `u64` instead. The change is breaking since could return other errors for 32-bit systems.
- [#786](https://github.com/FuelLabs/fuel-vm/pull/786): Fixed the CCP opcode to charge for the length from the input arguments.
- [#785](https://github.com/FuelLabs/fuel-vm/pull/785): Require `ContractCreated` output in the `Create` transaction. The `TransactionBuilder<Create>` has a `add_contract_created` method to simplify the creation of the `ContractCreated` output for tests.

## What's Changed
* Test ALU opcodes using only the external interface by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/754
* Store the base asset id in the metadata by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/781
* Use companies fork of the `publish-crates` action by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/782
* Refactor coin-based contract instruction tests by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/779
* Require `ContractCreated` output in the `Create` transaction by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/785
* Fixed the CCP opcode to charge for the length of the input by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/786
* Remove unnecessary look up for old values by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/783
* Fixed charge functions to profile cost before charging by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/787
* grow_stack and empty $hp range write fixes by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/788
* Optimized storage lookups for side nodes in the SMT by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/784
* Avoid conversion into `usize` type and use `u32` or `u64` instead by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/789


**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.54.1...v0.55.0
