### PR TITLE
WDCM and WQCM: reset $of and $err

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - [#838](https://github.com/FuelLabs/fuel-vm/pull/838): Implemented `AsRef<[u8]>` and `TryFrom<&[u8]>` for DA compression types: ScriptCode, PredicateCode, RegistryKey.
+- [#844](https://github.com/FuelLabs/fuel-vm/pull/844): `WDCM` and `WDQCM` reset `$of` and `$err`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - [#838](https://github.com/FuelLabs/fuel-vm/pull/838): Implemented `AsRef<[u8]>` and `TryFrom<&[u8]>` for DA compression types: ScriptCode, PredicateCode, RegistryKey.
-- [#844](https://github.com/FuelLabs/fuel-vm/pull/844): `WDCM` and `WDQCM` reset `$of` and `$err`.
 
 ### Removed
 
@@ -21,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 #### Breaking
 - [#829](https://github.com/FuelLabs/fuel-vm/pull/829): Updated `add_random_fee_input()` to accept an `rng` for true randomization. Introduced `add_fee_input()` to retain the previous behavior of `add_random_fee_input()`.
 - [#845](https://github.com/FuelLabs/fuel-vm/pull/845): Removed `Default` implementation of `SecretKey`.
+- [#844](https://github.com/FuelLabs/fuel-vm/pull/844): `WDCM` and `WQCM` reset `$of` and `$err`.
 
 ## [Version 0.57.1]
 

--- a/fuel-vm/src/interpreter/alu/wideint.rs
+++ b/fuel-vm/src/interpreter/alu/wideint.rs
@@ -89,7 +89,7 @@ macro_rules! wideint_ops {
                     };
 
                     *dest = [<cmp_ $t:lower>](lhs, rhs, args.mode);
-                    *of =  0;
+                    *of = 0;
                     *err = 0;
 
                     inc_pc(pc)?;

--- a/fuel-vm/src/interpreter/alu/wideint.rs
+++ b/fuel-vm/src/interpreter/alu/wideint.rs
@@ -75,7 +75,7 @@ macro_rules! wideint_ops {
                     c: Word,
                     args: CompareArgs,
                 ) -> SimpleResult<()> {
-                    let (SystemRegisters { pc, .. }, mut w) = split_registers(&mut self.registers);
+                    let (SystemRegisters { mut of, mut err, pc, .. }, mut w) = split_registers(&mut self.registers);
                     let dest: &mut Word = &mut w[ra.try_into()?];
 
                     // LHS argument is always indirect, load it
@@ -89,6 +89,8 @@ macro_rules! wideint_ops {
                     };
 
                     *dest = [<cmp_ $t:lower>](lhs, rhs, args.mode);
+                    *of =  0;
+                    *err = 0;
 
                     inc_pc(pc)?;
                     Ok(())

--- a/fuel-vm/src/interpreter/alu/wideint.rs
+++ b/fuel-vm/src/interpreter/alu/wideint.rs
@@ -75,6 +75,7 @@ macro_rules! wideint_ops {
                     c: Word,
                     args: CompareArgs,
                 ) -> SimpleResult<()> {
+
                     let (SystemRegisters { mut of, mut err, pc, .. }, mut w) = split_registers(&mut self.registers);
                     let dest: &mut Word = &mut w[ra.try_into()?];
 

--- a/fuel-vm/src/tests/wideint.rs
+++ b/fuel-vm/src/tests/wideint.rs
@@ -147,7 +147,6 @@ fn cmp_u128_resets_of() {
         panic!("Expected log receipt");
     };
 
-    println!("{:?}", receipts);
     // Then
     assert!(*reg_of_before_cmp != 0);
     assert_eq!(*reg_of_after_cmp, 0);
@@ -203,7 +202,6 @@ fn cmp_u128_resets_err() {
     };
 
     // Then
-    println!("{:?}", receipts);
     assert_eq!(*reg_err_before_cmp, 1);
     assert_eq!(*reg_err_after_cmp, 0);
 }
@@ -309,7 +307,6 @@ fn cmp_u256_resets_of() {
         panic!("Expected log receipt");
     };
 
-    println!("{:?}", receipts);
     // Then
     assert!(*reg_of_before_cmp != 0);
     assert_eq!(*reg_of_after_cmp, 0);
@@ -365,7 +362,6 @@ fn cmp_u256_resets_err() {
     };
 
     // Then
-    println!("{:?}", receipts);
     assert_eq!(*reg_err_before_cmp, 1);
     assert_eq!(*reg_err_after_cmp, 0);
 }

--- a/fuel-vm/src/tests/wideint.rs
+++ b/fuel-vm/src/tests/wideint.rs
@@ -103,11 +103,8 @@ fn cmp_u128_resets_of() {
     let mut ops = Vec::new();
     ops.push(op::movi(0x20, Flags::WRAPPING.bits() as u32));
     ops.push(op::flag(0x20));
-    ops.extend(make_u128(0x20, u128::MAX));
-    ops.extend(make_u128(0x21, 3u64.into()));
-    ops.extend(make_u128(0x22, 2u64.into()));
-    ops.extend(make_u128(0x23, 0u64.into()));
-    ops.push(op::wdmd(0x23, 0x20, 0x21, 0x22));
+    ops.push(op::not(0x20, 0));
+    ops.push(op::mul(0x20, 0x20, 0x20));
     ops.push(op::log(RegId::OF, RegId::ZERO, RegId::ZERO, RegId::ZERO));
 
     // Now push a cmp_u128 operation and log the value of $of again
@@ -145,19 +142,19 @@ fn cmp_u128_resets_of() {
     };
 
     // Then
-    assert_eq!(*reg_of_before_cmp, 1);
+    assert!(*reg_of_before_cmp != 0);
     assert_eq!(*reg_of_after_cmp, 0);
 }
 
 #[test]
 fn cmp_u128_resets_err() {
+    // Given
     // Issue an erroring operation first and log the value of $err
     let mut ops = Vec::new();
     ops.push(op::movi(0x20, Flags::UNSAFEMATH.bits() as u32));
     ops.push(op::flag(0x20));
-    ops.extend(make_u128(0x20, 1u64.into()));
-    ops.extend(make_u128(0x23, 0u64.into()));
-    ops.push(op::wdam(0x23, 0x20, 0x20, 0x23));
+    ops.push(op::movi(0x20, 1));
+    ops.push(op::divi(0x20, 0x20, 0));
     ops.push(op::log(RegId::ERR, RegId::ZERO, RegId::ZERO, RegId::ZERO));
 
     // Now push a cmp_u128 operation and log the value of $err again
@@ -175,6 +172,7 @@ fn cmp_u128_resets_err() {
     ops.push(op::log(RegId::ERR, RegId::ZERO, RegId::ZERO, RegId::ZERO));
     ops.push(op::ret(RegId::ONE));
 
+    // When
     let receipts: Vec<Receipt> = run_script(ops);
 
     let Receipt::Log {
@@ -193,6 +191,7 @@ fn cmp_u128_resets_err() {
         panic!("Expected log receipt");
     };
 
+    // Then
     assert_eq!(*reg_err_before_cmp, 1);
     assert_eq!(*reg_err_after_cmp, 0);
 }
@@ -254,11 +253,8 @@ fn cmp_u256_resets_of() {
     let mut ops = Vec::new();
     ops.push(op::movi(0x20, Flags::WRAPPING.bits() as u32));
     ops.push(op::flag(0x20));
-    ops.extend(make_u128(0x20, u128::MAX));
-    ops.extend(make_u128(0x21, 3u64.into()));
-    ops.extend(make_u128(0x22, 2u64.into()));
-    ops.extend(make_u128(0x23, 0u64.into()));
-    ops.push(op::wdmd(0x23, 0x20, 0x21, 0x22));
+    ops.push(op::not(0x20, 0));
+    ops.push(op::mul(0x20, 0x20, 0x20));
     ops.push(op::log(RegId::OF, RegId::ZERO, RegId::ZERO, RegId::ZERO));
 
     // Now push a cmp_u256 operation and log the value of $of again
@@ -296,19 +292,19 @@ fn cmp_u256_resets_of() {
     };
 
     // Then
-    assert_eq!(*reg_of_before_cmp, 1);
+    assert!(*reg_of_before_cmp != 0);
     assert_eq!(*reg_of_after_cmp, 0);
 }
 
 #[test]
 fn cmp_u256_resets_err() {
+    // Given
     // Issue an erroring operation first and log the value of $err
     let mut ops = Vec::new();
     ops.push(op::movi(0x20, Flags::UNSAFEMATH.bits() as u32));
     ops.push(op::flag(0x20));
-    ops.extend(make_u128(0x20, 1u64.into()));
-    ops.extend(make_u128(0x23, 0u64.into()));
-    ops.push(op::wdam(0x23, 0x20, 0x20, 0x23));
+    ops.push(op::movi(0x20, 1));
+    ops.push(op::divi(0x20, 0x20, 0));
     ops.push(op::log(RegId::ERR, RegId::ZERO, RegId::ZERO, RegId::ZERO));
 
     // Now push a cmp_u256 operation and log the value of $err again
@@ -326,6 +322,7 @@ fn cmp_u256_resets_err() {
     ops.push(op::log(RegId::ERR, RegId::ZERO, RegId::ZERO, RegId::ZERO));
     ops.push(op::ret(RegId::ONE));
 
+    // When
     let receipts: Vec<Receipt> = run_script(ops);
 
     let Receipt::Log {
@@ -344,6 +341,7 @@ fn cmp_u256_resets_err() {
         panic!("Expected log receipt");
     };
 
+    // Then
     assert_eq!(*reg_err_before_cmp, 1);
     assert_eq!(*reg_err_after_cmp, 0);
 }

--- a/fuel-vm/src/tests/wideint.rs
+++ b/fuel-vm/src/tests/wideint.rs
@@ -153,8 +153,7 @@ fn cmp_u128_resets_err() {
     let mut ops = Vec::new();
     ops.push(op::movi(0x20, Flags::UNSAFEMATH.bits() as u32));
     ops.push(op::flag(0x20));
-    ops.push(op::movi(0x20, 1));
-    ops.push(op::divi(0x20, 0x20, 0));
+    ops.push(op::div(0x10, RegId::ONE, RegId::ZERO));
     ops.push(op::log(RegId::ERR, RegId::ZERO, RegId::ZERO, RegId::ZERO));
 
     // Now push a cmp_u128 operation and log the value of $err again
@@ -303,8 +302,7 @@ fn cmp_u256_resets_err() {
     let mut ops = Vec::new();
     ops.push(op::movi(0x20, Flags::UNSAFEMATH.bits() as u32));
     ops.push(op::flag(0x20));
-    ops.push(op::movi(0x20, 1));
-    ops.push(op::divi(0x20, 0x20, 0));
+    ops.push(op::div(0x10, RegId::ONE, RegId::ZERO));
     ops.push(op::log(RegId::ERR, RegId::ZERO, RegId::ZERO, RegId::ZERO));
 
     // Now push a cmp_u256 operation and log the value of $err again

--- a/fuel-vm/src/tests/wideint.rs
+++ b/fuel-vm/src/tests/wideint.rs
@@ -99,22 +99,27 @@ fn cmp_u128(
 #[test]
 fn cmp_u128_resets_of() {
     // Given
-    // Issue an overflowing operation first and log the value of $of
     let mut ops = vec![
         op::movi(0x20, Flags::WRAPPING.bits() as u32),
         op::flag(0x20),
-        op::not(0x20, 0),
-        op::mul(0x20, 0x20, 0x20),
-        op::log(RegId::OF, RegId::ZERO, RegId::ZERO, RegId::ZERO),
     ];
 
-    // Now push a cmp_u128 operation and log the value of $of again
-    ops.extend(make_u128(0x20, 0));
+    // Prepare the operands used for the cmp_u128 operation before
+    // performing the division. This is needed because make_u128
+    // uses `movi` internally, which resets both RegId::OF and RegId::ERR.
     ops.extend(make_u128(0x21, 0));
+    ops.extend(make_u128(0x22, 0));
+
+    // Perform a mul operation that overflows and log the value of RegId::OF
+    ops.push(op::not(0x20, 0));
+    ops.push(op::mul(0x20, 0x20, 0x20));
+    ops.push(op::log(RegId::OF, RegId::ZERO, RegId::ZERO, RegId::ZERO));
+
+    // Now push a cmp_u128 operation and log the value of RegId::OF again
     ops.push(op::wdcm_args(
-        0x22,
-        0x20,
+        0x23,
         0x21,
+        0x22,
         CompareArgs {
             indirect_rhs: true,
             mode: CompareMode::EQ,
@@ -142,6 +147,7 @@ fn cmp_u128_resets_of() {
         panic!("Expected log receipt");
     };
 
+    println!("{:?}", receipts);
     // Then
     assert!(*reg_of_before_cmp != 0);
     assert_eq!(*reg_of_after_cmp, 0);
@@ -150,21 +156,25 @@ fn cmp_u128_resets_of() {
 #[test]
 fn cmp_u128_resets_err() {
     // Given
-    // Issue an erroring operation first and log the value of $err
     let mut ops = vec![
         op::movi(0x20, Flags::UNSAFEMATH.bits() as u32),
         op::flag(0x20),
-        op::div(0x10, RegId::ONE, RegId::ZERO),
-        op::log(RegId::ERR, RegId::ZERO, RegId::ZERO, RegId::ZERO),
     ];
-
-    // Now push a cmp_u128 operation and log the value of $err again
-    ops.extend(make_u128(0x20, 0));
+    // Prepare the operands used for the cmp_u128 operation before
+    // performing the division. This is needed because make_u128
+    // uses `movi` internally, which resets both RegId::OF and RegId::ERR.
     ops.extend(make_u128(0x21, 0));
+    ops.extend(make_u128(0x22, 0));
+
+    // Perform the division and log the value of RegId::ERR
+    ops.push(op::div(0x10, RegId::ONE, RegId::ZERO));
+    ops.push(op::log(RegId::ERR, RegId::ZERO, RegId::ZERO, RegId::ZERO));
+
+    // Push a cmp_u128 operation and log the value of RegId::ERR again
     ops.push(op::wdcm_args(
-        0x22,
-        0x20,
+        0x23,
         0x21,
+        0x22,
         CompareArgs {
             indirect_rhs: true,
             mode: CompareMode::EQ,
@@ -193,6 +203,7 @@ fn cmp_u128_resets_err() {
     };
 
     // Then
+    println!("{:?}", receipts);
     assert_eq!(*reg_err_before_cmp, 1);
     assert_eq!(*reg_err_after_cmp, 0);
 }
@@ -250,22 +261,27 @@ fn cmp_u256(
 #[test]
 fn cmp_u256_resets_of() {
     // Given
-    // Issue an overflowing operation first and log the value of $of
     let mut ops = vec![
         op::movi(0x20, Flags::WRAPPING.bits() as u32),
         op::flag(0x20),
-        op::not(0x20, 0),
-        op::mul(0x20, 0x20, 0x20),
-        op::log(RegId::OF, RegId::ZERO, RegId::ZERO, RegId::ZERO),
     ];
 
-    // Now push a cmp_u256 operation and log the value of $of again
-    ops.extend(make_u256(0x20, 0u64.into()));
+    // Prepare the operands used for the cmp_u256 operation before
+    // performing the division. This is needed because make_u256
+    // uses `movi` internally, which resets both RegId::OF and RegId::ERR.
     ops.extend(make_u256(0x21, 0u64.into()));
+    ops.extend(make_u256(0x22, 0u64.into()));
+
+    // Perform a mul operation that overflows and log the value of RegId::OF
+    ops.push(op::not(0x20, 0));
+    ops.push(op::mul(0x20, 0x20, 0x20));
+    ops.push(op::log(RegId::OF, RegId::ZERO, RegId::ZERO, RegId::ZERO));
+
+    // Now push a cmp_u256 operation and log the value of RegId::OF again
     ops.push(op::wqcm_args(
-        0x22,
-        0x20,
+        0x23,
         0x21,
+        0x22,
         CompareArgs {
             indirect_rhs: true,
             mode: CompareMode::EQ,
@@ -293,6 +309,7 @@ fn cmp_u256_resets_of() {
         panic!("Expected log receipt");
     };
 
+    println!("{:?}", receipts);
     // Then
     assert!(*reg_of_before_cmp != 0);
     assert_eq!(*reg_of_after_cmp, 0);
@@ -301,21 +318,25 @@ fn cmp_u256_resets_of() {
 #[test]
 fn cmp_u256_resets_err() {
     // Given
-    // Issue an erroring operation first and log the value of $err
     let mut ops = vec![
         op::movi(0x20, Flags::UNSAFEMATH.bits() as u32),
         op::flag(0x20),
-        op::div(0x10, RegId::ONE, RegId::ZERO),
-        op::log(RegId::ERR, RegId::ZERO, RegId::ZERO, RegId::ZERO),
     ];
-
-    // Now push a cmp_u256 operation and log the value of $err again
-    ops.extend(make_u256(0x20, 0u64.into()));
+    // Prepare the operands used for the cmp_u256 operation before
+    // performing the division. This is needed because make_u256
+    // uses `movi` internally, which resets both RegId::OF and RegId::ERR.
     ops.extend(make_u256(0x21, 0u64.into()));
+    ops.extend(make_u256(0x22, 0u64.into()));
+
+    // Perform the division and log the value of the RegId::ERR
+    ops.push(op::div(0x10, RegId::ONE, RegId::ZERO));
+    ops.push(op::log(RegId::ERR, RegId::ZERO, RegId::ZERO, RegId::ZERO));
+
+    // Push a cmp_u256 operation and log the value of RegId::ERR again
     ops.push(op::wqcm_args(
-        0x22,
-        0x20,
+        0x23,
         0x21,
+        0x22,
         CompareArgs {
             indirect_rhs: true,
             mode: CompareMode::EQ,
@@ -344,6 +365,7 @@ fn cmp_u256_resets_err() {
     };
 
     // Then
+    println!("{:?}", receipts);
     assert_eq!(*reg_err_before_cmp, 1);
     assert_eq!(*reg_err_after_cmp, 0);
 }

--- a/fuel-vm/src/tests/wideint.rs
+++ b/fuel-vm/src/tests/wideint.rs
@@ -131,7 +131,7 @@ fn cmp_u128_resets_of() {
     let Receipt::Log {
         ra: reg_of_before_cmp,
         ..
-    } = receipts.get(0).unwrap()
+    } = receipts.first().unwrap()
     else {
         panic!("Expected log receipt");
     };
@@ -180,7 +180,7 @@ fn cmp_u128_resets_err() {
     let Receipt::Log {
         ra: reg_err_before_cmp,
         ..
-    } = receipts.get(0).unwrap()
+    } = receipts.first().unwrap()
     else {
         panic!("Expected log receipt");
     };
@@ -282,7 +282,7 @@ fn cmp_u256_resets_of() {
     let Receipt::Log {
         ra: reg_of_before_cmp,
         ..
-    } = receipts.get(0).unwrap()
+    } = receipts.first().unwrap()
     else {
         panic!("Expected log receipt");
     };
@@ -331,7 +331,7 @@ fn cmp_u256_resets_err() {
     let Receipt::Log {
         ra: reg_err_before_cmp,
         ..
-    } = receipts.get(0).unwrap()
+    } = receipts.first().unwrap()
     else {
         panic!("Expected log receipt");
     };

--- a/fuel-vm/src/tests/wideint.rs
+++ b/fuel-vm/src/tests/wideint.rs
@@ -100,12 +100,13 @@ fn cmp_u128(
 fn cmp_u128_resets_of() {
     // Given
     // Issue an overflowing operation first and log the value of $of
-    let mut ops = Vec::new();
-    ops.push(op::movi(0x20, Flags::WRAPPING.bits() as u32));
-    ops.push(op::flag(0x20));
-    ops.push(op::not(0x20, 0));
-    ops.push(op::mul(0x20, 0x20, 0x20));
-    ops.push(op::log(RegId::OF, RegId::ZERO, RegId::ZERO, RegId::ZERO));
+    let mut ops = vec![
+        op::movi(0x20, Flags::WRAPPING.bits() as u32),
+        op::flag(0x20),
+        op::not(0x20, 0),
+        op::mul(0x20, 0x20, 0x20),
+        op::log(RegId::OF, RegId::ZERO, RegId::ZERO, RegId::ZERO),
+    ];
 
     // Now push a cmp_u128 operation and log the value of $of again
     ops.extend(make_u128(0x20, 0));
@@ -150,11 +151,12 @@ fn cmp_u128_resets_of() {
 fn cmp_u128_resets_err() {
     // Given
     // Issue an erroring operation first and log the value of $err
-    let mut ops = Vec::new();
-    ops.push(op::movi(0x20, Flags::UNSAFEMATH.bits() as u32));
-    ops.push(op::flag(0x20));
-    ops.push(op::div(0x10, RegId::ONE, RegId::ZERO));
-    ops.push(op::log(RegId::ERR, RegId::ZERO, RegId::ZERO, RegId::ZERO));
+    let mut ops = vec![
+        op::movi(0x20, Flags::UNSAFEMATH.bits() as u32),
+        op::flag(0x20),
+        op::div(0x10, RegId::ONE, RegId::ZERO),
+        op::log(RegId::ERR, RegId::ZERO, RegId::ZERO, RegId::ZERO),
+    ];
 
     // Now push a cmp_u128 operation and log the value of $err again
     ops.extend(make_u128(0x20, 0));
@@ -249,12 +251,13 @@ fn cmp_u256(
 fn cmp_u256_resets_of() {
     // Given
     // Issue an overflowing operation first and log the value of $of
-    let mut ops = Vec::new();
-    ops.push(op::movi(0x20, Flags::WRAPPING.bits() as u32));
-    ops.push(op::flag(0x20));
-    ops.push(op::not(0x20, 0));
-    ops.push(op::mul(0x20, 0x20, 0x20));
-    ops.push(op::log(RegId::OF, RegId::ZERO, RegId::ZERO, RegId::ZERO));
+    let mut ops = vec![
+        op::movi(0x20, Flags::WRAPPING.bits() as u32),
+        op::flag(0x20),
+        op::not(0x20, 0),
+        op::mul(0x20, 0x20, 0x20),
+        op::log(RegId::OF, RegId::ZERO, RegId::ZERO, RegId::ZERO),
+    ];
 
     // Now push a cmp_u256 operation and log the value of $of again
     ops.extend(make_u256(0x20, 0u64.into()));
@@ -299,11 +302,12 @@ fn cmp_u256_resets_of() {
 fn cmp_u256_resets_err() {
     // Given
     // Issue an erroring operation first and log the value of $err
-    let mut ops = Vec::new();
-    ops.push(op::movi(0x20, Flags::UNSAFEMATH.bits() as u32));
-    ops.push(op::flag(0x20));
-    ops.push(op::div(0x10, RegId::ONE, RegId::ZERO));
-    ops.push(op::log(RegId::ERR, RegId::ZERO, RegId::ZERO, RegId::ZERO));
+    let mut ops = vec![
+        op::movi(0x20, Flags::UNSAFEMATH.bits() as u32),
+        op::flag(0x20),
+        op::div(0x10, RegId::ONE, RegId::ZERO),
+        op::log(RegId::ERR, RegId::ZERO, RegId::ZERO, RegId::ZERO),
+    ];
 
     // Now push a cmp_u256 operation and log the value of $err again
     ops.extend(make_u256(0x20, 0u64.into()));


### PR DESCRIPTION
[Link to related issue(s) here, if any]

Closes https://github.com/FuelLabs/fuel-vm/issues/791

[Short description of the changes.]

The specification requires that WDCM and WDQCM reset the $of and $err registers, but this was not the case.

Questions:
- [ ] Is this a breaking change?
- [ ] I could not find any test that I could look at for the changes. Are there any?

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
