### PR TITLE
Return recipient as an owner for the message inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 #### Breaking
 - [#670](https://github.com/FuelLabs/fuel-vm/pull/670): The `predicate` field of `fuel_tx::input::Coin` is now a wrapper struct `PredicateCode`.
 
+### Fixed
+- [#822](https://github.com/FuelLabs/fuel-vm/pull/822): Return recipient as an owner for the message inputs.
+
 ## [Version 0.56.0]
 
 ### Added

--- a/fuel-tx/src/tests/valid_cases/transaction/upgrade.rs
+++ b/fuel-tx/src/tests/valid_cases/transaction/upgrade.rs
@@ -37,10 +37,38 @@ fn valid_upgrade_transaction() -> TransactionBuilder<Upgrade> {
     builder
 }
 
+fn valid_upgrade_transaction_with_message() -> TransactionBuilder<Upgrade> {
+    let mut builder = TransactionBuilder::upgrade(UpgradePurpose::StateTransition {
+        root: Default::default(),
+    });
+    builder.max_fee_limit(0);
+    builder.add_input(Input::message_coin_predicate(
+        Default::default(),
+        Input::predicate_owner(predicate()),
+        Default::default(),
+        Default::default(),
+        Default::default(),
+        predicate(),
+        vec![],
+    ));
+    builder.with_params(test_params());
+
+    builder
+}
+
 #[test]
 fn valid_upgrade_transaction_can_pass_check() {
     let block_height: BlockHeight = 1000.into();
     let tx = valid_upgrade_transaction()
+        .finalize()
+        .check(block_height, &test_params());
+    assert_eq!(tx, Ok(()));
+}
+
+#[test]
+fn valid_upgrade_transaction_can_pass_check_with_message() {
+    let block_height: BlockHeight = 1000.into();
+    let tx = valid_upgrade_transaction_with_message()
         .finalize()
         .check(block_height, &test_params());
     assert_eq!(tx, Ok(()));

--- a/fuel-tx/src/transaction/types/input.rs
+++ b/fuel-tx/src/transaction/types/input.rs
@@ -423,11 +423,13 @@ impl Input {
         match self {
             Self::CoinSigned(CoinSigned { owner, .. })
             | Self::CoinPredicate(CoinPredicate { owner, .. }) => Some(owner),
-            Self::MessageCoinSigned(_)
-            | Self::MessageCoinPredicate(_)
-            | Self::MessageDataSigned(_)
-            | Self::MessageDataPredicate(_)
-            | Self::Contract(_) => None,
+            Self::MessageCoinSigned(MessageCoinSigned { recipient, .. })
+            | Self::MessageCoinPredicate(MessageCoinPredicate { recipient, .. })
+            | Self::MessageDataSigned(MessageDataSigned { recipient, .. })
+            | Self::MessageDataPredicate(MessageDataPredicate { recipient, .. }) => {
+                Some(recipient)
+            }
+            Self::Contract(_) => None,
         }
     }
 

--- a/fuel-tx/src/transaction/types/input/repr.rs
+++ b/fuel-tx/src/transaction/types/input/repr.rs
@@ -30,7 +30,7 @@ impl InputRepr {
     pub const fn owner_offset(&self) -> Option<usize> {
         match self {
             Self::Coin => Some(INPUT_COIN_OWNER_OFFSET),
-            Self::Message => None,
+            Self::Message => Some(INPUT_MESSAGE_RECIPIENT_OFFSET),
             Self::Contract => None,
         }
     }


### PR DESCRIPTION
## Checklist
- [x] New behavior is reflected in tests
