### PR TITLE
fix(SecretKey): remove Default implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 #### Breaking
 - [#829](https://github.com/FuelLabs/fuel-vm/pull/829): Updated `add_random_fee_input()` to accept an `rng` for true randomization. Introduced `add_fee_input()` to retain the previous behavior of `add_random_fee_input()`.
+- [#845](https://github.com/FuelLabs/fuel-vm/pull/845): Removed `Default` implementation of `SecretKey`.
 
 ## [Version 0.57.0]
 

--- a/fuel-crypto/src/secp256/secret.rs
+++ b/fuel-crypto/src/secp256/secret.rs
@@ -29,7 +29,7 @@ use rand::{
 };
 
 /// Asymmetric secret key, guaranteed to be valid by construction
-#[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Zeroize)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Zeroize)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
 pub struct SecretKey(Bytes32);

--- a/fuel-crypto/src/secp256/secret.rs
+++ b/fuel-crypto/src/secp256/secret.rs
@@ -115,6 +115,15 @@ impl From<&SecretKey> for ::secp256k1::SecretKey {
     }
 }
 
+#[cfg(all(feature = "random", feature = "test-helpers"))]
+impl Default for SecretKey {
+    /// Creates a new random secret using rand::thread_rng()
+    fn default() -> Self {
+        let mut rng = rand::thread_rng();
+        SecretKey::random(&mut rng)
+    }
+}
+
 #[cfg(feature = "std")]
 pub type W = English;
 
@@ -186,5 +195,16 @@ impl str::FromStr for SecretKey {
         Bytes32::from_str(s)
             .map_err(|_| Error::InvalidSecretKey)
             .and_then(SecretKey::try_from)
+    }
+}
+
+#[cfg(test)]
+#[allow(non_snake_case)]
+mod tests {
+    #[cfg(feature = "random")]
+    #[test]
+    fn default__yields_valid_secret() {
+        use super::SecretKey;
+        let _ = SecretKey::default();
     }
 }


### PR DESCRIPTION

Fixes https://github.com/FuelLabs/fuel-vm/issues/830

## Description
Deriving `Default` for the `SecretKey` doesn't exactly make too much sense given that we don't use it anywhere in this codebase, and the fact that `k256::SecretKey` throws an error if the provided byte slice is 0 -

![image](https://github.com/user-attachments/assets/066b3617-e01a-44a4-ab37-2b7c4ae32988)


We could have a default impl by using rng, but we should expect consumers of this library to use their own impl, or use `SecretKey::random()`

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
