### PR TITLE
Release v0.57.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.57.0]
+
 ### Added
 - [#670](https://github.com/FuelLabs/fuel-vm/pull/670): Add DA compression functionality to `Transaction` and any types within
 - [#733](https://github.com/FuelLabs/fuel-vm/pull/733): Add LibAFL based fuzzer and update `secp256k1` version to 0.29.1.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,18 +18,18 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.56.0"
+version = "0.57.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.56.0", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.56.0", path = "fuel-crypto", default-features = false }
-fuel-compression = { version = "0.56.0", path = "fuel-compression", default-features = false }
-fuel-derive = { version = "0.56.0", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.56.0", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.56.0", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.56.0", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.56.0", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.56.0", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.57.0", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.57.0", path = "fuel-crypto", default-features = false }
+fuel-compression = { version = "0.57.0", path = "fuel-compression", default-features = false }
+fuel-derive = { version = "0.57.0", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.57.0", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.57.0", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.57.0", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.57.0", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.57.0", path = "fuel-vm", default-features = false }
 bitflags = "2"
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
## Version v0.57.0

### Added
- [#670](https://github.com/FuelLabs/fuel-vm/pull/670): Add DA compression functionality to `Transaction` and any types within
- [#733](https://github.com/FuelLabs/fuel-vm/pull/733): Add LibAFL based fuzzer and update `secp256k1` version to 0.29.1.
- [#825](https://github.com/FuelLabs/fuel-vm/pull/733): Avoid leaking partially allocated memory when array deserialization fails

### Changed
- [#824](https://github.com/FuelLabs/fuel-vm/pull/824): Use `self` instead of `&self` during decompression.
- [#823](https://github.com/FuelLabs/fuel-vm/pull/823): Returned the old behaviour of the json serialization for policies.

#### Breaking
- [#826](https://github.com/FuelLabs/fuel-vm/pull/826): Skip the panic reason from canonical serialization of the panic receipt.
- [#821](https://github.com/FuelLabs/fuel-vm/pull/821): Added `block_transaction_size_limit` to `ConsensusParameters`. It adds a new `ConensusParametersV2` as a variant of the `ConsensusParameters`.
- [#670](https://github.com/FuelLabs/fuel-vm/pull/670): The `predicate` field of `fuel_tx::input::Coin` is now a wrapper struct `PredicateCode`.

### Fixed
- [#822](https://github.com/FuelLabs/fuel-vm/pull/822): Return recipient as an owner for the message inputs.

## What's Changed
* Rust 1.79.0 by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/806
* chore: Add initial CODEOWNERS file by @netrome in https://github.com/FuelLabs/fuel-vm/pull/817
* DA compression for fuel-tx types by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/670
* Add advanced fuzzer (#724) by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/733
* Deserialize arrays: avoid leaking partially allocated memory when failing by @acerone85 in https://github.com/FuelLabs/fuel-vm/pull/825
* Add `block_transaction_size_limit` to `ConsensusParameters` by @rafal-ch in https://github.com/FuelLabs/fuel-vm/pull/821
* Return recipient as an owner for the message inputs by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/822
* Skip the panic reason from canonical serialization by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/826
* Returned the old behaviour of the json serialization for policies by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/823
* Use `self` instead of `&self` during decompression by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/824

## New Contributors
* @netrome made their first contribution in https://github.com/FuelLabs/fuel-vm/pull/817
* @acerone85 made their first contribution in https://github.com/FuelLabs/fuel-vm/pull/825
* @rafal-ch made their first contribution in https://github.com/FuelLabs/fuel-vm/pull/821

**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.56.0...v0.57.0
