### PR TITLE
Simplify transaction input types

### DIFF
--- a/fuel-derive/src/deserialize.rs
+++ b/fuel-derive/src/deserialize.rs
@@ -5,8 +5,8 @@ use quote::{
 };
 
 use crate::attribute::{
-    should_skip_field,
     should_skip_field_binding,
+    FieldAttrs,
     StructAttrs,
 };
 
@@ -16,7 +16,8 @@ fn deserialize_struct(s: &mut synstructure::Structure) -> TokenStream2 {
     let variant: &synstructure::VariantInfo = &s.variants()[0];
     let decode_main = variant.construct(|field, _| {
         let ty = &field.ty;
-        if should_skip_field(&field.attrs) {
+        let attrs = FieldAttrs::parse(&field.attrs);
+        if attrs.skip {
             quote! {
                 ::core::default::Default::default()
             }
@@ -100,7 +101,8 @@ fn deserialize_enum(s: &synstructure::Structure) -> TokenStream2 {
         .enumerate()
         .map(|(index, variant)| {
             let decode_main = variant.construct(|field, _| {
-                if should_skip_field(&field.attrs) {
+                let attrs = FieldAttrs::parse(&field.attrs);
+                if attrs.skip {
                     quote! {
                         ::core::default::Default::default()
                     }

--- a/fuel-tx/src/transaction/fee.rs
+++ b/fuel-tx/src/transaction/fee.rs
@@ -248,28 +248,20 @@ pub trait Chargeable: field::Inputs + field::Witnesses + field::Policies {
                 | Input::MessageCoinSigned(_)
                 | Input::MessageDataSigned(_) => gas_costs.ecr1(),
                 // Charge the cost of the contract root for predicate inputs
-                Input::CoinPredicate(CoinPredicate {
-                    predicate,
-                    predicate_gas_used,
-                    ..
-                })
+                Input::CoinPredicate(CoinPredicate { predicate, .. })
                 | Input::MessageCoinPredicate(MessageCoinPredicate {
-                    predicate,
-                    predicate_gas_used,
-                    ..
+                    predicate, ..
                 })
                 | Input::MessageDataPredicate(MessageDataPredicate {
-                    predicate,
-                    predicate_gas_used,
-                    ..
+                    predicate, ..
                 }) => {
                     let bytes_size = self.metered_bytes_size();
                     let vm_initialization_gas =
                         gas_costs.vm_initialization().resolve(bytes_size as Word);
                     gas_costs
                         .contract_root()
-                        .resolve(predicate.len() as u64)
-                        .saturating_add(*predicate_gas_used)
+                        .resolve(predicate.code.len() as u64)
+                        .saturating_add(predicate.gas_used)
                         .saturating_add(vm_initialization_gas)
                 }
                 // Charge nothing for all other inputs

--- a/fuel-tx/src/transaction/types/input/coin.rs
+++ b/fuel-tx/src/transaction/types/input/coin.rs
@@ -1,15 +1,9 @@
 use core::default::Default;
 
 use crate::{
-    input::{
-        fmt_as_field,
-        Empty,
-    },
-    transaction::types::input::AsField,
     TxPointer,
     UtxoId,
 };
-use alloc::vec::Vec;
 use derivative::Derivative;
 use fuel_types::{
     Address,
@@ -17,216 +11,66 @@ use fuel_types::{
     Word,
 };
 
-pub type CoinFull = Coin<Full>;
-pub type CoinSigned = Coin<Signed>;
-pub type CoinPredicate = Coin<Predicate>;
+use super::predicate::Predicate;
 
-mod private {
-    pub trait Seal {}
-
-    impl Seal for super::Full {}
-    impl Seal for super::Signed {}
-    impl Seal for super::Predicate {}
-}
-
-/// Specifies the coin based on the usage context. See [`Coin`].
-pub trait CoinSpecification: private::Seal {
-    type Witness: AsField<u16>;
-    type Predicate: AsField<Vec<u8>>;
-    type PredicateData: AsField<Vec<u8>>;
-    type PredicateGasUsed: AsField<Word>;
-}
-
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Signed;
-
-impl CoinSpecification for Signed {
-    type Predicate = Empty<Vec<u8>>;
-    type PredicateData = Empty<Vec<u8>>;
-    type PredicateGasUsed = Empty<Word>;
-    type Witness = u16;
-}
-
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Predicate;
-
-impl CoinSpecification for Predicate {
-    type Predicate = Vec<u8>;
-    type PredicateData = Vec<u8>;
-    type PredicateGasUsed = Word;
-    type Witness = Empty<u16>;
-}
-
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Full;
-
-impl CoinSpecification for Full {
-    type Predicate = Vec<u8>;
-    type PredicateData = Vec<u8>;
-    type PredicateGasUsed = Word;
-    type Witness = u16;
-}
-
-/// It is a full representation of the coin from the specification:
-/// <https://github.com/FuelLabs/fuel-specs/blob/master/src/tx-format/input.md#inputcoin>.
-///
-/// The specification defines the layout of the [`Coin`] in the serialized form for the
-/// `fuel-vm`. But on the business logic level, we don't use all fields at the same time.
-/// It is why in the [`super::Input`] the coin is represented by several forms based on
-/// the usage context. Leaving some fields empty reduces the memory consumption by the
-/// structure and erases the empty useless fields.
-///
-/// The [`CoinSpecification`] trait specifies the sub-coin for the corresponding usage
-/// context. It allows us to write the common logic of all sub-coins without the overhead
-/// and duplication.
-///
-/// Sub-coin:
-/// - [`Signed`] - means that the coin should be signed by the `owner`, and the
-///   signature(witness) should be stored under the `witness_index` index in the
-///   `witnesses` vector of the [`crate::Transaction`].
-/// - [`Predicate`] - means that the coin is not signed, and the `owner` is a `predicate`
-///   bytecode. The merkle root from the `predicate` should be equal to the `owner`.
-/// - [`Full`] - is used during the deserialization of the coin. It should be transformed
-///   into [`Signed`] or [`Predicate`] sub-coin. If the `predicate` is empty, it is
-///   [`Signed`], else [`Predicate`].
 #[derive(Default, Derivative, Clone, PartialEq, Eq, Hash)]
 #[derivative(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
-pub struct Coin<Specification>
-where
-    Specification: CoinSpecification,
-{
+pub struct CoinCommon {
     pub utxo_id: UtxoId,
     pub owner: Address,
     pub amount: Word,
     pub asset_id: AssetId,
     pub tx_pointer: TxPointer,
-    #[derivative(Debug(format_with = "fmt_as_field"))]
-    pub witness_index: Specification::Witness,
-    #[derivative(Debug(format_with = "fmt_as_field"))]
-    pub predicate_gas_used: Specification::PredicateGasUsed,
-    #[derivative(Debug(format_with = "fmt_as_field"))]
-    pub predicate: Specification::Predicate,
-    #[derivative(Debug(format_with = "fmt_as_field"))]
-    pub predicate_data: Specification::PredicateData,
 }
 
-impl<Specification> Coin<Specification>
-where
-    Specification: CoinSpecification,
-{
+#[derive(Default, Derivative, Clone, PartialEq, Eq, Hash)]
+#[derivative(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
+pub struct CoinSigned {
+    #[serde(flatten)]
+    pub common: CoinCommon,
+    pub witness_index: u16,
+}
+
+#[derive(Default, Derivative, Clone, PartialEq, Eq, Hash)]
+#[derivative(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
+pub struct CoinPredicate {
+    #[serde(flatten)]
+    pub common: CoinCommon,
+    #[serde(flatten)]
+    pub predicate: Predicate,
+}
+
+impl CoinSigned {
     /// The "Note" section from the specification:
     /// <https://github.com/FuelLabs/fuel-specs/blob/master/src/tx-format/input.md#inputcoin>.
     pub fn prepare_sign(&mut self) {
-        self.tx_pointer = Default::default();
-        if let Some(predicate_gas_used_field) = self.predicate_gas_used.as_mut_field() {
-            *predicate_gas_used_field = Default::default();
-        }
+        self.common.tx_pointer = Default::default();
     }
 }
 
-impl Coin<Full> {
-    pub fn into_signed(self) -> Coin<Signed> {
-        let Self {
-            utxo_id,
-            owner,
-            amount,
-            asset_id,
-            tx_pointer,
-            witness_index,
-            ..
-        } = self;
-
-        Coin {
-            utxo_id,
-            owner,
-            amount,
-            asset_id,
-            tx_pointer,
-            witness_index,
-            ..Default::default()
-        }
-    }
-
-    pub fn into_predicate(self) -> Coin<Predicate> {
-        let Self {
-            utxo_id,
-            owner,
-            amount,
-            asset_id,
-            tx_pointer,
-            predicate,
-            predicate_data,
-            predicate_gas_used,
-            ..
-        } = self;
-
-        Coin {
-            utxo_id,
-            owner,
-            amount,
-            asset_id,
-            tx_pointer,
-            predicate,
-            predicate_data,
-            predicate_gas_used,
-            ..Default::default()
-        }
+impl CoinPredicate {
+    /// The "Note" section from the specification:
+    /// <https://github.com/FuelLabs/fuel-specs/blob/master/src/tx-format/input.md#inputcoin>.
+    pub fn prepare_sign(&mut self) {
+        self.common.tx_pointer = Default::default();
+        self.predicate.prepare_sign();
     }
 }
 
-impl Coin<Signed> {
-    pub fn into_full(self) -> Coin<Full> {
-        let Self {
-            utxo_id,
-            owner,
-            amount,
-            asset_id,
-            tx_pointer,
-            witness_index,
-            ..
-        } = self;
-
-        Coin {
-            utxo_id,
-            owner,
-            amount,
-            asset_id,
-            tx_pointer,
-            witness_index,
-            ..Default::default()
-        }
-    }
-}
-
-impl Coin<Predicate> {
-    pub fn into_full(self) -> Coin<Full> {
-        let Self {
-            utxo_id,
-            owner,
-            amount,
-            asset_id,
-            tx_pointer,
-            predicate,
-            predicate_data,
-            predicate_gas_used,
-            ..
-        } = self;
-
-        Coin {
-            utxo_id,
-            owner,
-            amount,
-            asset_id,
-            tx_pointer,
-            predicate,
-            predicate_data,
-            predicate_gas_used,
-            ..Default::default()
-        }
-    }
+#[derive(Default, Derivative, Clone, PartialEq, Eq, Hash)]
+#[derivative(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
+pub struct CoinFull {
+    #[serde(flatten)]
+    pub common: CoinCommon,
+    pub witness_index: u16,
+    #[serde(flatten)]
+    pub predicate: Predicate,
 }

--- a/fuel-tx/src/transaction/types/input/message.rs
+++ b/fuel-tx/src/transaction/types/input/message.rs
@@ -1,7 +1,3 @@
-use crate::{
-    input::fmt_as_field,
-    transaction::types::input::AsField,
-};
 use alloc::vec::Vec;
 use derivative::Derivative;
 use fuel_types::{
@@ -11,117 +7,7 @@ use fuel_types::{
     Word,
 };
 
-pub type FullMessage = Message<specifications::Full>;
-pub type MessageDataSigned = Message<specifications::MessageData<specifications::Signed>>;
-pub type MessageDataPredicate =
-    Message<specifications::MessageData<specifications::Predicate>>;
-pub type MessageCoinSigned = Message<specifications::MessageCoin<specifications::Signed>>;
-pub type MessageCoinPredicate =
-    Message<specifications::MessageCoin<specifications::Predicate>>;
-
-mod private {
-    pub trait Seal {}
-
-    impl Seal for super::specifications::Full {}
-    impl Seal for super::specifications::MessageData<super::specifications::Signed> {}
-    impl Seal for super::specifications::MessageData<super::specifications::Predicate> {}
-    impl Seal for super::specifications::MessageCoin<super::specifications::Signed> {}
-    impl Seal for super::specifications::MessageCoin<super::specifications::Predicate> {}
-}
-
-/// Specifies the message based on the usage context. See [`Message`].
-pub trait MessageSpecification: private::Seal {
-    type Data: AsField<Vec<u8>>;
-    type Predicate: AsField<Vec<u8>>;
-    type PredicateData: AsField<Vec<u8>>;
-    type PredicateGasUsed: AsField<Word>;
-    type Witness: AsField<u16>;
-}
-
-pub mod specifications {
-    use alloc::vec::Vec;
-
-    use super::MessageSpecification;
-    use crate::input::Empty;
-    use fuel_types::Word;
-
-    /// The type means that the message should be signed by the `recipient`, and the
-    /// signature(witness) should be stored under the `witness_index` index in the
-    /// `witnesses` vector of the [`crate::Transaction`].
-    #[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    pub struct Signed;
-
-    /// The type means that the message is not signed, and the `owner` is a `predicate`
-    /// bytecode. The merkle root from the `predicate` should be equal to the `owner`.
-    #[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    pub struct Predicate;
-
-    /// The retrayable message metadata. It is a message that can't be used as a coin to
-    /// pay for fees but can be used to pass metadata to the contract. It may have a
-    /// non-zero `value` that will be transferred to the contract as a native asset
-    /// during the execution. If the execution of the transaction fails, the metadata
-    /// is not consumed and can be used later until successful execution.
-    #[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    pub struct MessageData<UsageRules>(core::marker::PhantomData<UsageRules>);
-
-    impl MessageSpecification for MessageData<Signed> {
-        type Data = Vec<u8>;
-        type Predicate = Empty<Vec<u8>>;
-        type PredicateData = Empty<Vec<u8>>;
-        type PredicateGasUsed = Empty<Word>;
-        type Witness = u16;
-    }
-
-    impl MessageSpecification for MessageData<Predicate> {
-        type Data = Vec<u8>;
-        type Predicate = Vec<u8>;
-        type PredicateData = Vec<u8>;
-        type PredicateGasUsed = Word;
-        type Witness = Empty<u16>;
-    }
-
-    /// The spendable message acts as a standard coin.
-    #[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    pub struct MessageCoin<UsageRules>(core::marker::PhantomData<UsageRules>);
-
-    impl MessageSpecification for MessageCoin<Signed> {
-        type Data = Empty<Vec<u8>>;
-        type Predicate = Empty<Vec<u8>>;
-        type PredicateData = Empty<Vec<u8>>;
-        type PredicateGasUsed = Empty<Word>;
-        type Witness = u16;
-    }
-
-    impl MessageSpecification for MessageCoin<Predicate> {
-        type Data = Empty<Vec<u8>>;
-        type Predicate = Vec<u8>;
-        type PredicateData = Vec<u8>;
-        type PredicateGasUsed = Word;
-        type Witness = Empty<u16>;
-    }
-
-    /// The type is used to represent the full message. It is used during the
-    /// deserialization of the message to determine the final type.
-    /// If the `data` field is empty, it should be transformed into [`MessageData`].
-    /// Otherwise into [`MessageCoin`].
-    /// If the `predicate` is empty, the usage rules should be [`Signed`], else
-    /// [`Predicate`].
-    #[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    pub struct Full;
-
-    impl MessageSpecification for Full {
-        type Data = Vec<u8>;
-        type Predicate = Vec<u8>;
-        type PredicateData = Vec<u8>;
-        type PredicateGasUsed = Word;
-        type Witness = u16;
-    }
-}
+use super::predicate::Predicate;
 
 /// It is a full representation of the message from the specification:
 /// <https://github.com/FuelLabs/fuel-specs/blob/master/src/tx-format/input.md#inputmessage>.
@@ -144,247 +30,115 @@ pub mod specifications {
 #[derivative(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
-pub struct Message<Specification>
-where
-    Specification: MessageSpecification,
-{
+pub struct MessageCommon {
     /// The sender from the L1 chain.
     pub sender: Address,
     /// The receiver on the `Fuel` chain.
     pub recipient: Address,
     pub amount: Word,
     pub nonce: Nonce,
-    #[derivative(Debug(format_with = "fmt_as_field"))]
-    pub witness_index: Specification::Witness,
-    #[derivative(Debug(format_with = "fmt_as_field"))]
-    pub predicate_gas_used: Specification::PredicateGasUsed,
-    #[derivative(Debug(format_with = "fmt_as_field"))]
-    pub data: Specification::Data,
-    #[derivative(Debug(format_with = "fmt_as_field"))]
-    pub predicate: Specification::Predicate,
-    #[derivative(Debug(format_with = "fmt_as_field"))]
-    pub predicate_data: Specification::PredicateData,
 }
 
-impl<Specification> Message<Specification>
-where
-    Specification: MessageSpecification,
-{
-    pub fn prepare_sign(&mut self) {
-        if let Some(predicate_gas_used_field) = self.predicate_gas_used.as_mut_field() {
-            *predicate_gas_used_field = Default::default();
-        }
-    }
-
-    pub fn message_id(&self) -> MessageId {
-        let Self {
-            sender,
-            recipient,
-            amount,
-            nonce,
-            data,
-            ..
-        } = self;
-        if let Some(data) = data.as_field() {
-            compute_message_id(sender, recipient, nonce, *amount, data)
-        } else {
-            compute_message_id(sender, recipient, nonce, *amount, &[])
-        }
-    }
+#[derive(Default, Derivative, Clone, PartialEq, Eq, Hash)]
+#[derivative(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
+pub struct MessageDataSigned {
+    pub common: MessageCommon,
+    pub witness_index: u16,
+    pub data: Vec<u8>,
 }
 
-impl FullMessage {
-    pub fn into_message_data_signed(self) -> MessageDataSigned {
-        let Self {
-            sender,
-            recipient,
-            amount,
-            nonce,
-            witness_index,
-            data,
-            ..
-        } = self;
-
-        Message {
-            sender,
-            recipient,
-            amount,
-            nonce,
-            witness_index,
-            data,
-            ..Default::default()
-        }
-    }
-
-    pub fn into_message_data_predicate(self) -> MessageDataPredicate {
-        let Self {
-            sender,
-            recipient,
-            amount,
-            nonce,
-            data,
-            predicate,
-            predicate_data,
-            predicate_gas_used,
-            ..
-        } = self;
-
-        Message {
-            sender,
-            recipient,
-            amount,
-            nonce,
-            data,
-            predicate,
-            predicate_data,
-            predicate_gas_used,
-            ..Default::default()
-        }
-    }
-
-    pub fn into_coin_signed(self) -> MessageCoinSigned {
-        let Self {
-            sender,
-            recipient,
-            amount,
-            nonce,
-            witness_index,
-            ..
-        } = self;
-
-        Message {
-            sender,
-            recipient,
-            amount,
-            nonce,
-            witness_index,
-            ..Default::default()
-        }
-    }
-
-    pub fn into_coin_predicate(self) -> MessageCoinPredicate {
-        let Self {
-            sender,
-            recipient,
-            amount,
-            nonce,
-            predicate,
-            predicate_data,
-            predicate_gas_used,
-            ..
-        } = self;
-
-        Message {
-            sender,
-            recipient,
-            amount,
-            nonce,
-            predicate,
-            predicate_data,
-            predicate_gas_used,
-            ..Default::default()
-        }
-    }
+#[derive(Default, Derivative, Clone, PartialEq, Eq, Hash)]
+#[derivative(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
+pub struct MessageDataPredicate {
+    pub common: MessageCommon,
+    pub data: Vec<u8>,
+    #[serde(flatten)]
+    pub predicate: Predicate,
 }
 
-impl MessageCoinSigned {
-    pub fn into_full(self) -> FullMessage {
-        let Self {
-            sender,
-            recipient,
-            amount,
-            nonce,
-            witness_index,
-            ..
-        } = self;
-
-        Message {
-            sender,
-            recipient,
-            amount,
-            nonce,
-            witness_index,
-            ..Default::default()
-        }
-    }
+#[derive(Default, Derivative, Clone, PartialEq, Eq, Hash)]
+#[derivative(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
+pub struct MessageCoinSigned {
+    pub common: MessageCommon,
+    pub witness_index: u16,
 }
 
-impl MessageCoinPredicate {
-    pub fn into_full(self) -> FullMessage {
-        let Self {
-            sender,
-            recipient,
-            amount,
-            nonce,
-            predicate,
-            predicate_data,
-            predicate_gas_used,
-            ..
-        } = self;
-
-        Message {
-            sender,
-            recipient,
-            amount,
-            nonce,
-            predicate,
-            predicate_data,
-            predicate_gas_used,
-            ..Default::default()
-        }
-    }
+#[derive(Default, Derivative, Clone, PartialEq, Eq, Hash)]
+#[derivative(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
+pub struct MessageCoinPredicate {
+    #[serde(flatten)]
+    pub common: MessageCommon,
+    #[serde(flatten)]
+    pub predicate: Predicate,
 }
 
-impl MessageDataPredicate {
-    pub fn into_full(self) -> FullMessage {
-        let Self {
-            sender,
-            recipient,
-            amount,
-            nonce,
+impl MessageCommon {
+    pub fn message_id_for_data(&self, data: &[u8]) -> MessageId {
+        compute_message_id(
+            &self.sender,
+            &self.recipient,
+            &self.nonce,
+            self.amount,
             data,
-            predicate,
-            predicate_data,
-            predicate_gas_used,
-            ..
-        } = self;
-
-        Message {
-            sender,
-            recipient,
-            amount,
-            nonce,
-            data,
-            predicate,
-            predicate_data,
-            predicate_gas_used,
-            ..Default::default()
-        }
+        )
     }
 }
 
 impl MessageDataSigned {
-    pub fn into_full(self) -> FullMessage {
-        let Self {
-            sender,
-            recipient,
-            amount,
-            nonce,
-            witness_index,
-            data,
-            ..
-        } = self;
+    pub fn prepare_sign(&mut self) {}
 
-        Message {
-            sender,
-            recipient,
-            amount,
-            nonce,
-            witness_index,
-            data,
-            ..Default::default()
-        }
+    pub fn message_id(&self) -> MessageId {
+        self.common.message_id_for_data(&self.data)
     }
+}
+
+impl MessageDataPredicate {
+    pub fn prepare_sign(&mut self) {
+        self.predicate.prepare_sign();
+    }
+
+    pub fn message_id(&self) -> MessageId {
+        self.common.message_id_for_data(&self.data)
+    }
+}
+
+impl MessageCoinSigned {
+    pub fn prepare_sign(&mut self) {}
+
+    pub fn message_id(&self) -> MessageId {
+        self.common.message_id_for_data(&[])
+    }
+}
+
+impl MessageCoinPredicate {
+    pub fn prepare_sign(&mut self) {
+        self.predicate.prepare_sign();
+    }
+
+    pub fn message_id(&self) -> MessageId {
+        self.common.message_id_for_data(&[])
+    }
+}
+
+#[derive(Default, Derivative, Clone, PartialEq, Eq, Hash)]
+#[derivative(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
+pub struct MessageFull {
+    #[serde(flatten)]
+    pub common: MessageCommon,
+    pub witness_index: u16,
+    pub data: Vec<u8>,
+    #[serde(flatten)]
+    pub predicate: Predicate,
 }
 
 pub fn compute_message_id(

--- a/fuel-tx/src/transaction/types/input/snapshot_tests.rs
+++ b/fuel-tx/src/transaction/types/input/snapshot_tests.rs
@@ -8,15 +8,14 @@ use fuel_types::canonical::Serialize;
 fn tx_with_signed_coin_snapshot() {
     let tx = TransactionBuilder::script(vec![], vec![])
         .add_input(Input::CoinSigned(CoinSigned {
-            utxo_id: UtxoId::new([1u8; 32].into(), 2),
-            owner: [2u8; 32].into(),
-            amount: 11,
-            asset_id: [5u8; 32].into(),
-            tx_pointer: TxPointer::new(46.into(), 5),
+            common: CoinCommon {
+                utxo_id: UtxoId::new([1u8; 32].into(), 2),
+                owner: [2u8; 32].into(),
+                amount: 11,
+                asset_id: [5u8; 32].into(),
+                tx_pointer: TxPointer::new(46.into(), 5),
+            },
             witness_index: 4,
-            predicate_gas_used: Empty::new(),
-            predicate: Empty::new(),
-            predicate_data: Empty::new(),
         }))
         .tip(1)
         .maturity(123.into())
@@ -33,15 +32,18 @@ fn tx_with_signed_coin_snapshot() {
 fn tx_with_predicate_coin_snapshot() {
     let tx = TransactionBuilder::script(vec![], vec![])
         .add_input(Input::CoinPredicate(CoinPredicate {
-            utxo_id: UtxoId::new([1u8; 32].into(), 2),
-            owner: [2u8; 32].into(),
-            amount: 11,
-            asset_id: [5u8; 32].into(),
-            tx_pointer: TxPointer::new(46.into(), 5),
-            witness_index: Empty::new(),
-            predicate_gas_used: 100_000,
-            predicate: vec![3u8; 10],
-            predicate_data: vec![4u8; 12],
+            common: CoinCommon {
+                utxo_id: UtxoId::new([1u8; 32].into(), 2),
+                owner: [2u8; 32].into(),
+                amount: 11,
+                asset_id: [5u8; 32].into(),
+                tx_pointer: TxPointer::new(46.into(), 5),
+            },
+            predicate: Predicate {
+                gas_used: 100_000,
+                code: vec![3u8; 10],
+                data: vec![4u8; 12],
+            },
         }))
         .tip(1)
         .maturity(123.into())
@@ -77,15 +79,13 @@ fn tx_with_contract_snapshot() {
 fn tx_with_signed_message_coin() {
     let tx = TransactionBuilder::script(vec![], vec![])
         .add_input(Input::MessageCoinSigned(MessageCoinSigned {
-            sender: [2u8; 32].into(),
-            recipient: [3u8; 32].into(),
-            amount: 4,
-            nonce: [5u8; 32].into(),
+            common: MessageCommon {
+                sender: [2u8; 32].into(),
+                recipient: [3u8; 32].into(),
+                amount: 4,
+                nonce: [5u8; 32].into(),
+            },
             witness_index: 6,
-            predicate_gas_used: Empty::new(),
-            data: Empty::new(),
-            predicate: Empty::new(),
-            predicate_data: Empty::new(),
         }))
         .tip(1)
         .maturity(123.into())
@@ -102,15 +102,17 @@ fn tx_with_signed_message_coin() {
 fn tx_with_predicate_message_coin() {
     let tx = TransactionBuilder::script(vec![], vec![])
         .add_input(Input::MessageCoinPredicate(MessageCoinPredicate {
-            sender: [2u8; 32].into(),
-            recipient: [3u8; 32].into(),
-            amount: 4,
-            nonce: [5u8; 32].into(),
-            witness_index: Empty::new(),
-            predicate_gas_used: 100_000,
-            data: Empty::new(),
-            predicate: vec![7u8; 11],
-            predicate_data: vec![8u8; 12],
+            common: MessageCommon {
+                sender: [2u8; 32].into(),
+                recipient: [3u8; 32].into(),
+                amount: 4,
+                nonce: [5u8; 32].into(),
+            },
+            predicate: Predicate {
+                gas_used: 100_000,
+                code: vec![7u8; 11],
+                data: vec![8u8; 12],
+            },
         }))
         .tip(1)
         .maturity(123.into())
@@ -126,15 +128,14 @@ fn tx_with_predicate_message_coin() {
 fn tx_with_signed_message_data() {
     let tx = TransactionBuilder::script(vec![], vec![])
         .add_input(Input::MessageDataSigned(MessageDataSigned {
-            sender: [2u8; 32].into(),
-            recipient: [3u8; 32].into(),
-            amount: 4,
-            nonce: [5u8; 32].into(),
+            common: MessageCommon {
+                sender: [2u8; 32].into(),
+                recipient: [3u8; 32].into(),
+                amount: 4,
+                nonce: [5u8; 32].into(),
+            },
             witness_index: 6,
-            predicate_gas_used: Empty::new(),
             data: vec![7u8; 10],
-            predicate: Empty::new(),
-            predicate_data: Empty::new(),
         }))
         .tip(1)
         .maturity(123.into())
@@ -151,15 +152,18 @@ fn tx_with_signed_message_data() {
 fn tx_with_predicate_message_data() {
     let tx = TransactionBuilder::script(vec![], vec![])
         .add_input(Input::MessageDataPredicate(MessageDataPredicate {
-            sender: [2u8; 32].into(),
-            recipient: [3u8; 32].into(),
-            amount: 4,
-            nonce: [5u8; 32].into(),
-            witness_index: Empty::new(),
-            predicate_gas_used: 100_000,
+            common: MessageCommon {
+                sender: [2u8; 32].into(),
+                recipient: [3u8; 32].into(),
+                amount: 4,
+                nonce: [5u8; 32].into(),
+            },
             data: vec![6u8; 10],
-            predicate: vec![7u8; 11],
-            predicate_data: vec![8u8; 12],
+            predicate: Predicate {
+                gas_used: 100_000,
+                code: vec![7u8; 11],
+                data: vec![8u8; 12],
+            },
         }))
         .tip(1)
         .maturity(123.into())

--- a/fuel-vm/src/checked_transaction/balances.rs
+++ b/fuel-vm/src/checked_transaction/balances.rs
@@ -2,12 +2,14 @@ use fuel_tx::{
     field,
     input::{
         coin::{
+            CoinCommon,
             CoinPredicate,
             CoinSigned,
         },
         message::{
             MessageCoinPredicate,
             MessageCoinSigned,
+            MessageCommon,
             MessageDataPredicate,
             MessageDataSigned,
         },
@@ -63,23 +65,43 @@ fn add_up_input_balances<T: field::Inputs>(
         match input {
             // Sum coin inputs
             Input::CoinPredicate(CoinPredicate {
-                asset_id, amount, ..
+                common:
+                    CoinCommon {
+                        asset_id, amount, ..
+                    },
+                ..
             })
             | Input::CoinSigned(CoinSigned {
-                asset_id, amount, ..
+                common:
+                    CoinCommon {
+                        asset_id, amount, ..
+                    },
+                ..
             }) => {
                 let balance = non_retryable_balances.entry(*asset_id).or_default();
                 *balance = (*balance).checked_add(*amount)?;
             }
             // Sum message coin inputs
-            Input::MessageCoinSigned(MessageCoinSigned { amount, .. })
-            | Input::MessageCoinPredicate(MessageCoinPredicate { amount, .. }) => {
+            Input::MessageCoinSigned(MessageCoinSigned {
+                common: MessageCommon { amount, .. },
+                ..
+            })
+            | Input::MessageCoinPredicate(MessageCoinPredicate {
+                common: MessageCommon { amount, .. },
+                ..
+            }) => {
                 let balance = non_retryable_balances.entry(*base_asset_id).or_default();
                 *balance = (*balance).checked_add(*amount)?;
             }
             // Sum data messages
-            Input::MessageDataSigned(MessageDataSigned { amount, .. })
-            | Input::MessageDataPredicate(MessageDataPredicate { amount, .. }) => {
+            Input::MessageDataSigned(MessageDataSigned {
+                common: MessageCommon { amount, .. },
+                ..
+            })
+            | Input::MessageDataPredicate(MessageDataPredicate {
+                common: MessageCommon { amount, .. },
+                ..
+            }) => {
                 retryable_balance = retryable_balance.checked_add(*amount)?;
             }
             Input::Contract(_) => {}

--- a/fuel-vm/src/tests/validation.rs
+++ b/fuel-vm/src/tests/validation.rs
@@ -141,9 +141,9 @@ fn malleable_fields_do_not_affect_validity_of_create() {
         let mut tx = tx.clone();
 
         match tx.inputs_mut()[0] {
-            Input::CoinPredicate(CoinPredicate {
-                ref mut tx_pointer, ..
-            }) => *tx_pointer = TxPointer::from_str("123456780001").unwrap(),
+            Input::CoinPredicate(CoinPredicate { ref mut common, .. }) => {
+                common.tx_pointer = TxPointer::from_str("123456780001").unwrap()
+            }
             _ => unreachable!(),
         };
 
@@ -239,9 +239,9 @@ fn malleable_fields_do_not_affect_validity_of_script() {
         *tx.receipts_root_mut() = [1u8; 32].into();
 
         match tx.inputs_mut()[0] {
-            Input::CoinPredicate(CoinPredicate {
-                ref mut tx_pointer, ..
-            }) => *tx_pointer = TxPointer::from_str("123456780001").unwrap(),
+            Input::CoinPredicate(CoinPredicate { ref mut common, .. }) => {
+                common.tx_pointer = TxPointer::from_str("123456780001").unwrap()
+            }
             _ => unreachable!(),
         };
 


### PR DESCRIPTION
Aspirational PR. Remove complex type-base Coin and Message types and replace them with plain old structs. Currently not backwards-comptabile, needs support for `flatten()` attribute for canonical serialization.

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here
