### PR TITLE
Rust 1.79.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.75.0
+  RUST_VERSION: 1.79.0
   RUST_VERSION_FMT: nightly-2024-02-07
   RUST_VERSION_COV: nightly-2024-06-05
   GIT_BRANCH: ${{ github.head_ref || github.ref_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - [#796](https://github.com/FuelLabs/fuel-vm/pull/796): Added implementation of the `MerkleRootStorage` for references.
 
+### Changed
+- [#806](https://github.com/FuelLabs/fuel-vm/pull/806): Update MSRV to 1.79.0.
+
 #### Breaking
 - [#780](https://github.com/FuelLabs/fuel-vm/pull/780): Added `Blob` transaction, and `BSIZ` and `BLDD` instructions. Also allows `LDC` to load blobs.
 - [#795](https://github.com/FuelLabs/fuel-vm/pull/795): Fixed `ed19` instruction to take variable length message instead of a fixed-length one. Changed the gas cost to be `DependentCost`.

--- a/ci_checks.sh
+++ b/ci_checks.sh
@@ -3,7 +3,7 @@
 # The script runs almost all CI checks locally.
 #
 # Requires installed:
-# - Rust `1.75.0`
+# - Rust `1.79.0`
 # - Nightly rust formatter
 # - `rustup target add thumbv6m-none-eabi`
 # - `rustup target add wasm32-unknown-unknown`

--- a/fuel-asm/src/macros.rs
+++ b/fuel-asm/src/macros.rs
@@ -1092,6 +1092,7 @@ macro_rules! impl_instructions {
     // Recursively generate a test constructor for each opcode
     (impl_opcode_test_construct $doc:literal $ix:literal $Op:ident $op:ident [$($fname:ident: $field:ident)*] $($rest:tt)*) => {
         #[cfg(test)]
+        #[allow(clippy::cast_possible_truncation)]
         impl crate::_op::$Op {
             op_test_construct_fn!($($field)*);
         }

--- a/fuel-tx/src/tests/offset.rs
+++ b/fuel-tx/src/tests/offset.rs
@@ -76,9 +76,9 @@ where
     outputs_assert(tx, bytes, cases);
 }
 
-fn inputs_assert<Tx: Inputs>(tx: &Tx, bytes: &[u8], cases: &mut TestedFields)
+fn inputs_assert<Tx>(tx: &Tx, bytes: &[u8], cases: &mut TestedFields)
 where
-    Tx: Buildable,
+    Tx: Inputs + Buildable,
 {
     tx.inputs().iter().enumerate().for_each(|(idx, i)| {
         let input_ofs = tx

--- a/fuel-tx/src/transaction/id.rs
+++ b/fuel-tx/src/transaction/id.rs
@@ -613,7 +613,7 @@ mod tests {
     fn id() {
         let rng = &mut StdRng::seed_from_u64(8586);
 
-        let inputs = vec![
+        let inputs = [
             vec![],
             vec![
                 Input::coin_signed(
@@ -672,7 +672,7 @@ mod tests {
             ],
         ];
 
-        let outputs = vec![
+        let outputs = [
             vec![],
             vec![
                 Output::coin(rng.gen(), rng.next_u64(), rng.gen()),
@@ -683,14 +683,14 @@ mod tests {
             ],
         ];
 
-        let witnesses = vec![
+        let witnesses = [
             vec![],
             vec![generate_bytes(rng).into(), generate_bytes(rng).into()],
         ];
 
-        let scripts = vec![vec![], generate_bytes(rng), generate_bytes(rng)];
-        let script_data = vec![vec![], generate_bytes(rng), generate_bytes(rng)];
-        let storage_slots = vec![vec![], vec![rng.gen(), rng.gen()]];
+        let scripts = [vec![], generate_bytes(rng), generate_bytes(rng)];
+        let script_data = [vec![], generate_bytes(rng), generate_bytes(rng)];
+        let storage_slots = [vec![], vec![rng.gen(), rng.gen()]];
         let purposes = [
             UpgradePurposeType::ConsensusParameters {
                 witness_index: rng.gen(),


### PR DESCRIPTION
Updates MSRV to 1.79.0. This is matches fuel-core and is needed by latest wasm tooling. CI currently fails without this update.