### PR TITLE
Deserialize arrays: avoid leaking partially allocated memory when failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - [#670](https://github.com/FuelLabs/fuel-vm/pull/670): Add DA compression functionality to `Transaction` and any types within
 - [#733](https://github.com/FuelLabs/fuel-vm/pull/733): Add LibAFL based fuzzer and update `secp256k1` version to 0.29.1.
+- [#825](https://github.com/FuelLabs/fuel-vm/pull/733): Avoid leaking partially allocated memory when array deserialization fails
 
 ### Changed
 

--- a/fuel-compression/src/key.rs
+++ b/fuel-compression/src/key.rs
@@ -44,7 +44,7 @@ impl TryFrom<u32> for RegistryKey {
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         let v = value.to_be_bytes();
         if v[0] != 0 {
-            return Err("RegistryKey must be less than 2^24")
+            return Err("RegistryKey must be less than 2^24");
         }
 
         let mut bytes = [0u8; 3];

--- a/fuel-compression/src/key.rs
+++ b/fuel-compression/src/key.rs
@@ -44,7 +44,7 @@ impl TryFrom<u32> for RegistryKey {
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         let v = value.to_be_bytes();
         if v[0] != 0 {
-            return Err("RegistryKey must be less than 2^24");
+            return Err("RegistryKey must be less than 2^24")
         }
 
         let mut bytes = [0u8; 3];

--- a/fuel-types/src/canonical.rs
+++ b/fuel-types/src/canonical.rs
@@ -301,7 +301,7 @@ impl<T: Serialize> Serialize for Vec<T> {
     // `encode_dynamic` method.
     fn encode_static<O: Output + ?Sized>(&self, buffer: &mut O) -> Result<(), Error> {
         if self.len() > VEC_DECODE_LIMIT {
-            return Err(Error::AllocationLimit);
+            return Err(Error::AllocationLimit)
         }
         let len: u64 = self.len().try_into().expect("msg.len() > u64::MAX");
         len.encode(buffer)
@@ -334,7 +334,7 @@ impl<T: Deserialize> Deserialize for Vec<T> {
         let cap = u64::decode(buffer)?;
         let cap: usize = cap.try_into().map_err(|_| Error::AllocationLimit)?;
         if cap > VEC_DECODE_LIMIT {
-            return Err(Error::AllocationLimit);
+            return Err(Error::AllocationLimit)
         }
         Ok(Vec::with_capacity(cap))
     }
@@ -446,7 +446,7 @@ impl<const N: usize, T: Deserialize> Deserialize for [T; N] {
                                 item.assume_init_drop();
                             }
                         }
-                        return Err(e);
+                        return Err(e)
                     }
                     Ok(decoded) => {
                         // SAFETY: `uninit[i]` is a MaybeUninit which can be
@@ -484,7 +484,7 @@ impl Output for Vec<u8> {
 impl<'a> Output for &'a mut [u8] {
     fn write(&mut self, from: &[u8]) -> Result<(), Error> {
         if from.len() > self.len() {
-            return Err(Error::BufferIsTooShort);
+            return Err(Error::BufferIsTooShort)
         }
         let len = from.len();
         self[..len].copy_from_slice(from);
@@ -505,7 +505,7 @@ impl<'a> Input for &'a [u8] {
 
     fn peek(&self, into: &mut [u8]) -> Result<(), Error> {
         if into.len() > self.len() {
-            return Err(Error::BufferIsTooShort);
+            return Err(Error::BufferIsTooShort)
         }
 
         let len = into.len();
@@ -515,7 +515,7 @@ impl<'a> Input for &'a [u8] {
 
     fn read(&mut self, into: &mut [u8]) -> Result<(), Error> {
         if into.len() > self.len() {
-            return Err(Error::BufferIsTooShort);
+            return Err(Error::BufferIsTooShort)
         }
 
         let len = into.len();
@@ -526,7 +526,7 @@ impl<'a> Input for &'a [u8] {
 
     fn skip(&mut self, n: usize) -> Result<(), Error> {
         if n > self.len() {
-            return Err(Error::BufferIsTooShort);
+            return Err(Error::BufferIsTooShort)
         }
 
         *self = &self[n..];


### PR DESCRIPTION
Closes #811

[Short description of the changes.]

* Minor changes to the logic for deserializing arrays, using a [MaybeUninit<T>; N] instead of MaybeUninit<[T]; N>. 
* Dropping initialized values when failing and the array has been partially initialized

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
