### PR TITLE
Prepare for 0.56.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Version 0.56.0]
 
-### Changed
+### Added
+- [#796](https://github.com/FuelLabs/fuel-vm/pull/796): Added implementation of the `MerkleRootStorage` for references.
 
 #### Breaking
 - [#780](https://github.com/FuelLabs/fuel-vm/pull/780): Added `Blob` transaction, and `BSIZ` and `BLDD` instructions. Also allows `LDC` to load blobs.
@@ -19,7 +20,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - [#781](https://github.com/FuelLabs/fuel-vm/pull/781): Added `base_asset_id` to checked metadata.
-- [#796](https://github.com/FuelLabs/fuel-vm/pull/796): Added implementation of the `MerkleRootStorage` for references.
 
 ### Changed
 - [#784](https://github.com/FuelLabs/fuel-vm/pull/784): Avoid storage lookups for side nodes in the SMT.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.56.0]
+
 ### Changed
 
 #### Breaking

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,17 +17,17 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.55.0"
+version = "0.56.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.55.0", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.55.0", path = "fuel-crypto", default-features = false }
-fuel-derive = { version = "0.55.0", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.55.0", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.55.0", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.55.0", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.55.0", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.55.0", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.56.0", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.56.0", path = "fuel-crypto", default-features = false }
+fuel-derive = { version = "0.56.0", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.56.0", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.56.0", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.56.0", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.56.0", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.56.0", path = "fuel-vm", default-features = false }
 bitflags = "2"
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
Version 0.56.0 includes the following changes:

- [#796](https://github.com/FuelLabs/fuel-vm/pull/796): Added implementation of the `MerkleRootStorage` for references.
- [#780](https://github.com/FuelLabs/fuel-vm/pull/780): Added `Blob` transaction, and `BSIZ` and `BLDD` instructions. Also allows `LDC` to load blobs.
- [#795](https://github.com/FuelLabs/fuel-vm/pull/795): Fixed `ed19` instruction to take variable length message instead of a fixed-length one. Changed the gas cost to be `DependentCost`.
