### PR TITLE
Remove `serde` feature from the `fuel-tx` crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           - command: check
             args: --target wasm32-unknown-unknown -p fuel-crypto --no-default-features
           - command: check
-            args: --target wasm32-unknown-unknown -p fuel-tx --features serde --no-default-features
+            args: --target wasm32-unknown-unknown -p fuel-tx --features alloc --no-default-features
           - command: check
             args: --target wasm32-unknown-unknown -p fuel-types --features serde --no-default-features
           - command: rustc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - [#838](https://github.com/FuelLabs/fuel-vm/pull/838): Implemented `AsRef<[u8]>` and `TryFrom<&[u8]>` for DA compression types: ScriptCode, PredicateCode, RegistryKey.
 
+### Removed
+
+#### Breaking
+- [#843](https://github.com/FuelLabs/fuel-vm/pull/843): Remove `serde` feature from the `fuel-tx` crate. It is default behaviour now if you enable `alloc` feature.
+
 ### Fixed
 - [#835](https://github.com/FuelLabs/fuel-vm/pull/835): Fixing WASM-NPM packaging and publishing
 

--- a/ci_checks.sh
+++ b/ci_checks.sh
@@ -25,7 +25,7 @@ cargo check --all-targets --all-features &&
 cargo check --target thumbv6m-none-eabi -p fuel-asm -p fuel-storage -p fuel-merkle --no-default-features &&
 cargo check --target wasm32-unknown-unknown -p fuel-crypto --no-default-features &&
 cargo check --target wasm32-unknown-unknown -p fuel-types --features serde --no-default-features &&
-cargo check --target wasm32-unknown-unknown -p fuel-tx --features serde --no-default-features &&
+cargo check --target wasm32-unknown-unknown -p fuel-tx --features alloc --no-default-features &&
 cargo check --target wasm32-unknown-unknown -p fuel-vm --features alloc --no-default-features &&
 cargo rustc --target wasm32-unknown-unknown -p fuel-types --features typescript --crate-type=cdylib &&
 cargo rustc --target wasm32-unknown-unknown -p fuel-asm --features typescript --crate-type=cdylib &&

--- a/fuel-tx/Cargo.toml
+++ b/fuel-tx/Cargo.toml
@@ -14,11 +14,11 @@ description = "FuelVM transaction."
 bitflags = { workspace = true, features = ["serde"], optional = true }
 derivative = { version = "2.2.0", default-features = false, features = ["use_core"], optional = true }
 derive_more = { version = "0.99", default-features = false, features = ["display"], optional = true }
-fuel-asm = { workspace = true, default-features = false, features = ["serde"] }
+fuel-asm = { workspace = true, default-features = false }
 fuel-compression = { workspace = true, optional = true }
 fuel-crypto = { workspace = true, default-features = false }
 fuel-merkle = { workspace = true, default-features = false, optional = true }
-fuel-types = { workspace = true, default-features = false, features = ["serde"] }
+fuel-types = { workspace = true, default-features = false }
 hashbrown = { version = "0.14", optional = true }
 itertools = { version = "0.10", default-features = false, optional = true }
 js-sys = { version = "0.3", optional = true }
@@ -55,7 +55,7 @@ internals = []
 typescript = ["dep:serde_json", "alloc", "js-sys", "wasm-bindgen", "serde-wasm-bindgen", "fuel-types/typescript"]
 random = ["fuel-crypto/random", "fuel-types/random", "rand"]
 std = ["alloc", "fuel-asm/std", "fuel-crypto/std", "fuel-merkle/std", "fuel-types/std", "itertools/default", "rand?/default", "serde/default", "hex/std"]
-alloc = ["hashbrown", "fuel-types/alloc", "itertools/use_alloc", "derivative", "fuel-merkle", "strum", "strum_macros", "bitflags", "postcard", "derive_more"]
+alloc = ["hashbrown", "fuel-types/alloc", "itertools/use_alloc", "derivative", "fuel-merkle", "strum", "strum_macros", "bitflags", "postcard", "derive_more", "fuel-asm/serde", "fuel-types/serde"]
 da-compression = ["fuel-compression"]
 
 [lints.rust]

--- a/fuel-tx/Cargo.toml
+++ b/fuel-tx/Cargo.toml
@@ -11,10 +11,10 @@ repository = { workspace = true }
 description = "FuelVM transaction."
 
 [dependencies]
-bitflags = { workspace = true }
+bitflags = { workspace = true, features = ["serde"], optional = true }
 derivative = { version = "2.2.0", default-features = false, features = ["use_core"], optional = true }
-derive_more = { version = "0.99", default-features = false, features = ["display"] }
-fuel-asm = { workspace = true, default-features = false }
+derive_more = { version = "0.99", default-features = false, features = ["display"], optional = true }
+fuel-asm = { workspace = true, default-features = false, features = ["serde"] }
 fuel-compression = { workspace = true, optional = true }
 fuel-crypto = { workspace = true, default-features = false }
 fuel-merkle = { workspace = true, default-features = false, optional = true }
@@ -22,7 +22,7 @@ fuel-types = { workspace = true, default-features = false, features = ["serde"] 
 hashbrown = { version = "0.14", optional = true }
 itertools = { version = "0.10", default-features = false, optional = true }
 js-sys = { version = "0.3", optional = true }
-postcard = { version = "1.0", features = ["alloc"] }
+postcard = { version = "1.0", features = ["alloc"], optional = true }
 rand = { version = "0.8", default-features = false, features = ["std_rng"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde-wasm-bindgen = { version = "0.6", optional = true }
@@ -35,7 +35,7 @@ wasm-bindgen = { version = "0.2.88", optional = true }
 bimap = "0.6"
 bincode = { workspace = true }
 fuel-crypto = { workspace = true, default-features = false, features = ["random"] }
-fuel-tx = { path = ".", features = ["random", "serde", "test-helpers"] }
+fuel-tx = { path = ".", features = ["random", "test-helpers", "da-compression"] }
 fuel-types = { workspace = true, default-features = false, features = ["random"] }
 hex = { version = "0.4", default-features = false }
 insta = "1.0"
@@ -52,13 +52,11 @@ tokio = { version = "1.27", features = ["full"] }
 default = ["fuel-asm/default", "fuel-crypto/default", "fuel-merkle/default", "fuel-types/default", "std"]
 test-helpers = ["alloc", "internals"]
 internals = []
-typescript = ["alloc", "js-sys", "wasm-bindgen", "serde", "serde-wasm-bindgen", "fuel-types/typescript"]
+typescript = ["dep:serde_json", "alloc", "js-sys", "wasm-bindgen", "serde-wasm-bindgen", "fuel-types/typescript"]
 random = ["fuel-crypto/random", "fuel-types/random", "rand"]
 std = ["alloc", "fuel-asm/std", "fuel-crypto/std", "fuel-merkle/std", "fuel-types/std", "itertools/default", "rand?/default", "serde/default", "hex/std"]
-alloc = ["hashbrown", "fuel-types/alloc", "itertools/use_alloc", "derivative", "fuel-merkle", "strum", "strum_macros"]
-# serde is requiring alloc because its mandatory for serde_json. to avoid adding a new feature only for serde_json, we just require `alloc` here since as of the moment we don't have a use case of serde without alloc.
-serde = ["alloc", "fuel-asm/serde", "fuel-crypto/serde", "fuel-merkle/serde", "serde_json", "hashbrown/serde", "bitflags/serde"]
-da-compression = ["serde", "fuel-compression"]
+alloc = ["hashbrown", "fuel-types/alloc", "itertools/use_alloc", "derivative", "fuel-merkle", "strum", "strum_macros", "bitflags", "postcard", "derive_more"]
+da-compression = ["fuel-compression"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }

--- a/fuel-tx/src/contract.rs
+++ b/fuel-tx/src/contract.rs
@@ -36,8 +36,12 @@ const MULTIPLE: usize = 8;
 
 #[derive(Default, Derivative, Clone, PartialEq, Eq, Hash)]
 #[derivative(Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
+#[derive(
+    serde::Serialize,
+    serde::Deserialize,
+    fuel_types::canonical::Deserialize,
+    fuel_types::canonical::Serialize,
+)]
 /// Deployable representation of a contract code.
 pub struct Contract(
     #[derivative(Debug(format_with = "fmt_truncated_hex::<16>"))] Vec<u8>,

--- a/fuel-tx/src/receipt.rs
+++ b/fuel-tx/src/receipt.rs
@@ -24,9 +24,9 @@ mod script_result;
 use crate::input::message::compute_message_id;
 pub use script_result::ScriptExecutionResult;
 
-#[derive(Clone, Derivative)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Deserialize, Serialize)]
+#[derive(
+    Clone, Derivative, serde::Serialize, serde::Deserialize, Deserialize, Serialize,
+)]
 #[derivative(Eq, PartialEq, Hash, Debug)]
 pub enum Receipt {
     Call {

--- a/fuel-tx/src/receipt/script_result.rs
+++ b/fuel-tx/src/receipt/script_result.rs
@@ -1,8 +1,17 @@
 use fuel_types::Word;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+    fuel_types::canonical::Deserialize,
+    fuel_types::canonical::Serialize,
+)]
 #[repr(u64)]
 pub enum ScriptExecutionResult {
     Success,

--- a/fuel-tx/src/tests/mod.rs
+++ b/fuel-tx/src/tests/mod.rs
@@ -3,19 +3,7 @@
 mod offset;
 mod valid_cases;
 
-#[cfg(feature = "serde")]
 mod bytes;
 #[cfg(feature = "da-compression")]
 mod da_compression;
-#[cfg(feature = "serde")]
 mod display;
-
-#[cfg(not(feature = "serde"))]
-use bincode as _;
-
-#[cfg(not(feature = "da-compression"))]
-use bimap as _;
-#[cfg(not(feature = "da-compression"))]
-use pretty_assertions as _;
-#[cfg(not(feature = "da-compression"))]
-use tokio as _;

--- a/fuel-tx/src/transaction.rs
+++ b/fuel-tx/src/transaction.rs
@@ -92,8 +92,16 @@ pub use id::{
 pub type TxId = Bytes32;
 
 /// The fuel transaction entity <https://github.com/FuelLabs/fuel-specs/blob/master/src/tx-format/transaction.md>.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, strum_macros::EnumCount)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    strum_macros::EnumCount,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 #[cfg_attr(
     feature = "da-compression",
     derive(fuel_compression::Compress, fuel_compression::Decompress)
@@ -339,7 +347,7 @@ impl Transaction {
     /// transaction because all of its attributes are trivially serialized.
     ///
     /// If an error happens, a JSON string with the error description will be returned
-    #[cfg(all(feature = "serde", feature = "alloc"))]
+    #[cfg(test)]
     pub fn to_json(&self) -> alloc::string::String {
         serde_json::to_string(self)
             .unwrap_or_else(|e| alloc::format!(r#"{{"error": "{e}"}}"#))
@@ -347,7 +355,7 @@ impl Transaction {
 
     /// Attempt to deserialize a transaction from a JSON string, returning `None` if it
     /// fails
-    #[cfg(all(feature = "serde", feature = "alloc"))]
+    #[cfg(test)]
     pub fn from_json<J>(json: J) -> Option<Self>
     where
         J: AsRef<str>,
@@ -1094,44 +1102,46 @@ pub mod typescript {
     };
     use fuel_types::Bytes32;
 
-    #[derive(Debug, Clone, Eq, Hash, PartialEq)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(Debug, Clone, Eq, Hash, PartialEq, serde::Serialize, serde::Deserialize)]
     #[wasm_bindgen]
     pub struct Transaction(#[wasm_bindgen(skip)] pub Box<crate::Transaction>);
 
-    #[derive(Default, Debug, Clone, Eq, Hash, PartialEq)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(
+        Default, Debug, Clone, Eq, Hash, PartialEq, serde::Serialize, serde::Deserialize,
+    )]
     #[wasm_bindgen]
     pub struct Create(#[wasm_bindgen(skip)] pub Box<crate::Create>);
 
-    #[derive(Default, Debug, Clone, Eq, Hash, PartialEq)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(
+        Default, Debug, Clone, Eq, Hash, PartialEq, serde::Serialize, serde::Deserialize,
+    )]
     #[wasm_bindgen]
     pub struct Script(#[wasm_bindgen(skip)] pub Box<crate::Script>);
 
-    #[derive(Default, Debug, Clone, Eq, Hash, PartialEq)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(
+        Default, Debug, Clone, Eq, Hash, PartialEq, serde::Serialize, serde::Deserialize,
+    )]
     #[wasm_bindgen]
     pub struct Mint(#[wasm_bindgen(skip)] pub Box<crate::Mint>);
 
-    #[derive(Default, Debug, Clone, Eq, Hash, PartialEq)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(
+        Default, Debug, Clone, Eq, Hash, PartialEq, serde::Serialize, serde::Deserialize,
+    )]
     #[wasm_bindgen]
     pub struct Upgrade(#[wasm_bindgen(skip)] pub Box<crate::Upgrade>);
 
-    #[derive(Debug, Clone, Eq, Hash, PartialEq)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(Debug, Clone, Eq, Hash, PartialEq, serde::Serialize, serde::Deserialize)]
     #[wasm_bindgen]
     pub struct UpgradePurpose(#[wasm_bindgen(skip)] pub Box<crate::UpgradePurpose>);
 
-    #[derive(Default, Debug, Clone, Eq, Hash, PartialEq)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(
+        Default, Debug, Clone, Eq, Hash, PartialEq, serde::Serialize, serde::Deserialize,
+    )]
     #[wasm_bindgen]
     pub struct Upload(#[wasm_bindgen(skip)] pub Box<crate::Upload>);
 
     #[wasm_bindgen]
     impl Transaction {
-        #[cfg(feature = "serde")]
         #[wasm_bindgen(js_name = toJSON)]
         pub fn to_json(&self) -> String {
             serde_json::to_string(&self.0).expect("unable to json format")
@@ -1292,7 +1302,6 @@ pub mod typescript {
                     <$t>::default()
                 }
 
-                #[cfg(feature = "serde")]
                 #[wasm_bindgen(js_name = toJSON)]
                 pub fn to_json(&self) -> String {
                     serde_json::to_string(&self).expect("unable to json format")

--- a/fuel-tx/src/transaction/consensus_parameters/gas.rs
+++ b/fuel-tx/src/transaction/consensus_parameters/gas.rs
@@ -1181,10 +1181,10 @@ pub struct GasCostsValuesV1 {
     pub lw: Word,
     pub mint: Word,
     pub mlog: Word,
-    #[cfg_attr(feature = "serde", serde(rename = "mod"))]
+    #[serde(rename = "mod")]
     pub mod_op: Word,
     pub modi: Word,
-    #[cfg_attr(feature = "serde", serde(rename = "move"))]
+    #[serde(rename = "move")]
     pub move_op: Word,
     pub movi: Word,
     pub mroo: Word,
@@ -1199,9 +1199,9 @@ pub struct GasCostsValuesV1 {
     pub popl: Word,
     pub pshh: Word,
     pub pshl: Word,
-    #[cfg_attr(feature = "serde", serde(rename = "ret_contract"))]
+    #[serde(rename = "ret_contract")]
     pub ret: Word,
-    #[cfg_attr(feature = "serde", serde(rename = "rvrt_contract"))]
+    #[serde(rename = "rvrt_contract")]
     pub rvrt: Word,
     pub sb: Word,
     pub sll: Word,
@@ -1246,7 +1246,7 @@ pub struct GasCostsValuesV1 {
     pub mcp: DependentCost,
     pub mcpi: DependentCost,
     pub meq: DependentCost,
-    #[cfg_attr(feature = "serde", serde(rename = "retd_contract"))]
+    #[serde(rename = "retd_contract")]
     pub retd: DependentCost,
     pub s256: DependentCost,
     pub scwq: DependentCost,
@@ -1308,10 +1308,10 @@ pub struct GasCostsValuesV2 {
     pub lw: Word,
     pub mint: Word,
     pub mlog: Word,
-    #[cfg_attr(feature = "serde", serde(rename = "mod"))]
+    #[serde(rename = "mod")]
     pub mod_op: Word,
     pub modi: Word,
-    #[cfg_attr(feature = "serde", serde(rename = "move"))]
+    #[serde(rename = "move")]
     pub move_op: Word,
     pub movi: Word,
     pub mroo: Word,
@@ -1326,9 +1326,9 @@ pub struct GasCostsValuesV2 {
     pub popl: Word,
     pub pshh: Word,
     pub pshl: Word,
-    #[cfg_attr(feature = "serde", serde(rename = "ret_contract"))]
+    #[serde(rename = "ret_contract")]
     pub ret: Word,
-    #[cfg_attr(feature = "serde", serde(rename = "rvrt_contract"))]
+    #[serde(rename = "rvrt_contract")]
     pub rvrt: Word,
     pub sb: Word,
     pub sll: Word,
@@ -1374,7 +1374,7 @@ pub struct GasCostsValuesV2 {
     pub mcp: DependentCost,
     pub mcpi: DependentCost,
     pub meq: DependentCost,
-    #[cfg_attr(feature = "serde", serde(rename = "retd_contract"))]
+    #[serde(rename = "retd_contract")]
     pub retd: DependentCost,
     pub s256: DependentCost,
     pub scwq: DependentCost,
@@ -1436,10 +1436,10 @@ pub struct GasCostsValuesV3 {
     pub lw: Word,
     pub mint: Word,
     pub mlog: Word,
-    #[cfg_attr(feature = "serde", serde(rename = "mod"))]
+    #[serde(rename = "mod")]
     pub mod_op: Word,
     pub modi: Word,
-    #[cfg_attr(feature = "serde", serde(rename = "move"))]
+    #[serde(rename = "move")]
     pub move_op: Word,
     pub movi: Word,
     pub mroo: Word,
@@ -1454,9 +1454,9 @@ pub struct GasCostsValuesV3 {
     pub popl: Word,
     pub pshh: Word,
     pub pshl: Word,
-    #[cfg_attr(feature = "serde", serde(rename = "ret_contract"))]
+    #[serde(rename = "ret_contract")]
     pub ret: Word,
-    #[cfg_attr(feature = "serde", serde(rename = "rvrt_contract"))]
+    #[serde(rename = "rvrt_contract")]
     pub rvrt: Word,
     pub sb: Word,
     pub sll: Word,
@@ -1504,7 +1504,7 @@ pub struct GasCostsValuesV3 {
     pub mcp: DependentCost,
     pub mcpi: DependentCost,
     pub meq: DependentCost,
-    #[cfg_attr(feature = "serde", serde(rename = "retd_contract"))]
+    #[serde(rename = "retd_contract")]
     pub retd: DependentCost,
     pub s256: DependentCost,
     pub scwq: DependentCost,
@@ -1565,10 +1565,10 @@ pub struct GasCostsValuesV4 {
     pub lw: Word,
     pub mint: Word,
     pub mlog: Word,
-    #[cfg_attr(feature = "serde", serde(rename = "mod"))]
+    #[serde(rename = "mod")]
     pub mod_op: Word,
     pub modi: Word,
-    #[cfg_attr(feature = "serde", serde(rename = "move"))]
+    #[serde(rename = "move")]
     pub move_op: Word,
     pub movi: Word,
     pub mroo: Word,
@@ -1583,9 +1583,9 @@ pub struct GasCostsValuesV4 {
     pub popl: Word,
     pub pshh: Word,
     pub pshl: Word,
-    #[cfg_attr(feature = "serde", serde(rename = "ret_contract"))]
+    #[serde(rename = "ret_contract")]
     pub ret: Word,
-    #[cfg_attr(feature = "serde", serde(rename = "rvrt_contract"))]
+    #[serde(rename = "rvrt_contract")]
     pub rvrt: Word,
     pub sb: Word,
     pub sll: Word,
@@ -1636,7 +1636,7 @@ pub struct GasCostsValuesV4 {
     pub mcp: DependentCost,
     pub mcpi: DependentCost,
     pub meq: DependentCost,
-    #[cfg_attr(feature = "serde", serde(rename = "retd_contract"))]
+    #[serde(rename = "retd_contract")]
     pub retd: DependentCost,
     pub s256: DependentCost,
     pub scwq: DependentCost,

--- a/fuel-tx/src/transaction/fee.rs
+++ b/fuel-tx/src/transaction/fee.rs
@@ -26,8 +26,19 @@ use fuel_asm::Word;
 use fuel_types::canonical::Serialize;
 use hashbrown::HashSet;
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 pub struct TransactionFee {
     pub(crate) min_fee: Word,
     pub(crate) max_fee: Word,

--- a/fuel-tx/src/transaction/policies.rs
+++ b/fuel-tx/src/transaction/policies.rs
@@ -23,7 +23,7 @@ use rand::{
 bitflags::bitflags! {
     /// See https://github.com/FuelLabs/fuel-specs/blob/master/src/tx-format/policy.md#policy
     #[derive(Clone, Copy, Default, Debug, PartialEq, Eq, Hash)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(serde::Serialize, serde::Deserialize)]
     pub struct PoliciesBits: u32 {
         /// If set, the gas price is present in the policies.
         const Tip = 1 << 0;
@@ -72,8 +72,9 @@ where
     Hash,
     strum_macros::EnumCount,
     strum_macros::EnumIter,
+    serde::Serialize,
+    serde::Deserialize,
 )]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PolicyType {
     Tip,
     WitnessLimit,
@@ -105,8 +106,9 @@ impl PolicyType {
 pub const POLICIES_NUMBER: usize = PoliciesBits::all().bits().count_ones() as usize;
 
 /// Container for managing policies.
-#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Clone, Copy, Default, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
+)]
 #[cfg_attr(
     feature = "da-compression",
     derive(fuel_compression::Compress, fuel_compression::Decompress)
@@ -325,7 +327,6 @@ pub mod typescript {
             Policies::default()
         }
 
-        #[cfg(feature = "serde")]
         #[wasm_bindgen(js_name = toJSON)]
         pub fn to_json(&self) -> String {
             serde_json::to_string(&self).expect("unable to json format")

--- a/fuel-tx/src/transaction/repr.rs
+++ b/fuel-tx/src/transaction/repr.rs
@@ -1,8 +1,16 @@
 use crate::Transaction;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(fuel_types::canonical::Serialize, fuel_types::canonical::Deserialize)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+    fuel_types::canonical::Serialize,
+    fuel_types::canonical::Deserialize,
+)]
 #[repr(u64)]
 pub enum TransactionRepr {
     Script = 0x00,

--- a/fuel-tx/src/transaction/types/blob.rs
+++ b/fuel-tx/src/transaction/types/blob.rs
@@ -45,8 +45,7 @@ pub type Blob = ChargeableTransaction<BlobBody, BlobMetadata>;
 pub struct BlobMetadata;
 
 /// The body of the [`Blob`] transaction.
-#[derive(Clone, Default, Derivative)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Default, Derivative, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(
     feature = "da-compression",
     derive(fuel_compression::Compress, fuel_compression::Decompress)

--- a/fuel-tx/src/transaction/types/chargeable_transaction.rs
+++ b/fuel-tx/src/transaction/types/chargeable_transaction.rs
@@ -76,7 +76,7 @@ impl<T> BodyConstraints for T {}
 
 #[derive(Clone, Derivative)]
 #[derivative(Eq, PartialEq, Hash, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[cfg_attr(
     feature = "da-compression",
     derive(fuel_compression::Compress, fuel_compression::Decompress)
@@ -92,7 +92,7 @@ where
     pub(crate) inputs: Vec<Input>,
     pub(crate) outputs: Vec<Output>,
     pub(crate) witnesses: Vec<Witness>,
-    #[cfg_attr(feature = "serde", serde(skip))]
+    #[serde(skip)]
     #[cfg_attr(feature = "da-compression", compress(skip))]
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     #[canonical(skip)]

--- a/fuel-tx/src/transaction/types/create.rs
+++ b/fuel-tx/src/transaction/types/create.rs
@@ -69,8 +69,7 @@ impl CreateMetadata {
     }
 }
 
-#[derive(Default, Debug, Clone, Derivative)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Default, Debug, Clone, Derivative, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(
     feature = "da-compression",
     derive(fuel_compression::Compress, fuel_compression::Decompress)

--- a/fuel-tx/src/transaction/types/input.rs
+++ b/fuel-tx/src/transaction/types/input.rs
@@ -68,8 +68,7 @@ where
 }
 
 /// The empty field used by sub-types of the specification.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(
     feature = "da-compression",
     derive(fuel_compression::Compress, fuel_compression::Decompress)
@@ -222,8 +221,16 @@ impl AsFieldFmt for PredicateCode {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, strum_macros::EnumCount)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    strum_macros::EnumCount,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 #[cfg_attr(
     feature = "da-compression",
     derive(fuel_compression::Compress, fuel_compression::Decompress)
@@ -948,14 +955,12 @@ pub mod typescript {
         vec::Vec,
     };
 
-    #[derive(Clone, Eq, Hash, PartialEq)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(Clone, Eq, Hash, PartialEq, serde::Serialize, serde::Deserialize)]
     #[wasm_bindgen]
     pub struct Input(#[wasm_bindgen(skip)] pub Box<crate::Input>);
 
     #[wasm_bindgen]
     impl Input {
-        #[cfg(feature = "serde")]
         #[wasm_bindgen(js_name = toJSON)]
         pub fn to_json(&self) -> String {
             serde_json::to_string(&self.0).expect("unable to json format")

--- a/fuel-tx/src/transaction/types/input/coin.rs
+++ b/fuel-tx/src/transaction/types/input/coin.rs
@@ -77,8 +77,9 @@ pub trait CoinSpecification: private::Seal {
     type PredicateGasUsed: AsField<Word>;
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Default, Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
+)]
 #[cfg_attr(
     feature = "da-compression",
     derive(fuel_compression::Compress, fuel_compression::Decompress)
@@ -92,8 +93,9 @@ impl CoinSpecification for Signed {
     type Witness = u16;
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Default, Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
+)]
 #[cfg_attr(
     feature = "da-compression",
     derive(fuel_compression::Compress, fuel_compression::Decompress)
@@ -107,8 +109,9 @@ impl CoinSpecification for Predicate {
     type Witness = Empty<u16>;
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Default, Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
+)]
 pub struct Full;
 
 impl CoinSpecification for Full {
@@ -142,7 +145,7 @@ impl CoinSpecification for Full {
 ///   [`Signed`], else [`Predicate`].
 #[derive(Default, Derivative, Clone, PartialEq, Eq, Hash)]
 #[derivative(Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "da-compression", derive(fuel_compression::Compress))]
 #[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
 pub struct Coin<Specification>

--- a/fuel-tx/src/transaction/types/input/contract.rs
+++ b/fuel-tx/src/transaction/types/input/contract.rs
@@ -12,8 +12,9 @@ use fuel_types::{
 ///
 /// The specification defines the layout of the [`Contract`] in the serialized form for
 /// the `fuel-vm`.
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Default, Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
+)]
 #[cfg_attr(
     feature = "da-compression",
     derive(fuel_compression::Compress, fuel_compression::Decompress)

--- a/fuel-tx/src/transaction/types/input/message.rs
+++ b/fuel-tx/src/transaction/types/input/message.rs
@@ -100,8 +100,9 @@ pub mod specifications {
     /// The type means that the message should be signed by the `recipient`, and the
     /// signature(witness) should be stored under the `witness_index` index in the
     /// `witnesses` vector of the [`crate::Transaction`].
-    #[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(
+        Default, Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
+    )]
     #[cfg_attr(
         feature = "da-compression",
         derive(fuel_compression::Compress, fuel_compression::Decompress)
@@ -110,8 +111,9 @@ pub mod specifications {
 
     /// The type means that the message is not signed, and the `owner` is a `predicate`
     /// bytecode. The merkle root from the `predicate` should be equal to the `owner`.
-    #[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(
+        Default, Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
+    )]
     #[cfg_attr(
         feature = "da-compression",
         derive(fuel_compression::Compress, fuel_compression::Decompress)
@@ -123,8 +125,9 @@ pub mod specifications {
     /// non-zero `value` that will be transferred to the contract as a native asset
     /// during the execution. If the execution of the transaction fails, the metadata
     /// is not consumed and can be used later until successful execution.
-    #[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(
+        Default, Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
+    )]
     pub struct MessageData<UsageRules>(core::marker::PhantomData<UsageRules>);
 
     impl MessageSpecification for MessageData<Signed> {
@@ -144,8 +147,9 @@ pub mod specifications {
     }
 
     /// The spendable message acts as a standard coin.
-    #[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(
+        Default, Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
+    )]
     pub struct MessageCoin<UsageRules>(core::marker::PhantomData<UsageRules>);
 
     impl MessageSpecification for MessageCoin<Signed> {
@@ -170,8 +174,9 @@ pub mod specifications {
     /// Otherwise into [`MessageCoin`].
     /// If the `predicate` is empty, the usage rules should be [`Signed`], else
     /// [`Predicate`].
-    #[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(
+        Default, Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
+    )]
     pub struct Full;
 
     impl MessageSpecification for Full {
@@ -202,7 +207,7 @@ pub mod specifications {
 /// - [`specifications::Full`].
 #[derive(Default, Derivative, Clone, PartialEq, Eq, Hash)]
 #[derivative(Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "da-compression", derive(fuel_compression::Compress))]
 #[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
 pub struct Message<Specification>

--- a/fuel-tx/src/transaction/types/input/predicate.rs
+++ b/fuel-tx/src/transaction/types/input/predicate.rs
@@ -7,9 +7,8 @@ use fuel_types::fmt_truncated_hex;
 
 use alloc::vec::Vec;
 
-#[derive(Clone, Default, Derivative)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(transparent))]
+#[derive(Clone, Default, Derivative, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
 #[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
 #[derivative(Eq, PartialEq, Hash, Debug)]
 pub struct PredicateCode {

--- a/fuel-tx/src/transaction/types/mint.rs
+++ b/fuel-tx/src/transaction/types/mint.rs
@@ -47,8 +47,7 @@ impl MintMetadata {
 ///
 /// This transaction can be created by the block producer and included in the block only
 /// by it.
-#[derive(Default, Debug, Clone, Derivative)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Default, Debug, Clone, Derivative, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "da-compression", derive(fuel_compression::Compress))]
 #[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
 #[canonical(prefix = TransactionRepr::Mint)]
@@ -67,7 +66,7 @@ pub struct Mint {
     pub(crate) mint_asset_id: AssetId,
     /// Gas Price used for current block
     pub(crate) gas_price: Word,
-    #[cfg_attr(feature = "serde", serde(skip))]
+    #[serde(skip)]
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     #[canonical(skip)]
     #[cfg_attr(feature = "da-compression", compress(skip))]

--- a/fuel-tx/src/transaction/types/output.rs
+++ b/fuel-tx/src/transaction/types/output.rs
@@ -19,8 +19,17 @@ mod repr;
 use contract::Contract;
 pub use repr::OutputRepr;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, strum_macros::EnumCount)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    strum_macros::EnumCount,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 #[cfg_attr(
     feature = "da-compression",
     derive(fuel_compression::Compress, fuel_compression::Decompress)
@@ -253,14 +262,12 @@ pub mod typescript {
         vec::Vec,
     };
 
-    #[derive(Clone, Eq, Hash, PartialEq)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(Clone, Eq, Hash, PartialEq, serde::Serialize, serde::Deserialize)]
     #[wasm_bindgen]
     pub struct Output(#[wasm_bindgen(skip)] pub Box<crate::Output>);
 
     #[wasm_bindgen]
     impl Output {
-        #[cfg(feature = "serde")]
         #[wasm_bindgen(js_name = toJSON)]
         pub fn to_json(&self) -> String {
             serde_json::to_string(&self.0).expect("unable to json format")

--- a/fuel-tx/src/transaction/types/output/contract.rs
+++ b/fuel-tx/src/transaction/types/output/contract.rs
@@ -5,8 +5,9 @@ use fuel_types::Bytes32;
 ///
 /// The specification defines the layout of the [`Contract`] in the serialized form for
 /// the `fuel-vm`.
-#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Default, Debug, Copy, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
+)]
 #[cfg_attr(
     feature = "da-compression",
     derive(fuel_compression::Compress, fuel_compression::Decompress)

--- a/fuel-tx/src/transaction/types/script.rs
+++ b/fuel-tx/src/transaction/types/script.rs
@@ -50,9 +50,8 @@ pub struct ScriptMetadata {
     pub script_data_offset: usize,
 }
 
-#[derive(Clone, Default, Derivative)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(transparent))]
+#[derive(Clone, Default, Derivative, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
 #[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
 #[derivative(Eq, PartialEq, Hash, Debug)]
 pub struct ScriptCode {
@@ -105,9 +104,14 @@ impl fuel_compression::Compressible for ScriptCode {
     type Compressed = fuel_compression::RegistryKey;
 }
 
-#[derive(Clone, Derivative)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
+#[derive(
+    Clone,
+    Derivative,
+    serde::Serialize,
+    serde::Deserialize,
+    fuel_types::canonical::Deserialize,
+    fuel_types::canonical::Serialize,
+)]
 #[cfg_attr(
     feature = "da-compression",
     derive(fuel_compression::Compress, fuel_compression::Decompress)

--- a/fuel-tx/src/transaction/types/storage.rs
+++ b/fuel-tx/src/transaction/types/storage.rs
@@ -17,8 +17,9 @@ use rand::{
 
 use core::cmp::Ordering;
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Debug, Default, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
+)]
 #[cfg_attr(
     feature = "da-compression",
     derive(fuel_compression::Compress, fuel_compression::Decompress)

--- a/fuel-tx/src/transaction/types/upgrade.rs
+++ b/fuel-tx/src/transaction/types/upgrade.rs
@@ -94,8 +94,9 @@ impl UpgradeMetadata {
 
 /// The types describe the purpose of the upgrade performed by the [`Upgrade`]
 /// transaction.
-#[derive(Copy, Clone, Derivative, strum_macros::EnumCount)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Copy, Clone, Derivative, strum_macros::EnumCount, serde::Serialize, serde::Deserialize,
+)]
 #[cfg_attr(
     feature = "da-compression",
     derive(fuel_compression::Compress, fuel_compression::Decompress)
@@ -124,8 +125,7 @@ pub enum UpgradePurpose {
 }
 
 /// The body of the [`Upgrade`] transaction.
-#[derive(Clone, Derivative)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Derivative, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(
     feature = "da-compression",
     derive(fuel_compression::Compress, fuel_compression::Decompress)

--- a/fuel-tx/src/transaction/types/upload.rs
+++ b/fuel-tx/src/transaction/types/upload.rs
@@ -37,8 +37,7 @@ pub type Upload = ChargeableTransaction<UploadBody, UploadMetadata>;
 pub struct UploadMetadata;
 
 /// The body of the [`Upload`] transaction.
-#[derive(Clone, Default, Derivative)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Default, Derivative, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(
     feature = "da-compression",
     derive(fuel_compression::Compress, fuel_compression::Decompress)
@@ -59,8 +58,9 @@ pub struct UploadBody {
     pub proof_set: Vec<Bytes32>,
 }
 
-#[derive(Clone, Default, Eq, PartialEq, Hash, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Clone, Default, Eq, PartialEq, Hash, Debug, serde::Serialize, serde::Deserialize,
+)]
 pub struct UploadSubsection {
     /// The root of the Merkle tree is created over the bytecode.
     pub root: Bytes32,
@@ -74,8 +74,9 @@ pub struct UploadSubsection {
     pub proof_set: Vec<Bytes32>,
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Copy, Clone, Eq, PartialEq, Hash, Debug, serde::Serialize, serde::Deserialize,
+)]
 pub enum SplitError {
     /// The size of the subsection is too small to fit all subsections into `u16::MAX`.
     SubsectionSizeTooSmall,

--- a/fuel-tx/src/transaction/types/utxo_id.rs
+++ b/fuel-tx/src/transaction/types/utxo_id.rs
@@ -19,8 +19,12 @@ use rand::{
 /// Identification of unspend transaction output.
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "typescript", wasm_bindgen::prelude::wasm_bindgen)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
+#[derive(
+    serde::Serialize,
+    serde::Deserialize,
+    fuel_types::canonical::Deserialize,
+    fuel_types::canonical::Serialize,
+)]
 pub struct UtxoId {
     /// transaction id
     tx_id: TxId,

--- a/fuel-tx/src/transaction/types/witness.rs
+++ b/fuel-tx/src/transaction/types/witness.rs
@@ -25,7 +25,7 @@ use rand::{
 #[derive(Derivative, Default, Clone, PartialEq, Eq, Hash)]
 #[derivative(Debug)]
 #[cfg_attr(feature = "typescript", wasm_bindgen::prelude::wasm_bindgen)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[cfg_attr(
     feature = "da-compression",
     derive(fuel_compression::Compress, fuel_compression::Decompress)
@@ -124,7 +124,6 @@ pub mod typescript {
 
     #[wasm_bindgen]
     impl Witness {
-        #[cfg(feature = "serde")]
         #[wasm_bindgen(js_name = toJSON)]
         pub fn to_json(&self) -> String {
             serde_json::to_string(&self.data).expect("unable to json format")

--- a/fuel-tx/src/transaction/validity/error.rs
+++ b/fuel-tx/src/transaction/validity/error.rs
@@ -6,8 +6,16 @@ use fuel_types::{
 };
 
 /// The error returned during the checking of the transaction's validity rules.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, derive_more::Display)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    derive_more::Display,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 #[non_exhaustive]
 pub enum ValidityError {
     /// The actual and calculated metadata of the transaction mismatch.

--- a/fuel-tx/src/tx_pointer.rs
+++ b/fuel-tx/src/tx_pointer.rs
@@ -25,7 +25,7 @@ use rand::{
 /// Identification of unspend transaction output.
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "typescript", wasm_bindgen::prelude::wasm_bindgen)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[cfg_attr(
     feature = "da-compression",
     derive(fuel_compression::Compress, fuel_compression::Decompress)

--- a/fuel-vm/Cargo.toml
+++ b/fuel-vm/Cargo.toml
@@ -96,7 +96,6 @@ serde = [
     "hashbrown/serde",
     "fuel-asm/serde",
     "fuel-types/serde",
-    "fuel-tx/serde",
     "fuel-merkle/serde",
     "backtrace?/serde",
 ]


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuel-vm/issues/832

After we introduced the `Upgrade` transaction and started to use postcard to encode the consensus parameters, we basically made the `serde` feature required. 

Part of our codebase already derived `serde::Seriliaze` and `serde::Deserialize` regardless of the `serde` feature. This PR removes the `serde` feature and enables it for the `fuel-tx` crate by default under the `alloc` feature.


## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog

### Before requesting review
- [x] I have reviewed the code myself