### PR TITLE
Skip the panic reason from canonical serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 #### Breaking
+- [#826](https://github.com/FuelLabs/fuel-vm/pull/826): Skip the panic reason from canonical serialization of the panic receipt.
 - [#670](https://github.com/FuelLabs/fuel-vm/pull/670): The `predicate` field of `fuel_tx::input::Coin` is now a wrapper struct `PredicateCode`.
 
 ## [Version 0.56.0]

--- a/fuel-asm/src/panic_instruction.rs
+++ b/fuel-asm/src/panic_instruction.rs
@@ -13,6 +13,7 @@ use crate::{
 #[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
 /// Describe a panic reason with the instruction that generated it
 pub struct PanicInstruction {
+    #[canonical(skip)]
     reason: PanicReason,
     instruction: RawInstruction,
 }
@@ -112,5 +113,24 @@ impl From<Word> for PanicInstruction {
             reason,
             instruction,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::op;
+    use fuel_types::canonical::Serialize;
+
+    #[test]
+    fn canonical_serialization_ignores_panic_reason() {
+        let revert_panic_instruction =
+            PanicInstruction::error(PanicReason::Revert, op::noop().into());
+        let out_of_gas_panic_instruction =
+            PanicInstruction::error(PanicReason::OutOfGas, op::noop().into());
+        assert_eq!(
+            revert_panic_instruction.to_bytes(),
+            out_of_gas_panic_instruction.to_bytes()
+        );
     }
 }

--- a/fuel-asm/src/panic_reason.rs
+++ b/fuel-asm/src/panic_reason.rs
@@ -23,14 +23,14 @@ macro_rules! enum_from {
 }
 
 enum_from! {
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, strum::EnumIter)]
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash, strum::EnumIter)]
     #[cfg_attr(feature = "typescript", wasm_bindgen::prelude::wasm_bindgen)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[derive(fuel_types::canonical::Serialize, fuel_types::canonical::Deserialize)]
     #[repr(u8)]
     #[non_exhaustive]
     /// Panic reason representation for the interpreter.
     pub enum PanicReason {
+        #[default]
         /// The byte can't be mapped to any known `PanicReason`.
         UnknownPanicReason = 0x00,
         /// Found `RVRT` instruction.

--- a/fuel-tx/src/tests/bytes.rs
+++ b/fuel-tx/src/tests/bytes.rs
@@ -31,7 +31,6 @@ use rand::{
     SeedableRng,
 };
 use std::fmt;
-use strum::IntoEnumIterator;
 
 pub fn assert_encoding_correct<T>(data: &[T])
 where
@@ -158,7 +157,7 @@ fn output() {
 fn receipt() {
     let rng = &mut StdRng::seed_from_u64(8586);
 
-    let mut receipts = vec![
+    let receipts = vec![
         Receipt::call(
             rng.gen(),
             rng.gen(),
@@ -216,7 +215,7 @@ fn receipt() {
         Receipt::panic(
             rng.gen(),
             PanicInstruction::error(
-                PanicReason::ContractNotInInputs,
+                PanicReason::UnknownPanicReason,
                 op::ji(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
@@ -241,18 +240,6 @@ fn receipt() {
         Receipt::mint(rng.gen(), rng.gen(), rng.gen(), rng.gen(), rng.gen()),
         Receipt::burn(rng.gen(), rng.gen(), rng.gen(), rng.gen(), rng.gen()),
     ];
-
-    for panic_reason in PanicReason::iter() {
-        receipts.push(Receipt::panic(
-            rng.gen(),
-            PanicInstruction::error(
-                panic_reason,
-                op::ji(rng.gen::<Immediate24>() & 0xffffff).into(),
-            ),
-            rng.gen(),
-            rng.gen(),
-        ));
-    }
 
     assert_encoding_correct(&receipts);
 }


### PR DESCRIPTION
Related specification PR: https://github.com/FuelLabs/fuel-specs/pull/609

The main reason for removing it from canonical serialization is to avoid affecting the block ID for different panic reasons. The primary goal is just to know that some operation was done incorrectly; what exactly failed is less important. It reduces the chance of getting different blocks within one panic.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
