### PR TITLE
Implemented `AsRef<[u8]>` and `TryFrom<&[u8]>` for DA compression types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- [#838](https://github.com/FuelLabs/fuel-vm/pull/838): Implemented `AsRef<[u8]>` and `TryFrom<&[u8]>` for DA compression types: ScriptCode, PredicateCode, RegistryKey.
+
 ### Fixed
 - [#835](https://github.com/FuelLabs/fuel-vm/pull/835): Fixing WASM-NPM packaging and publishing
 

--- a/fuel-compression/src/key.rs
+++ b/fuel-compression/src/key.rs
@@ -38,6 +38,7 @@ impl RegistryKey {
         }
     }
 }
+
 impl TryFrom<u32> for RegistryKey {
     type Error = &'static str;
 
@@ -50,6 +51,26 @@ impl TryFrom<u32> for RegistryKey {
         let mut bytes = [0u8; 3];
         bytes.copy_from_slice(&v[1..]);
         Ok(Self(bytes))
+    }
+}
+
+impl TryFrom<&[u8]> for RegistryKey {
+    type Error = &'static str;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        if value.len() != Self::SIZE {
+            return Err("RegistryKey must be 3 bytes long");
+        }
+
+        let mut bytes = [0u8; 3];
+        bytes.copy_from_slice(value);
+        Ok(Self(bytes))
+    }
+}
+
+impl AsRef<[u8]> for RegistryKey {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
     }
 }
 

--- a/fuel-tx/src/transaction/types/input/predicate.rs
+++ b/fuel-tx/src/transaction/types/input/predicate.rs
@@ -16,11 +16,33 @@ pub struct PredicateCode {
     #[derivative(Debug(format_with = "fmt_truncated_hex::<16>"))]
     pub bytes: Vec<u8>,
 }
+
 impl From<Vec<u8>> for PredicateCode {
     fn from(bytes: Vec<u8>) -> Self {
         Self { bytes }
     }
 }
+
+impl From<&[u8]> for PredicateCode {
+    fn from(bytes: &[u8]) -> Self {
+        Self {
+            bytes: bytes.to_vec(),
+        }
+    }
+}
+
+impl AsRef<[u8]> for PredicateCode {
+    fn as_ref(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+impl AsMut<[u8]> for PredicateCode {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.bytes
+    }
+}
+
 impl Deref for PredicateCode {
     type Target = Vec<u8>;
 
@@ -28,6 +50,7 @@ impl Deref for PredicateCode {
         &self.bytes
     }
 }
+
 impl DerefMut for PredicateCode {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.bytes

--- a/fuel-tx/src/transaction/types/script.rs
+++ b/fuel-tx/src/transaction/types/script.rs
@@ -59,11 +59,33 @@ pub struct ScriptCode {
     #[derivative(Debug(format_with = "fmt_truncated_hex::<16>"))]
     pub bytes: Vec<u8>,
 }
+
 impl From<Vec<u8>> for ScriptCode {
     fn from(bytes: Vec<u8>) -> Self {
         Self { bytes }
     }
 }
+
+impl From<&[u8]> for ScriptCode {
+    fn from(bytes: &[u8]) -> Self {
+        Self {
+            bytes: bytes.to_vec(),
+        }
+    }
+}
+
+impl AsRef<[u8]> for ScriptCode {
+    fn as_ref(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+impl AsMut<[u8]> for ScriptCode {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.bytes
+    }
+}
+
 impl Deref for ScriptCode {
     type Target = Vec<u8>;
 
@@ -71,6 +93,7 @@ impl Deref for ScriptCode {
         &self.bytes
     }
 }
+
 impl DerefMut for ScriptCode {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.bytes


### PR DESCRIPTION
Implemented `AsRef<[u8]>` and `TryFrom<&[u8]>` for DA compression types: ScriptCode, PredicateCode, RegistryKey. It allows to use `Raw` codec in the `fuel-core`

### Before requesting review
- [x] I have reviewed the code myself