### PR TITLE
Fixing WASM-NPM packaging and publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,7 +298,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
         with:
-          version: 9.4.0
+          version: ^9.4.0
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,8 +146,8 @@ jobs:
           git push
           export PAGES_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/$BRANCH_B64/index.html"
           echo "$PAGES_URL"
-          echo "Codecov report $PAGES_URL" >> $GITHUB_STEP_SUMMARY          
-  
+          echo "Codecov report $PAGES_URL" >> $GITHUB_STEP_SUMMARY
+
 
   rustfmt:
     runs-on: buildjet-4vcpu-ubuntu-2204
@@ -226,7 +226,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
         with:
-          version: 8.6.9
+          version: ^9.4.0
 
       - name: Setup Node
         uses: actions/setup-node@v3
@@ -298,7 +298,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
         with:
-          version: 8.6.9
+          version: 9.4.0
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.npm/.scripts/prepare-wasm-packages.sh
+++ b/.npm/.scripts/prepare-wasm-packages.sh
@@ -50,8 +50,9 @@ build_wasm_npm_pkg_for ()
   write_template ${NAME_DASHED} ${NAME_UNDERSCORED} src/index.js
 
   # commenting out all `new URL()` and `fetch()` calls for great compatibility with JS bundlers
-  sed -i.bkp -r 's;(input = new URL.+);//\1;g' ${PKG_DIR}/src/${NAME_UNDERSCORED}.js
-  sed -i.bkp -r 's;(input = fetch.+);//\1;g' ${PKG_DIR}/src/${NAME_UNDERSCORED}.js
+  sed -i.bkp -r 's;(.+= new URL.+);//\1;g' ${PKG_DIR}/src/${NAME_UNDERSCORED}.js
+  sed -i.bkp -r 's;(.+= fetch.+);//\1;g' ${PKG_DIR}/src/${NAME_UNDERSCORED}.js
+
   rm ${PKG_DIR}/src/${NAME_UNDERSCORED}.js.bkp
 }
 

--- a/.npm/package.json
+++ b/.npm/package.json
@@ -13,7 +13,7 @@
     "wasm": ".scripts/prepare-wasm-packages.sh",
     "build": "turbo run build",
     "test": "turbo run test",
-    "pack:all": "pnpm run-s wasm build test"
+    "pack:all": "run-s wasm build test"
   },
   "license": "Apache-2.0",
   "devDependencies": {
@@ -25,4 +25,5 @@
     "rollup-plugin-dts": "^5.3.1",
     "turbo": "^2.1.2"
   }
+
 }

--- a/.npm/package.json
+++ b/.npm/package.json
@@ -6,7 +6,7 @@
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "engines": {
     "node": ">= 18.14.1",
-    "pnpm": ">= 8.1.1"
+    "pnpm": "^9.4.0"
   },
   "packageManager": "pnpm@8.1.1",
   "scripts": {
@@ -23,6 +23,6 @@
     "npm-run-all": "^4.1.5",
     "rollup": "^3.29.4",
     "rollup-plugin-dts": "^5.3.1",
-    "turbo": "^1.10.16"
+    "turbo": "^2.1.2"
   }
 }

