### PR TITLE
Add `fn add_fee_input()` and make `fn add_random_fee_input()` truly random

### DIFF
--- a/fuel-tx/src/builder.rs
+++ b/fuel-tx/src/builder.rs
@@ -68,6 +68,11 @@ use fuel_types::{
     Salt,
     Word,
 };
+#[cfg(feature = "rand")]
+use rand::{
+    rngs::StdRng,
+    Rng,
+};
 
 pub trait BuildableAloc
 where
@@ -408,7 +413,18 @@ impl<Tx: Buildable> TransactionBuilder<Tx> {
     }
 
     #[cfg(feature = "rand")]
-    pub fn add_random_fee_input(&mut self) -> &mut Self {
+    pub fn add_random_fee_input(&mut self, rng: &mut StdRng) -> &mut Self {
+        self.add_unsigned_coin_input(
+            SecretKey::random(rng),
+            rng.gen(),
+            u32::MAX as u64,
+            *self.params.base_asset_id(),
+            Default::default(),
+        )
+    }
+
+    #[cfg(feature = "rand")]
+    pub fn add_fee_input(&mut self) -> &mut Self {
         use rand::{
             Rng,
             SeedableRng,

--- a/fuel-tx/src/tests/valid_cases/transaction.rs
+++ b/fuel-tx/src/tests/valid_cases/transaction.rs
@@ -45,14 +45,14 @@ fn gas_limit() {
 
     TransactionBuilder::script(generate_bytes(rng), generate_bytes(rng))
         .maturity(maturity)
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize()
         .check(block_height, &test_params())
         .expect("Failed to validate transaction");
 
     TransactionBuilder::create(vec![0xfau8].into(), rng.gen(), vec![])
         .maturity(maturity)
-        .add_random_fee_input()
+        .add_fee_input()
         .add_contract_created()
         .finalize()
         .check(block_height, &test_params())
@@ -81,14 +81,14 @@ fn maturity() {
 
     TransactionBuilder::script(generate_bytes(rng), generate_bytes(rng))
         .maturity(block_height)
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize()
         .check(block_height, &test_params())
         .expect("Failed to validate script");
 
     TransactionBuilder::create(rng.gen(), rng.gen(), vec![])
         .maturity(block_height)
-        .add_random_fee_input()
+        .add_fee_input()
         .add_contract_created()
         .finalize()
         .check(block_height, &test_params())
@@ -131,7 +131,7 @@ fn script__check__not_set_witness_limit_success() {
 
     // When
     let result = TransactionBuilder::script(generate_bytes(rng), generate_bytes(rng))
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize()
         .check(block_height, &test_params());
 
@@ -148,7 +148,7 @@ fn create_not_set_witness_limit_success() {
 
     // When
     let result = TransactionBuilder::create(bytecode.clone().into(), rng.gen(), vec![])
-        .add_random_fee_input()
+        .add_fee_input()
         .add_contract_created()
         .finalize()
         .check(block_height, &test_params());
@@ -168,7 +168,7 @@ fn script__check__set_witness_limit_for_empty_witness_success() {
 
     // When
     let result = TransactionBuilder::script(generate_bytes(rng), generate_bytes(rng))
-        .add_random_fee_input()
+        .add_fee_input()
         .witness_limit(limit as u64)
         .finalize()
         .check(block_height, &test_params());
@@ -189,7 +189,7 @@ fn script_set_witness_limit_less_than_witness_data_size_fails() {
 
     // When
     let err = TransactionBuilder::script(generate_bytes(rng), generate_bytes(rng))
-        .add_random_fee_input()
+        .add_fee_input()
         .witness_limit(limit as u64)
         .finalize()
         .check(block_height, &test_params())
@@ -210,7 +210,7 @@ fn create_set_witness_limit_for_empty_witness_success() {
 
     // When
     let result = TransactionBuilder::create(bytecode.clone().into(), rng.gen(), vec![])
-        .add_random_fee_input()
+        .add_fee_input()
         .add_contract_created()
         .witness_limit(limit as u64)
         .finalize()
@@ -231,7 +231,7 @@ fn create_set_witness_limit_less_than_witness_data_size_fails() {
 
     // When
     let err = TransactionBuilder::create(bytecode.clone().into(), rng.gen(), vec![])
-        .add_random_fee_input()
+        .add_fee_input()
         .witness_limit(limit as u64 - 1)
         .finalize()
         .check(block_height, &test_params())
@@ -249,7 +249,7 @@ fn script_not_set_max_fee_limit_success() {
 
     // When
     let result = TransactionBuilder::script(generate_bytes(rng), generate_bytes(rng))
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize()
         .check(block_height, &test_params());
 
@@ -264,7 +264,7 @@ fn script__check__no_max_fee_fails() {
 
     // Given
     let mut tx = TransactionBuilder::script(generate_bytes(rng), generate_bytes(rng))
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize();
     tx.policies_mut().set(PolicyType::MaxFee, None);
 
@@ -285,7 +285,7 @@ fn create_not_set_max_fee_limit_success() {
 
     // When
     let result = TransactionBuilder::create(rng.gen(), rng.gen(), vec![])
-        .add_random_fee_input()
+        .add_fee_input()
         .add_contract_created()
         .finalize()
         .check(block_height, &test_params());
@@ -301,7 +301,7 @@ fn create__check__no_max_fee_fails() {
 
     // Given
     let mut tx = TransactionBuilder::create(rng.gen(), rng.gen(), vec![])
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize();
     tx.policies_mut().set(PolicyType::MaxFee, None);
 
@@ -646,7 +646,7 @@ fn create__check__happy_path() {
 
     TransactionBuilder::create(generate_bytes(rng).into(), rng.gen(), vec![])
         .maturity(maturity)
-        .add_random_fee_input()
+        .add_fee_input()
         .add_contract_created()
         .finalize()
         .check(block_height, &test_params())
@@ -692,7 +692,7 @@ fn create__check__must_contain_contract_created_output() {
 
     let err = TransactionBuilder::create(generate_bytes(rng).into(), rng.gen(), vec![])
         .maturity(maturity)
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize()
         .check(block_height, &test_params())
         .expect_err("Expected erroneous transaction");
@@ -742,7 +742,7 @@ fn create__check__cannot_have_variable_output() {
 
     let err = TransactionBuilder::create(generate_bytes(rng).into(), rng.gen(), vec![])
         .maturity(maturity)
-        .add_random_fee_input()
+        .add_fee_input()
         .add_contract_created()
         .add_output(Output::variable(rng.gen(), rng.gen(), rng.gen()))
         .finalize()

--- a/fuel-tx/src/tests/valid_cases/transaction/blob.rs
+++ b/fuel-tx/src/tests/valid_cases/transaction/blob.rs
@@ -164,7 +164,7 @@ fn check__set_witness_limit_less_than_witness_data_size_fails() {
 #[test]
 fn check__no_max_fee_fails() {
     let block_height = 1000.into();
-    let mut tx = valid_blob_transaction().add_random_fee_input().finalize();
+    let mut tx = valid_blob_transaction().add_fee_input().finalize();
 
     // Given
     tx.policies_mut().set(PolicyType::MaxFee, None);

--- a/fuel-tx/src/tests/valid_cases/transaction/upgrade.rs
+++ b/fuel-tx/src/tests/valid_cases/transaction/upgrade.rs
@@ -130,7 +130,7 @@ fn script_set_witness_limit_less_than_witness_data_size_fails() {
     let failing_limit = limit - 1;
     let tx = valid_upgrade_transaction()
         .witness_limit(failing_limit as u64)
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize_as_transaction();
 
     // When
@@ -143,9 +143,7 @@ fn script_set_witness_limit_less_than_witness_data_size_fails() {
 #[test]
 fn check__no_max_fee_fails() {
     let block_height = 1000.into();
-    let mut tx = valid_upgrade_transaction()
-        .add_random_fee_input()
-        .finalize();
+    let mut tx = valid_upgrade_transaction().add_fee_input().finalize();
 
     // Given
     tx.policies_mut().set(PolicyType::MaxFee, None);

--- a/fuel-tx/src/tests/valid_cases/transaction/upload.rs
+++ b/fuel-tx/src/tests/valid_cases/transaction/upload.rs
@@ -228,7 +228,7 @@ fn check__set_witness_limit_less_than_witness_data_size_fails() {
 #[test]
 fn check__no_max_fee_fails() {
     let block_height = 1000.into();
-    let mut tx = valid_upload_transaction().add_random_fee_input().finalize();
+    let mut tx = valid_upload_transaction().add_fee_input().finalize();
 
     // Given
     tx.policies_mut().set(PolicyType::MaxFee, None);

--- a/fuel-tx/src/transaction.rs
+++ b/fuel-tx/src/transaction.rs
@@ -123,7 +123,7 @@ impl Transaction {
 
         crate::TransactionBuilder::script(vec![], vec![])
             .max_fee_limit(0)
-            .add_random_fee_input()
+            .add_fee_input()
             .finalize()
             .into()
     }

--- a/fuel-tx/src/transaction/types/create.rs
+++ b/fuel-tx/src/transaction/types/create.rs
@@ -418,7 +418,7 @@ mod tests {
             Salt::zeroed(),
             storage_slots,
         )
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize();
         tx.body.storage_slots.reverse();
 
@@ -441,7 +441,7 @@ mod tests {
             Salt::zeroed(),
             storage_slots,
         )
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize()
         .check(0.into(), &ConsensusParameters::standard())
         .expect_err("Expected erroneous transaction");

--- a/fuel-vm/benches/execution.rs
+++ b/fuel-vm/benches/execution.rs
@@ -45,7 +45,7 @@ fn execution(c: &mut Criterion) {
         vec![],
     )
     .max_fee_limit(0)
-    .add_random_fee_input()
+    .add_fee_input()
     .finalize();
     let script = script
         .into_checked_basic(Default::default(), &Default::default())
@@ -92,7 +92,7 @@ fn execution(c: &mut Criterion) {
         vec![],
     )
     .max_fee_limit(0)
-    .add_random_fee_input()
+    .add_fee_input()
     .finalize();
     let script = script
         .into_checked_basic(Default::default(), &Default::default())
@@ -137,7 +137,7 @@ fn execution(c: &mut Criterion) {
         vec![],
     )
     .max_fee_limit(0)
-    .add_random_fee_input()
+    .add_fee_input()
     .finalize();
     let script = script
         .into_checked_basic(Default::default(), &Default::default())

--- a/fuel-vm/examples/external.rs
+++ b/fuel-vm/examples/external.rs
@@ -108,7 +108,7 @@ fn example_file_read() {
     let tx = TransactionBuilder::script(script, script_data)
         .script_gas_limit(1_000_000)
         .maturity(Default::default())
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize()
         .into_checked(Default::default(), &consensus_params)
         .expect("failed to generate a checked tx");
@@ -170,7 +170,7 @@ fn example_counter() {
     let tx = TransactionBuilder::script(script, script_data)
         .script_gas_limit(1_000_000)
         .maturity(Default::default())
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize()
         .into_checked(Default::default(), &consensus_params)
         .expect("failed to generate a checked tx");
@@ -233,7 +233,7 @@ fn example_shared_counter() {
     let tx = TransactionBuilder::script(script, script_data)
         .script_gas_limit(1_000_000)
         .maturity(Default::default())
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize()
         .into_checked(Default::default(), &consensus_params)
         .expect("failed to generate a checked tx");

--- a/fuel-vm/examples/single_step.rs
+++ b/fuel-vm/examples/single_step.rs
@@ -48,7 +48,7 @@ fn main() {
     let tx = TransactionBuilder::script(script, script_data)
         .script_gas_limit(1_000_000)
         .maturity(Default::default())
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize()
         .into_checked(Default::default(), &consensus_params)
         .expect("failed to generate a checked tx")

--- a/fuel-vm/src/interpreter/debug.rs
+++ b/fuel-vm/src/interpreter/debug.rs
@@ -94,7 +94,7 @@ mod tests {
 
         let tx = TransactionBuilder::script(script, vec![])
             .script_gas_limit(gas_limit)
-            .add_random_fee_input()
+            .add_fee_input()
             .finalize()
             .into_checked(height, &consensus_params)
             .expect("failed to generate checked tx")
@@ -173,7 +173,7 @@ mod tests {
 
         let tx = TransactionBuilder::script(script, vec![])
             .script_gas_limit(gas_limit)
-            .add_random_fee_input()
+            .add_fee_input()
             .finalize()
             .into_checked(height, &consensus_params)
             .expect("failed to generate checked tx")
@@ -226,7 +226,7 @@ mod tests {
 
         let tx = TransactionBuilder::script(script, vec![])
             .script_gas_limit(gas_limit)
-            .add_random_fee_input()
+            .add_fee_input()
             .finalize()
             .into_checked(height, &consensus_params)
             .expect("failed to generate checked tx")

--- a/fuel-vm/src/interpreter/executors/instruction/tests/reserved_registers.rs
+++ b/fuel-vm/src/interpreter/executors/instruction/tests/reserved_registers.rs
@@ -69,7 +69,7 @@ fn cant_write_to_reserved_registers(raw_random_instruction: u32) -> TestResult {
     let script = op::ret(0x10).to_bytes().to_vec();
     let block_height = Default::default();
     let tx = TransactionBuilder::script(script, vec![])
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize();
 
     let tx = tx

--- a/fuel-vm/src/interpreter/executors/main/tests.rs
+++ b/fuel-vm/src/interpreter/executors/main/tests.rs
@@ -117,7 +117,7 @@ fn valid_script_tx() -> Checked<Script> {
 
     TransactionBuilder::script(vec![], vec![])
         .max_fee_limit(arb_max_fee)
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize_checked_basic(Default::default())
 }
 
@@ -151,7 +151,7 @@ fn valid_create_tx() -> Checked<Create> {
 
     TransactionBuilder::create(witness, salt, vec![])
         .max_fee_limit(arb_max_fee)
-        .add_random_fee_input()
+        .add_fee_input()
         .add_contract_created()
         .finalize_checked_basic(Default::default())
 }
@@ -193,7 +193,7 @@ fn valid_upgrade_tx() -> Checked<Upgrade> {
         Default::default(),
         0,
     ))
-    .add_random_fee_input()
+    .add_fee_input()
     .finalize_checked_basic(Default::default())
 }
 
@@ -234,7 +234,7 @@ fn valid_upload_tx() -> Checked<Upload> {
     })
     .add_witness(subsection.subsection.into())
     .max_fee_limit(arb_max_fee)
-    .add_random_fee_input()
+    .add_fee_input()
     .finalize_checked_basic(Default::default())
 }
 

--- a/fuel-vm/src/interpreter/internal/tests.rs
+++ b/fuel-vm/src/interpreter/internal/tests.rs
@@ -131,7 +131,7 @@ fn variable_output_updates_in_memory() {
 
     let tx = TransactionBuilder::script(vec![], vec![])
         .script_gas_limit(gas_limit)
-        .add_random_fee_input()
+        .add_fee_input()
         .add_output(variable_output)
         .finalize()
         .into_checked(height, &consensus_params)

--- a/fuel-vm/src/interpreter/memory/tests.rs
+++ b/fuel-vm/src/interpreter/memory/tests.rs
@@ -28,7 +28,7 @@ fn memcopy() {
     );
     let tx = TransactionBuilder::script(op::ret(0x10).to_bytes().to_vec(), vec![])
         .script_gas_limit(100_000)
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize();
 
     let tx = tx
@@ -97,7 +97,7 @@ fn stack_alloc_ownership() {
 
     let tx = TransactionBuilder::script(vec![], vec![])
         .script_gas_limit(1000000)
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize()
         .into_checked(Default::default(), &ConsensusParameters::standard())
         .expect("Empty script should be valid")

--- a/fuel-vm/src/predicate.rs
+++ b/fuel-vm/src/predicate.rs
@@ -128,7 +128,7 @@ mod tests {
         for i in inputs {
             let tx = TransactionBuilder::script(vec![], vec![])
                 .add_input(i)
-                .add_random_fee_input()
+                .add_fee_input()
                 .finalize_checked_basic(height);
 
             // assert invalid idx wont panic
@@ -277,7 +277,7 @@ mod tests {
                     vec![],
                 )
                 .add_input(input)
-                .add_random_fee_input()
+                .add_fee_input()
                 .finalize_checked_basic(height);
 
                 let result = Interpreter::check_predicates(

--- a/fuel-vm/src/tests/blockchain.rs
+++ b/fuel-vm/src/tests/blockchain.rs
@@ -73,7 +73,7 @@ fn deploy_contract<M>(
     let height = Default::default();
     let contract_deployer = TransactionBuilder::create(contract, salt, storage_slots)
         .with_tx_params(tx_params)
-        .add_random_fee_input()
+        .add_fee_input()
         .add_contract_created()
         .finalize_checked(height);
 
@@ -600,7 +600,7 @@ where
     let tx_create_target =
         TransactionBuilder::create(target_contract_witness.clone(), salt, vec![])
             .maturity(maturity)
-            .add_random_fee_input()
+            .add_fee_input()
             .add_contract_created()
             .finalize()
             .into_checked(height, &consensus_params)
@@ -662,7 +662,7 @@ where
     .script_gas_limit(gas_limit)
     .maturity(maturity)
     .add_input(input0.clone())
-    .add_random_fee_input()
+    .add_fee_input()
     .add_output(output0)
     .finalize()
     .into_checked(height, &consensus_params)
@@ -679,7 +679,7 @@ where
             .script_gas_limit(gas_limit)
             .maturity(maturity)
             .add_input(input0)
-            .add_random_fee_input()
+            .add_fee_input()
             .add_output(output0)
             .finalize()
             .into_checked(height, &consensus_params)
@@ -737,7 +737,7 @@ fn ldc_reason_helper(cmd: Vec<Instruction>, expected_reason: PanicReason) {
 
     let tx_create_target = TransactionBuilder::create(program, salt, vec![])
         .maturity(maturity)
-        .add_random_fee_input()
+        .add_fee_input()
         .add_contract_created()
         .finalize()
         .into_checked(height, &consensus_params)
@@ -753,7 +753,7 @@ fn ldc_reason_helper(cmd: Vec<Instruction>, expected_reason: PanicReason) {
     )
     .script_gas_limit(gas_limit)
     .maturity(maturity)
-    .add_random_fee_input()
+    .add_fee_input()
     .finalize()
     .into_checked(height, &consensus_params)
     .expect("failed to check tx");
@@ -1938,7 +1938,7 @@ fn timestamp_works() {
         let tx = TransactionBuilder::script(script, script_data)
             .script_gas_limit(gas_limit)
             .maturity(maturity)
-            .add_random_fee_input()
+            .add_fee_input()
             .finalize_checked(block_height);
 
         let receipts = client.transact(tx);
@@ -1992,7 +1992,7 @@ fn block_height_works(#[values(0, 1, 2, 10, 100)] current_height: u32) {
     let tx = TransactionBuilder::script(script, script_data)
         .script_gas_limit(gas_limit)
         .maturity(maturity)
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize_checked(current_height);
 
     let receipts = client.transact(tx);
@@ -2041,7 +2041,7 @@ fn block_hash_works(
     let tx = TransactionBuilder::script(script, script_data)
         .script_gas_limit(gas_limit)
         .maturity(maturity)
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize_checked(current_height);
 
     let receipts = client.transact(tx);
@@ -2079,7 +2079,7 @@ fn coinbase_works() {
     let tx = TransactionBuilder::script(script, script_data)
         .script_gas_limit(gas_limit)
         .maturity(maturity)
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize_checked(10.into());
 
     let receipts = client.transact(tx);
@@ -2122,7 +2122,7 @@ fn various_ldc_issues_poc() {
     let tx_create_target =
         TransactionBuilder::create(target_program.clone(), salt, vec![])
             .maturity(maturity)
-            .add_random_fee_input()
+            .add_fee_input()
             .add_contract_created()
             .finalize()
             .into_checked(height, &consensus_params)
@@ -2193,7 +2193,7 @@ fn various_ldc_issues_poc() {
     let tx_create_loader =
         TransactionBuilder::create(loader_program.clone(), salt, vec![])
             .maturity(maturity)
-            .add_random_fee_input()
+            .add_fee_input()
             .add_contract_created()
             .finalize()
             .into_checked(height, &consensus_params)
@@ -2246,7 +2246,7 @@ fn various_ldc_issues_poc() {
             .maturity(maturity)
             .add_input(input0)
             .add_input(input1)
-            .add_random_fee_input()
+            .add_fee_input()
             .add_output(output0)
             .add_output(output1)
             .finalize()
@@ -2372,7 +2372,7 @@ where
     })
     .add_witness(blob_code.into())
     .maturity(maturity)
-    .add_random_fee_input()
+    .add_fee_input()
     .finalize()
     .into_checked(height, &consensus_params)
     .expect("failed to check tx");
@@ -2432,7 +2432,7 @@ where
     )
     .script_gas_limit(gas_limit)
     .maturity(maturity)
-    .add_random_fee_input()
+    .add_fee_input()
     .finalize()
     .into_checked(height, &consensus_params)
     .expect("failed to check tx");
@@ -2446,7 +2446,7 @@ where
         TransactionBuilder::script(load_blob.into_iter().collect(), vec![])
             .script_gas_limit(gas_limit)
             .maturity(maturity)
-            .add_random_fee_input()
+            .add_fee_input()
             .finalize()
             .into_checked(height, &consensus_params)
             .expect("failed to check tx");
@@ -2492,7 +2492,7 @@ fn ldcv2_reason_helper(cmd: Vec<Instruction>, expected_reason: PanicReason) {
     })
     .add_witness(program.into())
     .maturity(maturity)
-    .add_random_fee_input()
+    .add_fee_input()
     .finalize()
     .into_checked(height, &consensus_params)
     .expect("failed to check tx");
@@ -2505,7 +2505,7 @@ fn ldcv2_reason_helper(cmd: Vec<Instruction>, expected_reason: PanicReason) {
         TransactionBuilder::script(load_blob.into_iter().collect(), blob_id.to_vec())
             .script_gas_limit(gas_limit)
             .maturity(maturity)
-            .add_random_fee_input()
+            .add_fee_input()
             .finalize()
             .into_checked(height, &consensus_params)
             .expect("failed to check tx");

--- a/fuel-vm/src/tests/crypto.rs
+++ b/fuel-vm/src/tests/crypto.rs
@@ -92,7 +92,7 @@ fn secp256k1_recover() {
     let tx = TransactionBuilder::script(script, script_data)
         .script_gas_limit(gas_limit)
         .maturity(maturity)
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize_checked(height);
 
     let receipts = client.transact(tx);
@@ -145,7 +145,7 @@ fn ecrecover_tx_id() {
     let mut tx = TransactionBuilder::script(script, script_data)
         .script_gas_limit(gas_limit)
         .maturity(maturity)
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize();
 
     tx.sign_inputs(&secret, &chain_id);
@@ -377,7 +377,7 @@ fn secp256r1_recover() {
     let tx = TransactionBuilder::script(script, script_data)
         .script_gas_limit(gas_limit)
         .maturity(maturity)
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize_checked(height);
 
     let receipts = client.transact(tx);
@@ -512,7 +512,7 @@ fn ed25519_verifies_message() {
     let tx = TransactionBuilder::script(script.clone(), script_data)
         .script_gas_limit(gas_limit)
         .maturity(maturity)
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize_checked(height);
 
     let receipts = client.transact(tx);
@@ -537,7 +537,7 @@ fn ed25519_verifies_message() {
     let tx = TransactionBuilder::script(script.clone(), script_data)
         .script_gas_limit(gas_limit)
         .maturity(maturity)
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize_checked(height);
 
     let receipts = client.transact(tx);
@@ -561,7 +561,7 @@ fn ed25519_verifies_message() {
     let tx = TransactionBuilder::script(script, script_data)
         .script_gas_limit(gas_limit)
         .maturity(maturity)
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize_checked(height);
 
     let receipts = client.transact(tx);
@@ -612,7 +612,7 @@ fn ed25519_zero_length_is_treated_as_32() {
     let tx = TransactionBuilder::script(script.clone(), script_data)
         .script_gas_limit(gas_limit)
         .maturity(maturity)
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize_checked(height);
 
     let receipts = client.transact(tx);
@@ -715,7 +715,7 @@ fn sha256() {
     let tx = TransactionBuilder::script(script, script_data)
         .script_gas_limit(gas_limit)
         .maturity(maturity)
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize_checked(height);
 
     let receipts = client.transact(tx);
@@ -804,7 +804,7 @@ fn keccak256() {
     let tx = TransactionBuilder::script(script, script_data)
         .script_gas_limit(gas_limit)
         .maturity(maturity)
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize_checked(height);
 
     let receipts = client.transact(tx);

--- a/fuel-vm/src/tests/external.rs
+++ b/fuel-vm/src/tests/external.rs
@@ -69,7 +69,7 @@ fn noop_ecal() {
     let tx = TransactionBuilder::script(script, vec![])
         .script_gas_limit(1_000_000)
         .maturity(Default::default())
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize()
         .into_checked(Default::default(), &consensus_params)
         .expect("failed to generate a checked tx");
@@ -145,7 +145,7 @@ fn provide_ecal_fn() {
     let tx = TransactionBuilder::script(script, script_data)
         .script_gas_limit(1_000_000)
         .maturity(Default::default())
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize()
         .into_checked(Default::default(), &consensus_params)
         .expect("failed to generate a checked tx");
@@ -216,7 +216,7 @@ fn complex_ecal_fn(val: u32, result: PanicReason) {
     let tx = TransactionBuilder::script(script, vec![])
         .script_gas_limit(1_000_000)
         .maturity(Default::default())
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize()
         .into_checked(Default::default(), &consensus_params)
         .expect("failed to generate a checked tx");

--- a/fuel-vm/src/tests/memory.rs
+++ b/fuel-vm/src/tests/memory.rs
@@ -42,7 +42,7 @@ fn setup(program: Vec<Instruction>) -> Transactor<MemoryInstance, MemoryStorage,
     let tx = TransactionBuilder::script(script, vec![])
         .script_gas_limit(gas_limit)
         .maturity(maturity)
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize()
         .into_checked(height, &consensus_params)
         .expect("failed to check tx");

--- a/fuel-vm/src/tests/metadata.rs
+++ b/fuel-vm/src/tests/metadata.rs
@@ -86,7 +86,7 @@ fn metadata() {
 
     let tx = TransactionBuilder::create(program, salt, vec![])
         .maturity(maturity)
-        .add_random_fee_input()
+        .add_fee_input()
         .add_contract_created()
         .finalize()
         .into_checked(height, &consensus_params)
@@ -135,7 +135,7 @@ fn metadata() {
     let contract_call = contract.id(&salt, &contract_root, &state_root);
     let tx = TransactionBuilder::create(program, salt, vec![])
         .maturity(maturity)
-        .add_random_fee_input()
+        .add_fee_input()
         .add_contract_created()
         .finalize()
         .into_checked(height, &consensus_params)
@@ -199,7 +199,7 @@ fn metadata() {
         .add_input(inputs[1].clone())
         .add_output(outputs[0])
         .add_output(outputs[1])
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize()
         .into_checked(height, &consensus_params)
         .expect("failed to check tx");
@@ -261,7 +261,7 @@ fn get_metadata_chain_id() {
     let script = TransactionBuilder::script(get_chain_id.into_iter().collect(), vec![])
         .script_gas_limit(gas_limit)
         .with_chain_id(chain_id)
-        .add_random_fee_input()
+        .add_fee_input()
         .finalize()
         .into_checked(height, &consensus_params)
         .unwrap();
@@ -296,7 +296,7 @@ fn get_metadata_base_asset_id() {
         vec![],
     )
     .script_gas_limit(gas_limit)
-    .add_random_fee_input()
+    .add_fee_input()
     .finalize()
     .into_checked(height, &params)
     .unwrap();
@@ -334,7 +334,7 @@ fn get_metadata_tx_start() {
         vec![],
     )
     .script_gas_limit(gas_limit)
-    .add_random_fee_input()
+    .add_fee_input()
     .finalize()
     .into_checked(height, &ConsensusParameters::default())
     .unwrap();

--- a/fuel-vm/src/util.rs
+++ b/fuel-vm/src/util.rs
@@ -309,7 +309,7 @@ pub mod test_helpers {
         }
 
         pub fn fee_input(&mut self) -> &mut TestBuilder {
-            self.builder.add_random_fee_input();
+            self.builder.add_fee_input();
             self
         }
 
@@ -488,7 +488,7 @@ pub mod test_helpers {
             let tx = TransactionBuilder::create(program, salt, storage_slots)
                 .max_fee_limit(self.max_fee_limit)
                 .maturity(Default::default())
-                .add_random_fee_input()
+                .add_fee_input()
                 .add_contract_created()
                 .finalize()
                 .into_checked(self.block_height, &self.consensus_params)
@@ -523,7 +523,7 @@ pub mod test_helpers {
             .add_witness(data.into())
             .max_fee_limit(self.max_fee_limit)
             .maturity(Default::default())
-            .add_random_fee_input()
+            .add_fee_input()
             .finalize()
             .into_checked(self.block_height, &self.consensus_params)
             .expect("failed to check tx");
@@ -719,7 +719,7 @@ pub mod test_helpers {
         let contract_deployer = TransactionBuilder::create(contract, salt, storage_slots)
             .max_fee_limit(zero_fee_limit)
             .with_tx_params(tx_params)
-            .add_random_fee_input()
+            .add_fee_input()
             .add_contract_created()
             .finalize_checked(height);
 
@@ -755,7 +755,7 @@ pub mod test_helpers {
                 Default::default(),
                 contract_id,
             ))
-            .add_random_fee_input()
+            .add_fee_input()
             .add_output(Output::contract(0, Default::default(), Default::default()))
             .finalize_checked(height);
 


### PR DESCRIPTION
Previously the `add_random_fee_input()` wasn't actually producing a random input, which was confusing. This PR:
1. adds the `add_fee_input()` which is an equivalent to the former version of `add_random_fee_input()` 
2. modifies the `add_random_fee_input()` to accept an `rng` and provide truly random fee input

For compatibility reasons, all tests that were previously using `add_random_fee_input()` were modified to use `add_fee_input()`.

This change should make the test code more explicit and make it easier to create random transactions in test code.

### Before requesting review
- [X] I have reviewed the code myself
- [X] I have created follow-up issues caused by this PR and linked them here

Follow-up draft PR in `fuel-core`: https://github.com/FuelLabs/fuel-core/pull/2211