### PR TITLE
Release v0.57.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.57.1]
+
 ### Fixed
 - [#835](https://github.com/FuelLabs/fuel-vm/pull/835): Fixing WASM-NPM packaging and publishing
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,18 +18,18 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.57.0"
+version = "0.57.1"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.57.0", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.57.0", path = "fuel-crypto", default-features = false }
-fuel-compression = { version = "0.57.0", path = "fuel-compression", default-features = false }
-fuel-derive = { version = "0.57.0", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.57.0", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.57.0", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.57.0", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.57.0", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.57.0", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.57.1", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.57.1", path = "fuel-crypto", default-features = false }
+fuel-compression = { version = "0.57.1", path = "fuel-compression", default-features = false }
+fuel-derive = { version = "0.57.1", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.57.1", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.57.1", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.57.1", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.57.1", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.57.1", path = "fuel-vm", default-features = false }
 bitflags = "2"
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
## Version v0.57.1

### Fixed
- [#835](https://github.com/FuelLabs/fuel-vm/pull/835): Fixing WASM-NPM packaging and publishing

## What's Changed
* Fixing WASM-NPM packaging and publishing by @arboleya in https://github.com/FuelLabs/fuel-vm/pull/835


**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.57.0...v0.57.1