--- a/.npm/packages/fuel-asm/index.test.mjs
+++ b/.npm/packages/fuel-asm/index.test.mjs
@@ -16,9 +16,8 @@ Top-level usage:
 describe('fuel-asm [esm]', () => {
 
   it('should ensure URL/fetch patching was succesful', async () => {
-    const dist = join(import.meta.dirname, 'dist');
-    const cjsContents = readFileSync(join(dist, 'node/index.cjs'), 'utf-8')
-    const mjsContents = readFileSync(join(dist, 'web/index.mjs'), 'utf-8')
+    const cjsContents = readFileSync('./dist/node/index.cjs', 'utf-8')
+    const mjsContents = readFileSync('./dist/web/index.mjs', 'utf-8')
 
     const reg = /(new URL|fetch)\(.+\)/
     expect(mjsContents).to.not.match(reg);

--- a/.npm/packages/fuel-asm/index.test.mjs
+++ b/.npm/packages/fuel-asm/index.test.mjs
@@ -1,4 +1,6 @@
 import { expect } from 'chai'
+import { join } from 'path'
+import { readFileSync } from 'fs'
 import * as asm from './dist/web/index.mjs'
 
 /*
@@ -12,6 +14,16 @@ Top-level usage:
 */
 
 describe('fuel-asm [esm]', () => {
+
+  it('should ensure URL/fetch patching was succesful', async () => {
+    const dist = join(import.meta.dirname, 'dist');
+    const cjsContents = readFileSync(join(dist, 'node/index.cjs'), 'utf-8')
+    const mjsContents = readFileSync(join(dist, 'web/index.mjs'), 'utf-8')
+
+    const reg = /(new URL|fetch)\(.+\)/
+    expect(mjsContents).to.not.match(reg);
+    expect(cjsContents).to.not.match(reg);
+  })
 
   it('should compose simple script', async () => {
 

--- a/.npm/packages/fuel-tx/index.test.mjs
+++ b/.npm/packages/fuel-tx/index.test.mjs
@@ -6,6 +6,8 @@ import * as tx from './dist/web/index.mjs'
 describe('fuel-tx [mjs]', () => {
 
     it('should ensure URL/fetch patching was succesful', async () => {
+        console.log('import.meta', import.meta);
+
         const mjsContents = fs.readFileSync('./dist/web/index.mjs', 'utf-8')
         const cjsContents = fs.readFileSync('./dist/node/index.cjs', 'utf-8')
 

--- a/.npm/packages/fuel-tx/index.test.mjs
+++ b/.npm/packages/fuel-tx/index.test.mjs
@@ -5,6 +5,16 @@ import * as tx from './dist/web/index.mjs'
 
 describe('fuel-tx [mjs]', () => {
 
+    it('should ensure URL/fetch patching was succesful', async () => {
+        const dist = path.join(import.meta.dirname, 'dist');
+        const cjsContents = fs.readFileSync(path.join(dist, 'node/index.cjs'), 'utf-8')
+        const mjsContents = fs.readFileSync(path.join(dist, 'web/index.mjs'), 'utf-8')
+
+        const reg = /(new URL|fetch)\(.+\)/
+        expect(mjsContents).to.not.match(reg);
+        expect(cjsContents).to.not.match(reg);
+    })
+
     it('should export all types', () => {
         expect(tx.UtxoId).to.be.ok
         expect(tx.TxPointer).to.be.ok

--- a/.npm/packages/fuel-tx/index.test.mjs
+++ b/.npm/packages/fuel-tx/index.test.mjs
@@ -6,9 +6,8 @@ import * as tx from './dist/web/index.mjs'
 describe('fuel-tx [mjs]', () => {
 
     it('should ensure URL/fetch patching was succesful', async () => {
-        const dist = path.join(import.meta.dirname, 'dist');
-        const cjsContents = fs.readFileSync(path.join(dist, 'node/index.cjs'), 'utf-8')
-        const mjsContents = fs.readFileSync(path.join(dist, 'web/index.mjs'), 'utf-8')
+        const mjsContents = fs.readFileSync('./dist/web/index.mjs', 'utf-8')
+        const cjsContents = fs.readFileSync('./dist/node/index.cjs', 'utf-8')
 
         const reg = /(new URL|fetch)\(.+\)/
         expect(mjsContents).to.not.match(reg);

--- a/.npm/packages/fuel-types/index.test.mjs
+++ b/.npm/packages/fuel-types/index.test.mjs
@@ -6,9 +6,8 @@ import * as types from './dist/web/index.mjs'
 describe('fuel-types [esm]', () => {
 
   it('should ensure URL/fetch patching was succesful', async () => {
-    const dist = join(import.meta.dirname, 'dist');
-    const cjsContents = readFileSync(join(dist, 'node/index.cjs'), 'utf-8')
-    const mjsContents = readFileSync(join(dist, 'web/index.mjs'), 'utf-8')
+    const cjsContents = readFileSync('./dist/node/index.cjs', 'utf-8')
+    const mjsContents = readFileSync('./dist/web/index.mjs', 'utf-8')
 
     const reg = /(new URL|fetch)\(.+\)/
     expect(mjsContents).to.not.match(reg);

--- a/.npm/packages/fuel-types/index.test.mjs
+++ b/.npm/packages/fuel-types/index.test.mjs
@@ -1,7 +1,19 @@
 import { expect } from 'chai'
+import { join } from 'path'
+import { readFileSync } from 'fs'
 import * as types from './dist/web/index.mjs'
 
 describe('fuel-types [esm]', () => {
+
+  it('should ensure URL/fetch patching was succesful', async () => {
+    const dist = join(import.meta.dirname, 'dist');
+    const cjsContents = readFileSync(join(dist, 'node/index.cjs'), 'utf-8')
+    const mjsContents = readFileSync(join(dist, 'web/index.mjs'), 'utf-8')
+
+    const reg = /(new URL|fetch)\(.+\)/
+    expect(mjsContents).to.not.match(reg);
+    expect(cjsContents).to.not.match(reg);
+  })
 
   it('should export all types', () => {
 

--- a/.npm/pnpm-lock.yaml
+++ b/.npm/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^5.3.1
         version: 5.3.1(rollup@3.29.4)(typescript@5.3.2)
       turbo:
-        specifier: ^1.10.16
-        version: 1.10.16
+        specifier: ^2.1.2
+        version: 2.1.2
 
   packages/fuel-asm: {}
 
@@ -709,38 +709,38 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  turbo-darwin-64@1.10.16:
-    resolution: {integrity: sha512-+Jk91FNcp9e9NCLYlvDDlp2HwEDp14F9N42IoW3dmHI5ZkGSXzalbhVcrx3DOox3QfiNUHxzWg4d7CnVNCuuMg==}
+  turbo-darwin-64@2.1.2:
+    resolution: {integrity: sha512-3TEBxHWh99h2yIzkuIigMEOXt/ItYQp0aPiJjPd1xN4oDcsKK5AxiFKPH9pdtfIBzYsY59kQhZiFj0ELnSP7Bw==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@1.10.16:
-    resolution: {integrity: sha512-jqGpFZipIivkRp/i+jnL8npX0VssE6IAVNKtu573LXtssZdV/S+fRGYA16tI46xJGxSAivrZ/IcgZrV6Jk80bw==}
+  turbo-darwin-arm64@2.1.2:
+    resolution: {integrity: sha512-he0miWNq2WxJzsH82jS2Z4MXpnkzn9SH8a79iPXiJkq25QREImucscM4RPasXm8wARp91pyysJMq6aasD45CeA==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@1.10.16:
-    resolution: {integrity: sha512-PpqEZHwLoizQ6sTUvmImcRmACyRk9EWLXGlqceogPZsJ1jTRK3sfcF9fC2W56zkSIzuLEP07k5kl+ZxJd8JMcg==}
+  turbo-linux-64@2.1.2:
+    resolution: {integrity: sha512-fKUBcc0rK8Vdqv5a/E3CSpMBLG1bzwv+Q0Q83F8fG2ZfNCNKGbcEYABdonNZkkx141Rj03cZQFCgxu3MVEGU+A==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@1.10.16:
-    resolution: {integrity: sha512-TMjFYz8to1QE0fKVXCIvG/4giyfnmqcQIwjdNfJvKjBxn22PpbjeuFuQ5kNXshUTRaTJihFbuuCcb5OYFNx4uw==}
+  turbo-linux-arm64@2.1.2:
+    resolution: {integrity: sha512-sV8Bpmm0WiuxgbhxymcC7wSsuxfBBieI98GegSwbr/bs1ANAgzCg93urIrdKdQ3/b31zZxQwcaP4FBF1wx1Qdg==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@1.10.16:
-    resolution: {integrity: sha512-+jsf68krs0N66FfC4/zZvioUap/Tq3sPFumnMV+EBo8jFdqs4yehd6+MxIwYTjSQLIcpH8KoNMB0gQYhJRLZzw==}
+  turbo-windows-64@2.1.2:
+    resolution: {integrity: sha512-wcmIJZI9ORT9ykHGliFE6kWRQrlH930QGSjSgWC8uFChFFuOyUlvC7ttcxuSvU9VqC7NF4C+GVAcFJQ8lTjN7g==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@1.10.16:
-    resolution: {integrity: sha512-sKm3hcMM1bl0B3PLG4ifidicOGfoJmOEacM5JtgBkYM48ncMHjkHfFY7HrJHZHUnXM4l05RQTpLFoOl/uIo2HQ==}
+  turbo-windows-arm64@2.1.2:
+    resolution: {integrity: sha512-zdnXjrhk7YO6CP+Q5wPueEvOCLH4lDa6C4rrwiakcWcPgcQGbVozJlo4uaQ6awo8HLWQEvOwu84RkWTdLAc/Hw==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@1.10.16:
-    resolution: {integrity: sha512-2CEaK4FIuSZiP83iFa9GqMTQhroW2QryckVqUydmg4tx78baftTOS0O+oDAhvo9r9Nit4xUEtC1RAHoqs6ZEtg==}
+  turbo@2.1.2:
+    resolution: {integrity: sha512-Jb0rbU4iHEVQ18An/YfakdIv9rKnd3zUfSE117EngrfWXFHo3RndVH96US3GsT8VHpwTncPePDBT2t06PaFLrw==}
     hasBin: true
 
   type-detect@4.0.8:
@@ -1565,32 +1565,32 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  turbo-darwin-64@1.10.16:
+  turbo-darwin-64@2.1.2:
     optional: true
 
-  turbo-darwin-arm64@1.10.16:
+  turbo-darwin-arm64@2.1.2:
     optional: true
 
-  turbo-linux-64@1.10.16:
+  turbo-linux-64@2.1.2:
     optional: true
 
-  turbo-linux-arm64@1.10.16:
+  turbo-linux-arm64@2.1.2:
     optional: true
 
-  turbo-windows-64@1.10.16:
+  turbo-windows-64@2.1.2:
     optional: true
 
-  turbo-windows-arm64@1.10.16:
+  turbo-windows-arm64@2.1.2:
     optional: true
 
-  turbo@1.10.16:
+  turbo@2.1.2:
     optionalDependencies:
-      turbo-darwin-64: 1.10.16
-      turbo-darwin-arm64: 1.10.16
-      turbo-linux-64: 1.10.16
-      turbo-linux-arm64: 1.10.16
-      turbo-windows-64: 1.10.16
-      turbo-windows-arm64: 1.10.16
+      turbo-darwin-64: 2.1.2
+      turbo-darwin-arm64: 2.1.2
+      turbo-linux-64: 2.1.2
+      turbo-linux-arm64: 2.1.2
+      turbo-windows-64: 2.1.2
+      turbo-windows-arm64: 2.1.2
 
   type-detect@4.0.8: {}
 

--- a/.npm/turbo.json
+++ b/.npm/turbo.json
@@ -2,10 +2,15 @@
   "$schema": "https://turborepo.org/schema.json",
   "tasks": {
     "build": {
+      "dependsOn": ["^build"],
+      "inputs": ["src/**"],
       "outputs": ["dist/**"],
       "outputLogs": "new-only"
     },
     "test": {
+      "dependsOn": ["^test", "build"],
+      "inputs": ["src/**"],
+      "outputs": ["dist/**"],
       "outputLogs": "new-only"
     }
   }

--- a/.npm/turbo.json
+++ b/.npm/turbo.json
@@ -1,12 +1,12 @@
 {
   "$schema": "https://turborepo.org/schema.json",
-  "pipeline": {
+  "tasks": {
     "build": {
       "outputs": ["dist/**"],
-      "outputMode": "new-only"
+      "outputLogs": "new-only"
     },
     "test": {
-      "outputMode": "new-only"
+      "outputLogs": "new-only"
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- [#835](https://github.com/FuelLabs/fuel-vm/pull/835): Fixing WASM-NPM packaging and publishing
+
 ## [Version 0.57.0]
 
 ### Added


### PR DESCRIPTION
The generated WASM/JS code changed in v`0.57.0`, and the regexes used to patch it stopped working.

This prevented dependent NPM packages, including the TS SDK and all apps using it, from building.

```
Error: Can't resolve 'fuel_asm_bg.wasm' in '/.../fuels-ts/node_modules/.pnpm/@fuels+vm-asm@0.57.0/node_modules/@fuels/vm-asm/dist/web'
```

This PR fixes those regexes and updates the essential tools used for packaging.


### Before requesting review
- [x] I have reviewed the code myself