### PR TITLE
Implement `MerkleRootStorage` for reference types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - [#781](https://github.com/FuelLabs/fuel-vm/pull/781): Added `base_asset_id` to checked metadata.
+- [#796](https://github.com/FuelLabs/fuel-vm/pull/796): Added implementation of the `MerkleRootStorage` for references.
 
 ### Changed
 - [#784](https://github.com/FuelLabs/fuel-vm/pull/784): Avoid storage lookups for side nodes in the SMT.

--- a/fuel-storage/src/impls.rs
+++ b/fuel-storage/src/impls.rs
@@ -154,6 +154,14 @@ impl<'a, T: StorageWrite<Type> + ?Sized, Type: Mappable> StorageWrite<Type>
 }
 
 impl<'a, T: MerkleRootStorage<Key, Type> + ?Sized, Key, Type: Mappable>
+    MerkleRootStorage<Key, Type> for &'a T
+{
+    fn root(&self, key: &Key) -> Result<MerkleRoot, Self::Error> {
+        <T as MerkleRootStorage<Key, Type>>::root(self, key)
+    }
+}
+
+impl<'a, T: MerkleRootStorage<Key, Type> + ?Sized, Key, Type: Mappable>
     MerkleRootStorage<Key, Type> for &'a mut T
 {
     fn root(&self, key: &Key) -> Result<MerkleRoot, Self::Error> {


### PR DESCRIPTION
We forgot to add implementation for references.

### Before requesting review
- [x] I have reviewed the code myself
