### PR TITLE
Add `Display` and `Error` impls to custom error type `SettingBlockTransactionSizeLimitNotSupported`

### DIFF
--- a/fuel-tx/src/transaction/consensus_parameters.rs
+++ b/fuel-tx/src/transaction/consensus_parameters.rs
@@ -24,6 +24,14 @@ const MAX_SIZE: u64 = 110 * 1024;
 
 #[derive(Debug)]
 pub struct SettingBlockTransactionSizeLimitNotSupported;
+#[cfg(feature = "std")]
+impl std::fmt::Display for SettingBlockTransactionSizeLimitNotSupported {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "setting block transaction size limit is not supported")
+    }
+}
+#[cfg(feature = "std")]
+impl std::error::Error for SettingBlockTransactionSizeLimitNotSupported {}
 
 /// A versioned set of consensus parameters.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]

--- a/fuel-tx/src/transaction/consensus_parameters.rs
+++ b/fuel-tx/src/transaction/consensus_parameters.rs
@@ -22,14 +22,9 @@ const MAX_GAS: u64 = 100_000_000;
 #[cfg(feature = "test-helpers")]
 const MAX_SIZE: u64 = 110 * 1024;
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::Display)]
+#[display(fmt = "setting block transaction size limit is not supported")]
 pub struct SettingBlockTransactionSizeLimitNotSupported;
-#[cfg(feature = "std")]
-impl std::fmt::Display for SettingBlockTransactionSizeLimitNotSupported {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "setting block transaction size limit is not supported")
-    }
-}
 #[cfg(feature = "std")]
 impl std::error::Error for SettingBlockTransactionSizeLimitNotSupported {}
 


### PR DESCRIPTION
This PR adds the `std::error::Error` implementations for the recently introduced `SettingBlockTransactionSizeLimitNotSupported` custom error type.

It also adds the derived `Display`.

This will make it easier for the consumers to properly use this error type.

### Before requesting review
- [X] I have reviewed the code myself