### PR TITLE
LDC support in predicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- [#848](https://github.com/FuelLabs/fuel-vm/pull/848): Allow usage of the blob opcode `BSIZ`, `BLDD`, and `LDC` with mode `1` in the predicates.
 - [#838](https://github.com/FuelLabs/fuel-vm/pull/838): Implemented `AsRef<[u8]>` and `TryFrom<&[u8]>` for DA compression types: ScriptCode, PredicateCode, RegistryKey.
 - [#820](https://github.com/FuelLabs/fuel-vm/pull/820): Add fuzzing in CI with ClusterFuzzLite.
 
 ### Removed
 
 #### Breaking
+- [#848](https://github.com/FuelLabs/fuel-vm/pull/848): All estimation and verification of predicate functionality is reworked and now requires the instance of the storage with predicates.
 - [#843](https://github.com/FuelLabs/fuel-vm/pull/843): Remove `serde` feature from the `fuel-tx` crate. It is default behaviour now if you enable `alloc` feature.
 
 ### Changed

--- a/fuel-asm/src/lib.rs
+++ b/fuel-asm/src/lib.rs
@@ -993,9 +993,9 @@ fn check_predicate_allowed() {
     for byte in 0..u8::MAX {
         if let Ok(repr) = Opcode::try_from(byte) {
             let should_allow = match repr {
-                BAL | BHEI | BHSH | BURN | CALL | CB | CCP | CROO | CSIZ | LDC | LOG
-                | LOGD | MINT | RETD | RVRT | SMO | SCWQ | SRW | SRWQ | SWW | SWWQ
-                | TIME | TR | TRO | ECAL | BSIZ | BLDD => false,
+                BAL | BHEI | BHSH | BURN | CALL | CB | CCP | CROO | CSIZ | LOG | LOGD
+                | MINT | RETD | RVRT | SMO | SCWQ | SRW | SRWQ | SWW | SWWQ | TIME
+                | TR | TRO | ECAL => false,
                 _ => true,
             };
             assert_eq!(should_allow, repr.is_predicate_allowed());

--- a/fuel-asm/src/lib.rs
+++ b/fuel-asm/src/lib.rs
@@ -701,7 +701,7 @@ impl Opcode {
             | K256 | S256 | NOOP | FLAG | ADDI | ANDI | DIVI | EXPI | MODI | MULI
             | MLDV | ORI | SLLI | SRLI | SUBI | XORI | JNEI | LB | LW | SB | SW
             | MCPI | MCLI | GM | MOVI | JNZI | JI | JMP | JNE | JMPF | JMPB | JNZF
-            | JNZB | JNEF | JNEB | CFEI | CFSI | CFE | CFS | GTF => true,
+            | JNZB | JNEF | JNEB | CFEI | CFSI | CFE | CFS | GTF | LDC => true,
             _ => false,
         }
     }

--- a/fuel-asm/src/lib.rs
+++ b/fuel-asm/src/lib.rs
@@ -701,7 +701,9 @@ impl Opcode {
             | K256 | S256 | NOOP | FLAG | ADDI | ANDI | DIVI | EXPI | MODI | MULI
             | MLDV | ORI | SLLI | SRLI | SUBI | XORI | JNEI | LB | LW | SB | SW
             | MCPI | MCLI | GM | MOVI | JNZI | JI | JMP | JNE | JMPF | JMPB | JNZF
-            | JNZB | JNEF | JNEB | CFEI | CFSI | CFE | CFS | GTF | LDC => true,
+            | JNZB | JNEF | JNEB | CFEI | CFSI | CFE | CFS | GTF | LDC | BSIZ | BLDD => {
+                true
+            }
             _ => false,
         }
     }

--- a/fuel-crypto/Cargo.toml
+++ b/fuel-crypto/Cargo.toml
@@ -16,9 +16,9 @@ coins-bip39 = { version = "0.8", default-features = false, features = ["english"
 ecdsa = { version = "0.16", default-features = false }
 ed25519-dalek = { version = "2.0.0", default-features = false }
 fuel-types = { workspace = true, default-features = false }
-k256 =  { version = "0.13", default-features = false, features = ["digest", "ecdsa"] }
+k256 = { version = "0.13", default-features = false, features = ["digest", "ecdsa"] }
 lazy_static = { version = "1.4", optional = true }
-p256 =  { version = "0.13", default-features = false, features = ["digest", "ecdsa"] }
+p256 = { version = "0.13", default-features = false, features = ["digest", "ecdsa"] }
 rand = { version = "0.8", default-features = false, optional = true }
 # `rand-std` is used to further protect the blinders from side-channel attacks and won't compromise
 # the deterministic arguments of the signature (key, nonce, message), as defined in the RFC-6979
@@ -35,7 +35,7 @@ sha2 = "0.10"
 
 [features]
 default = ["fuel-types/default", "std"]
-alloc = ["rand?/alloc", "secp256k1/alloc", "fuel-types/alloc"]
+alloc = ["rand?/alloc", "secp256k1?/alloc", "fuel-types/alloc"]
 random = ["fuel-types/random", "rand"]
 serde = ["dep:serde", "fuel-types/serde"]
 std = ["alloc", "coins-bip32", "secp256k1", "coins-bip39", "fuel-types/std", "lazy_static", "rand?/std_rng", "serde?/default"]

--- a/fuel-tx/Cargo.toml
+++ b/fuel-tx/Cargo.toml
@@ -55,7 +55,7 @@ internals = []
 typescript = ["dep:serde_json", "alloc", "js-sys", "wasm-bindgen", "serde-wasm-bindgen", "fuel-types/typescript"]
 random = ["fuel-crypto/random", "fuel-types/random", "rand"]
 std = ["alloc", "fuel-asm/std", "fuel-crypto/std", "fuel-merkle/std", "fuel-types/std", "itertools/default", "rand?/default", "serde/default", "hex/std"]
-alloc = ["hashbrown", "fuel-types/alloc", "fuel-crypto/alloc", "itertools/use_alloc", "derivative", "fuel-merkle", "strum", "strum_macros", "bitflags", "postcard", "derive_more", "fuel-asm/serde", "fuel-types/serde", "fuel-crypto/serde"]
+alloc = ["hashbrown", "fuel-types/alloc", "itertools/use_alloc", "derivative", "fuel-merkle", "strum", "strum_macros", "bitflags", "postcard", "derive_more", "fuel-asm/serde", "fuel-types/serde", "fuel-crypto/serde"]
 da-compression = ["fuel-compression"]
 
 [lints.rust]

--- a/fuel-tx/Cargo.toml
+++ b/fuel-tx/Cargo.toml
@@ -55,7 +55,7 @@ internals = []
 typescript = ["dep:serde_json", "alloc", "js-sys", "wasm-bindgen", "serde-wasm-bindgen", "fuel-types/typescript"]
 random = ["fuel-crypto/random", "fuel-types/random", "rand"]
 std = ["alloc", "fuel-asm/std", "fuel-crypto/std", "fuel-merkle/std", "fuel-types/std", "itertools/default", "rand?/default", "serde/default", "hex/std"]
-alloc = ["hashbrown", "fuel-types/alloc", "fuel-crypto/alloc", "itertools/use_alloc", "derivative", "fuel-merkle", "strum", "strum_macros", "bitflags", "postcard", "derive_more", "fuel-asm/serde", "fuel-types/serde", "fuel-crypto/serde"]
+alloc = ["hashbrown", "fuel-types/alloc", "fuel-crypto/alloc", "itertools/use_alloc", "derivative", "fuel-merkle", "strum", "strum_macros", "bitflags", "postcard", "derive_more", "fuel-asm/serde", "fuel-types/serde", "fuel-crypto/alloc", "fuel-crypto/serde", "fuel-merkle/serde"]
 da-compression = ["fuel-compression"]
 
 [lints.rust]

--- a/fuel-tx/Cargo.toml
+++ b/fuel-tx/Cargo.toml
@@ -55,7 +55,7 @@ internals = []
 typescript = ["dep:serde_json", "alloc", "js-sys", "wasm-bindgen", "serde-wasm-bindgen", "fuel-types/typescript"]
 random = ["fuel-crypto/random", "fuel-types/random", "rand"]
 std = ["alloc", "fuel-asm/std", "fuel-crypto/std", "fuel-merkle/std", "fuel-types/std", "itertools/default", "rand?/default", "serde/default", "hex/std"]
-alloc = ["hashbrown", "fuel-types/alloc", "itertools/use_alloc", "derivative", "fuel-merkle", "strum", "strum_macros", "bitflags", "postcard", "derive_more", "fuel-asm/serde", "fuel-types/serde"]
+alloc = ["hashbrown", "fuel-types/alloc", "itertools/use_alloc", "derivative", "fuel-merkle", "strum", "strum_macros", "bitflags", "postcard", "derive_more", "fuel-asm/serde", "fuel-types/serde", "fuel-crypto/serde"]
 da-compression = ["fuel-compression"]
 
 [lints.rust]

--- a/fuel-tx/Cargo.toml
+++ b/fuel-tx/Cargo.toml
@@ -55,7 +55,7 @@ internals = []
 typescript = ["dep:serde_json", "alloc", "js-sys", "wasm-bindgen", "serde-wasm-bindgen", "fuel-types/typescript"]
 random = ["fuel-crypto/random", "fuel-types/random", "rand"]
 std = ["alloc", "fuel-asm/std", "fuel-crypto/std", "fuel-merkle/std", "fuel-types/std", "itertools/default", "rand?/default", "serde/default", "hex/std"]
-alloc = ["hashbrown", "fuel-types/alloc", "fuel-crypto/alloc", "itertools/use_alloc", "derivative", "fuel-merkle", "strum", "strum_macros", "bitflags", "postcard", "derive_more", "fuel-asm/serde", "fuel-types/serde", "fuel-crypto/alloc", "fuel-crypto/serde", "fuel-merkle/serde"]
+alloc = ["hashbrown", "fuel-types/alloc", "itertools/use_alloc", "derivative", "fuel-merkle", "strum", "strum_macros", "bitflags", "postcard", "derive_more", "fuel-asm/serde", "fuel-types/serde"]
 da-compression = ["fuel-compression"]
 
 [lints.rust]

--- a/fuel-tx/Cargo.toml
+++ b/fuel-tx/Cargo.toml
@@ -55,7 +55,7 @@ internals = []
 typescript = ["dep:serde_json", "alloc", "js-sys", "wasm-bindgen", "serde-wasm-bindgen", "fuel-types/typescript"]
 random = ["fuel-crypto/random", "fuel-types/random", "rand"]
 std = ["alloc", "fuel-asm/std", "fuel-crypto/std", "fuel-merkle/std", "fuel-types/std", "itertools/default", "rand?/default", "serde/default", "hex/std"]
-alloc = ["hashbrown", "fuel-types/alloc", "itertools/use_alloc", "derivative", "fuel-merkle", "strum", "strum_macros", "bitflags", "postcard", "derive_more", "fuel-asm/serde", "fuel-types/serde", "fuel-crypto/serde"]
+alloc = ["hashbrown", "fuel-types/alloc", "fuel-crypto/alloc", "itertools/use_alloc", "derivative", "fuel-merkle", "strum", "strum_macros", "bitflags", "postcard", "derive_more", "fuel-asm/serde", "fuel-types/serde", "fuel-crypto/serde"]
 da-compression = ["fuel-compression"]
 
 [lints.rust]

--- a/fuel-tx/src/transaction/id.rs
+++ b/fuel-tx/src/transaction/id.rs
@@ -108,6 +108,7 @@ where
                 }) if owner == &pk => Some(*witness_index as usize),
                 _ => None,
             })
+            .sorted()
             .dedup()
             .collect_vec();
 

--- a/fuel-tx/src/transaction/types/input.rs
+++ b/fuel-tx/src/transaction/types/input.rs
@@ -572,6 +572,26 @@ impl Input {
         }
     }
 
+    pub fn set_predicate_gas_used(&mut self, gas: Word) {
+        match self {
+            Input::CoinPredicate(CoinPredicate {
+                predicate_gas_used, ..
+            })
+            | Input::MessageCoinPredicate(MessageCoinPredicate {
+                predicate_gas_used,
+                ..
+            })
+            | Input::MessageDataPredicate(MessageDataPredicate {
+                predicate_gas_used,
+                ..
+            }) => *predicate_gas_used = gas,
+            Input::CoinSigned(_)
+            | Input::MessageCoinSigned(_)
+            | Input::MessageDataSigned(_)
+            | Input::Contract(_) => {}
+        }
+    }
+
     pub fn message_id(&self) -> Option<MessageId> {
         match self {
             Self::MessageCoinSigned(message) => Some(message.message_id()),

--- a/fuel-vm/Cargo.toml
+++ b/fuel-vm/Cargo.toml
@@ -22,7 +22,7 @@ backtrace = { version = "0.3", optional = true } # requires debug symbols to wor
 bitflags = { workspace = true }
 derivative = "2.2"
 derive_more = { version = "0.99", default-features = false, features = [
-    "display",
+  "display",
 ] }
 dyn-clone = { version = "1.0", optional = true }
 ethnum = "1.3"
@@ -38,7 +38,7 @@ itertools = { version = "0.10", default-features = false }
 libm = { version = "0.2", default-features = false }
 paste = "1.0"
 percent-encoding = { version = "2.3", features = [
-    "alloc",
+  "alloc",
 ], default-features = false }
 primitive-types = { version = "0.12", default-features = false }
 rand = { version = "0.8", optional = true }
@@ -55,11 +55,11 @@ ed25519-dalek = { version = "2.0.0", features = ["rand_core"] }
 fuel-crypto = { workspace = true, features = ["test-helpers"] }
 fuel-tx = { workspace = true, features = ["test-helpers"] }
 fuel-vm = { path = ".", default-features = false, features = [
-    "test-helpers",
-    "serde",
-    "profile-coverage",
-    "profile-gas",
-    "random",
+  "test-helpers",
+  "serde",
+  "profile-coverage",
+  "profile-gas",
+  "random",
 ] }
 futures = "0.3.28"
 ntest = "0.9.2"
@@ -77,35 +77,35 @@ tokio-rayon = "2.1.0"
 [features]
 default = ["std"]
 std = [
-    "alloc",
-    "fuel-crypto/std",
-    "fuel-types/std",
-    "fuel-asm/std",
-    "fuel-tx/std",
-    "itertools/use_std",
+  "alloc",
+  "fuel-crypto/std",
+  "fuel-types/std",
+  "fuel-asm/std",
+  "fuel-tx/std",
+  "itertools/use_std",
 ]
-alloc = ["fuel-asm/alloc", "fuel-tx/alloc", "fuel-tx/alloc"]
+alloc = ["fuel-asm/alloc", "fuel-tx/alloc", "fuel-crypto/alloc"]
 profile-gas = ["profile-any"]
 profile-coverage = ["profile-any"]
 profile-any = ["dyn-clone"] # All profiling features should depend on this
 random = ["fuel-crypto/random", "fuel-types/random", "fuel-tx/random", "rand"]
 da-compression = ["fuel-compression", "fuel-tx/da-compression"]
 serde = [
-    "dep:serde",
-    "dep:serde_with",
-    "hashbrown/serde",
-    "fuel-asm/serde",
-    "fuel-types/serde",
-    "fuel-merkle/serde",
-    "backtrace?/serde",
+  "dep:serde",
+  "dep:serde_with",
+  "hashbrown/serde",
+  "fuel-asm/serde",
+  "fuel-types/serde",
+  "fuel-merkle/serde",
+  "backtrace?/serde",
 ]
 test-helpers = [
-    "fuel-tx/test-helpers",
-    "alloc",
-    "random",
-    "dep:anyhow",
-    "tai64",
-    "fuel-crypto/test-helpers",
+  "fuel-tx/test-helpers",
+  "alloc",
+  "random",
+  "dep:anyhow",
+  "tai64",
+  "fuel-crypto/test-helpers",
 ]
 
 [lints.rust]

--- a/fuel-vm/Cargo.toml
+++ b/fuel-vm/Cargo.toml
@@ -84,7 +84,7 @@ std = [
   "fuel-tx/std",
   "itertools/use_std",
 ]
-alloc = ["fuel-asm/alloc", "fuel-tx/alloc"]
+alloc = ["fuel-asm/alloc", "fuel-tx/alloc", "fuel-crypto/alloc"]
 profile-gas = ["profile-any"]
 profile-coverage = ["profile-any"]
 profile-any = ["dyn-clone"] # All profiling features should depend on this

--- a/fuel-vm/Cargo.toml
+++ b/fuel-vm/Cargo.toml
@@ -84,7 +84,7 @@ std = [
   "fuel-tx/std",
   "itertools/use_std",
 ]
-alloc = ["fuel-asm/alloc", "fuel-tx/alloc", "fuel-crypto/alloc"]
+alloc = ["fuel-asm/alloc", "fuel-tx/alloc"]
 profile-gas = ["profile-any"]
 profile-coverage = ["profile-any"]
 profile-any = ["dyn-clone"] # All profiling features should depend on this

--- a/fuel-vm/Cargo.toml
+++ b/fuel-vm/Cargo.toml
@@ -22,7 +22,7 @@ backtrace = { version = "0.3", optional = true } # requires debug symbols to wor
 bitflags = { workspace = true }
 derivative = "2.2"
 derive_more = { version = "0.99", default-features = false, features = [
-  "display",
+    "display",
 ] }
 dyn-clone = { version = "1.0", optional = true }
 ethnum = "1.3"
@@ -31,14 +31,14 @@ fuel-compression = { workspace = true, default-features = false, optional = true
 fuel-crypto = { workspace = true, default-features = false }
 fuel-merkle = { workspace = true, default-features = false }
 fuel-storage = { workspace = true }
-fuel-tx = { workspace = true, default-features = false }
+fuel-tx = { workspace = true, default-features = false, features = ["alloc"] }
 fuel-types = { workspace = true, default-features = false }
 hashbrown = "0.14"
 itertools = { version = "0.10", default-features = false }
 libm = { version = "0.2", default-features = false }
 paste = "1.0"
 percent-encoding = { version = "2.3", features = [
-  "alloc",
+    "alloc",
 ], default-features = false }
 primitive-types = { version = "0.12", default-features = false }
 rand = { version = "0.8", optional = true }
@@ -55,11 +55,11 @@ ed25519-dalek = { version = "2.0.0", features = ["rand_core"] }
 fuel-crypto = { workspace = true, features = ["test-helpers"] }
 fuel-tx = { workspace = true, features = ["test-helpers"] }
 fuel-vm = { path = ".", default-features = false, features = [
-  "test-helpers",
-  "serde",
-  "profile-coverage",
-  "profile-gas",
-  "random",
+    "test-helpers",
+    "serde",
+    "profile-coverage",
+    "profile-gas",
+    "random",
 ] }
 futures = "0.3.28"
 ntest = "0.9.2"
@@ -77,12 +77,12 @@ tokio-rayon = "2.1.0"
 [features]
 default = ["std"]
 std = [
-  "alloc",
-  "fuel-crypto/std",
-  "fuel-types/std",
-  "fuel-asm/std",
-  "fuel-tx/std",
-  "itertools/use_std",
+    "alloc",
+    "fuel-crypto/std",
+    "fuel-types/std",
+    "fuel-asm/std",
+    "fuel-tx/std",
+    "itertools/use_std",
 ]
 alloc = ["fuel-asm/alloc", "fuel-tx/alloc", "fuel-crypto/alloc"]
 profile-gas = ["profile-any"]
@@ -91,21 +91,22 @@ profile-any = ["dyn-clone"] # All profiling features should depend on this
 random = ["fuel-crypto/random", "fuel-types/random", "fuel-tx/random", "rand"]
 da-compression = ["fuel-compression", "fuel-tx/da-compression"]
 serde = [
-  "dep:serde",
-  "dep:serde_with",
-  "hashbrown/serde",
-  "fuel-asm/serde",
-  "fuel-types/serde",
-  "fuel-merkle/serde",
-  "backtrace?/serde",
+    "dep:serde",
+    "dep:serde_with",
+    "hashbrown/serde",
+    "fuel-asm/serde",
+    "fuel-types/serde",
+    "fuel-merkle/serde",
+    "fuel-crypto/serde",
+    "backtrace?/serde",
 ]
 test-helpers = [
-  "fuel-tx/test-helpers",
-  "alloc",
-  "random",
-  "dep:anyhow",
-  "tai64",
-  "fuel-crypto/test-helpers",
+    "fuel-tx/test-helpers",
+    "alloc",
+    "random",
+    "dep:anyhow",
+    "tai64",
+    "fuel-crypto/test-helpers",
 ]
 
 [lints.rust]

--- a/fuel-vm/src/checked_transaction.rs
+++ b/fuel-vm/src/checked_transaction.rs
@@ -303,7 +303,7 @@ pub trait IntoChecked: FormatValidityChecks + Sized {
     ) -> Result<Checked<Self>, CheckError>
     where
         Checked<Self>: CheckPredicates,
-        S: StorageRead<BlobData> + Clone,
+        S: StorageRead<BlobData>,
     {
         self.into_checked_reusable_memory(
             block_height,
@@ -324,7 +324,7 @@ pub trait IntoChecked: FormatValidityChecks + Sized {
     ) -> Result<Checked<Self>, CheckError>
     where
         Checked<Self>: CheckPredicates,
-        S: StorageRead<BlobData> + Clone,
+        S: StorageRead<BlobData>,
     {
         let check_predicate_params = consensus_params.into();
         self.into_checked_basic(block_height, consensus_params)?
@@ -406,7 +406,7 @@ pub trait CheckPredicates: Sized {
         storage: S,
     ) -> Result<Self, CheckError>
     where
-        S: StorageRead<BlobData> + Clone;
+        S: StorageRead<BlobData>;
 
     /// Performs predicates verification of the transaction in parallel.
     async fn check_predicates_async<E: ParallelExecutor, S>(
@@ -416,7 +416,7 @@ pub trait CheckPredicates: Sized {
         storage: S,
     ) -> Result<Self, CheckError>
     where
-        S: StorageRead<BlobData> + Clone + Send + 'static;
+        S: StorageRead<BlobData> + Send + 'static;
 }
 
 /// Provides predicate estimation functionality for the transaction.
@@ -430,7 +430,7 @@ pub trait EstimatePredicates: Sized {
         storage: S,
     ) -> Result<(), CheckError>
     where
-        S: StorageRead<BlobData> + Clone;
+        S: StorageRead<BlobData>;
 
     /// Estimates predicates of the transaction in parallel.
     async fn estimate_predicates_async<E: ParallelExecutor, S>(
@@ -440,7 +440,7 @@ pub trait EstimatePredicates: Sized {
         storage: S,
     ) -> Result<(), CheckError>
     where
-        S: StorageRead<BlobData> + Clone + Send + 'static;
+        S: StorageRead<BlobData> + Send + 'static;
 }
 
 /// Executes CPU-heavy tasks in parallel.
@@ -475,7 +475,7 @@ where
         storage: S,
     ) -> Result<Self, CheckError>
     where
-        S: StorageRead<BlobData> + Clone,
+        S: StorageRead<BlobData>,
     {
         if !self.checks_bitmask.contains(Checks::Predicates) {
             Interpreter::<&mut MemoryInstance, PredicateStorage<S>, Tx>::check_predicates(&self, params, memory, storage)?;
@@ -492,7 +492,7 @@ where
     ) -> Result<Self, CheckError>
     where
         E: ParallelExecutor,
-        S: StorageRead<BlobData> + Clone + Send + 'static,
+        S: StorageRead<BlobData> + Send + 'static,
     {
         if !self.checks_bitmask.contains(Checks::Predicates) {
             Interpreter::check_predicates_async::<E>(&self, params, pool, storage)
@@ -516,7 +516,7 @@ impl<Tx: ExecutableTransaction + Send + Sync + 'static> EstimatePredicates for T
         storage: S,
     ) -> Result<(), CheckError>
     where
-        S: StorageRead<BlobData> + Clone,
+        S: StorageRead<BlobData>,
     {
         Interpreter::estimate_predicates(self, params, memory, storage)?;
         Ok(())
@@ -530,7 +530,7 @@ impl<Tx: ExecutableTransaction + Send + Sync + 'static> EstimatePredicates for T
     ) -> Result<(), CheckError>
     where
         E: ParallelExecutor,
-        S: StorageRead<BlobData> + Clone + Send + 'static,
+        S: StorageRead<BlobData> + Send + 'static,
     {
         Interpreter::estimate_predicates_async::<E>(self, params, pool, storage).await?;
 
@@ -547,7 +547,7 @@ impl EstimatePredicates for Transaction {
         storage: S,
     ) -> Result<(), CheckError>
     where
-        S: StorageRead<BlobData> + Clone,
+        S: StorageRead<BlobData>,
     {
         match self {
             Self::Script(tx) => tx.estimate_predicates(params, memory, storage),
@@ -566,7 +566,7 @@ impl EstimatePredicates for Transaction {
         storage: S,
     ) -> Result<(), CheckError>
     where
-        S: StorageRead<BlobData> + Clone + Send + 'static,
+        S: StorageRead<BlobData> + Send + 'static,
     {
         match self {
             Self::Script(tx) => {
@@ -603,7 +603,7 @@ impl CheckPredicates for Checked<Mint> {
         _storage: S,
     ) -> Result<Self, CheckError>
     where
-        S: StorageRead<BlobData> + Clone,
+        S: StorageRead<BlobData>,
     {
         self.checks_bitmask.insert(Checks::Predicates);
         Ok(self)
@@ -616,7 +616,7 @@ impl CheckPredicates for Checked<Mint> {
         _storage: S,
     ) -> Result<Self, CheckError>
     where
-        S: StorageRead<BlobData> + Clone + Send + 'static,
+        S: StorageRead<BlobData> + Send + 'static,
     {
         self.checks_bitmask.insert(Checks::Predicates);
         Ok(self)
@@ -632,7 +632,7 @@ impl CheckPredicates for Checked<Transaction> {
         storage: S,
     ) -> Result<Self, CheckError>
     where
-        S: StorageRead<BlobData> + Clone,
+        S: StorageRead<BlobData>,
     {
         let checked_transaction: CheckedTransaction = self.into();
         let checked_transaction: CheckedTransaction = match checked_transaction {
@@ -666,7 +666,7 @@ impl CheckPredicates for Checked<Transaction> {
     ) -> Result<Self, CheckError>
     where
         E: ParallelExecutor,
-        S: StorageRead<BlobData> + Clone + Send + 'static,
+        S: StorageRead<BlobData> + Send + 'static,
     {
         let checked_transaction: CheckedTransaction = self.into();
 

--- a/fuel-vm/src/checked_transaction/builder.rs
+++ b/fuel-vm/src/checked_transaction/builder.rs
@@ -7,6 +7,11 @@ use super::{
 use crate::{
     checked_transaction::CheckPredicates,
     prelude::*,
+    storage::BlobData,
+};
+use fuel_storage::{
+    StorageRead,
+    StorageSize,
 };
 use fuel_tx::{
     Finalizable,
@@ -20,7 +25,11 @@ where
     Tx: IntoChecked,
 {
     /// Finalize the builder into a [`Checked<Tx>`] of the correct type
-    fn finalize_checked(&self, height: BlockHeight) -> Checked<Tx>;
+    fn finalize_checked(
+        &self,
+        height: BlockHeight,
+        storage: impl StorageSize<BlobData> + StorageRead<BlobData> + Clone,
+    ) -> Checked<Tx>;
 
     /// Finalize the builder into a [`Checked<Tx>`] of the correct type, with basic checks
     /// only
@@ -32,9 +41,13 @@ where
     Self: Finalizable<Tx>,
     Checked<Tx>: CheckPredicates,
 {
-    fn finalize_checked(&self, height: BlockHeight) -> Checked<Tx> {
+    fn finalize_checked(
+        &self,
+        height: BlockHeight,
+        storage: impl StorageSize<BlobData> + StorageRead<BlobData> + Clone,
+    ) -> Checked<Tx> {
         self.finalize()
-            .into_checked(height, self.get_params())
+            .into_checked(height, self.get_params(), storage)
             .expect("failed to check tx")
     }
 

--- a/fuel-vm/src/checked_transaction/builder.rs
+++ b/fuel-vm/src/checked_transaction/builder.rs
@@ -25,7 +25,7 @@ where
     fn finalize_checked(
         &self,
         height: BlockHeight,
-        storage: impl StorageRead<BlobData> + Clone,
+        storage: impl StorageRead<BlobData>,
     ) -> Checked<Tx>;
 
     /// Finalize the builder into a [`Checked<Tx>`] of the correct type, with basic checks
@@ -41,7 +41,7 @@ where
     fn finalize_checked(
         &self,
         height: BlockHeight,
-        storage: impl StorageRead<BlobData> + Clone,
+        storage: impl StorageRead<BlobData>,
     ) -> Checked<Tx> {
         self.finalize()
             .into_checked(height, self.get_params(), storage)

--- a/fuel-vm/src/checked_transaction/builder.rs
+++ b/fuel-vm/src/checked_transaction/builder.rs
@@ -7,8 +7,9 @@ use super::{
 use crate::{
     checked_transaction::CheckPredicates,
     prelude::*,
-    storage::predicate::PredicateBlobStorage,
+    storage::BlobData,
 };
+use fuel_storage::StorageRead;
 use fuel_tx::{
     Finalizable,
     TransactionBuilder,
@@ -24,7 +25,7 @@ where
     fn finalize_checked(
         &self,
         height: BlockHeight,
-        storage: impl PredicateBlobStorage,
+        storage: impl StorageRead<BlobData> + Clone,
     ) -> Checked<Tx>;
 
     /// Finalize the builder into a [`Checked<Tx>`] of the correct type, with basic checks
@@ -40,7 +41,7 @@ where
     fn finalize_checked(
         &self,
         height: BlockHeight,
-        storage: impl PredicateBlobStorage,
+        storage: impl StorageRead<BlobData> + Clone,
     ) -> Checked<Tx> {
         self.finalize()
             .into_checked(height, self.get_params(), storage)

--- a/fuel-vm/src/checked_transaction/builder.rs
+++ b/fuel-vm/src/checked_transaction/builder.rs
@@ -7,11 +7,7 @@ use super::{
 use crate::{
     checked_transaction::CheckPredicates,
     prelude::*,
-    storage::BlobData,
-};
-use fuel_storage::{
-    StorageRead,
-    StorageSize,
+    storage::predicate::PredicateBlobStorage,
 };
 use fuel_tx::{
     Finalizable,
@@ -28,7 +24,7 @@ where
     fn finalize_checked(
         &self,
         height: BlockHeight,
-        storage: impl StorageSize<BlobData> + StorageRead<BlobData> + Clone,
+        storage: impl PredicateBlobStorage,
     ) -> Checked<Tx>;
 
     /// Finalize the builder into a [`Checked<Tx>`] of the correct type, with basic checks
@@ -44,7 +40,7 @@ where
     fn finalize_checked(
         &self,
         height: BlockHeight,
-        storage: impl StorageSize<BlobData> + StorageRead<BlobData> + Clone,
+        storage: impl PredicateBlobStorage,
     ) -> Checked<Tx> {
         self.finalize()
             .into_checked(height, self.get_params(), storage)

--- a/fuel-vm/src/error.rs
+++ b/fuel-vm/src/error.rs
@@ -285,10 +285,10 @@ pub enum PredicateVerificationFailed {
     Storage,
 }
 
-impl<E> From<InterpreterError<predicate::PredicateStorageError<E>>>
+impl From<InterpreterError<predicate::PredicateStorageError>>
     for PredicateVerificationFailed
 {
-    fn from(error: InterpreterError<predicate::PredicateStorageError<E>>) -> Self {
+    fn from(error: InterpreterError<predicate::PredicateStorageError>) -> Self {
         match error {
             error if error.panic_reason() == Some(PanicReason::OutOfGas) => {
                 PredicateVerificationFailed::OutOfGas

--- a/fuel-vm/src/error.rs
+++ b/fuel-vm/src/error.rs
@@ -285,10 +285,10 @@ pub enum PredicateVerificationFailed {
     Storage,
 }
 
-impl From<InterpreterError<predicate::StorageUnavailable>>
+impl<E> From<InterpreterError<predicate::PredicateStorageError<E>>>
     for PredicateVerificationFailed
 {
-    fn from(error: InterpreterError<predicate::StorageUnavailable>) -> Self {
+    fn from(error: InterpreterError<predicate::PredicateStorageError<E>>) -> Self {
         match error {
             error if error.panic_reason() == Some(PanicReason::OutOfGas) => {
                 PredicateVerificationFailed::OutOfGas

--- a/fuel-vm/src/interpreter.rs
+++ b/fuel-vm/src/interpreter.rs
@@ -81,6 +81,7 @@ pub use ecal::{
     EcalHandler,
     PredicateErrorEcal,
 };
+pub use executors::predicates;
 pub use memory::{
     Memory,
     MemoryInstance,

--- a/fuel-vm/src/interpreter/blockchain.rs
+++ b/fuel-vm/src/interpreter/blockchain.rs
@@ -104,7 +104,7 @@ where
     /// contract_code = contracts[contract_id]
     /// mem[$ssp, $rC] = contract_code[$rB, $rC]
     /// ```
-    pub(crate) fn load_contract_code(
+    pub(crate) fn zload_contract_code(
         &mut self,
         id_addr: Word,
         offset: Word,
@@ -598,6 +598,11 @@ where
         let ssp = *self.ssp;
         let sp = *self.sp;
         let region_start = ssp;
+
+        // only blobs are allowed in predicates
+        if self.context.is_predicate() {
+            return Err(PanicReason::ContractInstructionNotAllowed.into())
+        }
 
         if ssp != sp {
             return Err(PanicReason::ExpectedUnallocatedStack.into())

--- a/fuel-vm/src/interpreter/blockchain.rs
+++ b/fuel-vm/src/interpreter/blockchain.rs
@@ -104,7 +104,7 @@ where
     /// contract_code = contracts[contract_id]
     /// mem[$ssp, $rC] = contract_code[$rB, $rC]
     /// ```
-    pub(crate) fn zload_contract_code(
+    pub(crate) fn load_contract_code(
         &mut self,
         id_addr: Word,
         offset: Word,

--- a/fuel-vm/src/interpreter/executors.rs
+++ b/fuel-vm/src/interpreter/executors.rs
@@ -3,3 +3,5 @@ mod main;
 mod predicate;
 
 mod debug;
+
+pub use main::predicates;

--- a/fuel-vm/src/interpreter/executors/main.rs
+++ b/fuel-vm/src/interpreter/executors/main.rs
@@ -794,7 +794,6 @@ where
 impl<M, S, Tx, Ecal> Interpreter<M, S, Tx, Ecal>
 where
     M: Memory,
-
     S: InterpreterStorage,
     Tx: ExecutableTransaction,
     Ecal: EcalHandler,

--- a/fuel-vm/src/interpreter/executors/main.rs
+++ b/fuel-vm/src/interpreter/executors/main.rs
@@ -54,7 +54,6 @@ use crate::{
     interpreter::InterpreterParams,
     prelude::MemoryInstance,
     storage::{
-        predicate::PredicateBlobStorage,
         UploadedBytecode,
         UploadedBytecodes,
     },
@@ -144,7 +143,7 @@ enum PredicateAction {
 impl<Tx, S> Interpreter<&mut MemoryInstance, PredicateStorage<S>, Tx>
 where
     Tx: ExecutableTransaction,
-    S: PredicateBlobStorage,
+    S: StorageRead<BlobData> + Clone,
 {
     /// Initialize the VM with the provided transaction and check all predicates defined
     /// in the inputs.

--- a/fuel-vm/src/interpreter/executors/main.rs
+++ b/fuel-vm/src/interpreter/executors/main.rs
@@ -54,6 +54,7 @@ use crate::{
     interpreter::InterpreterParams,
     prelude::MemoryInstance,
     storage::{
+        predicate::PredicateBlobStorage,
         UploadedBytecode,
         UploadedBytecodes,
     },
@@ -107,7 +108,6 @@ use fuel_types::{
     BlobId,
     Word,
 };
-use crate::storage::predicate::PredicateBlobStorage;
 
 /// Predicates were checked succesfully
 #[derive(Debug, Clone, Copy)]

--- a/fuel-vm/src/interpreter/executors/main.rs
+++ b/fuel-vm/src/interpreter/executors/main.rs
@@ -143,7 +143,7 @@ enum PredicateAction {
 impl<Tx, S> Interpreter<&mut MemoryInstance, PredicateStorage<S>, Tx>
 where
     Tx: ExecutableTransaction,
-    S: StorageRead<BlobData> + Clone,
+    S: StorageRead<BlobData>,
 {
     /// Initialize the VM with the provided transaction and check all predicates defined
     /// in the inputs.
@@ -278,7 +278,7 @@ where
                 let tx = kind.tx().clone();
                 let my_params = params.clone();
                 let mut memory = pool.get_new().await;
-                let my_storage = storage.clone();
+                let my_storage = &storage;
 
                 let verify_task = E::create_task(move || {
                     let (used_gas, result) = Interpreter::check_predicate(
@@ -319,7 +319,6 @@ where
 
         for index in 0..kind.tx().inputs().len() {
             let tx = kind.tx().clone();
-            let storage = storage.clone();
 
             if let Some(predicate) =
                 RuntimePredicate::from_tx(&tx, params.tx_offset, index)
@@ -337,7 +336,7 @@ where
                     predicate,
                     params.clone(),
                     memory.as_mut(),
-                    storage,
+                    &storage,
                 );
                 available_gas = available_gas.saturating_sub(gas_used);
                 let result = result.map(|_| (gas_used, index));

--- a/fuel-vm/src/interpreter/executors/main/tests.rs
+++ b/fuel-vm/src/interpreter/executors/main/tests.rs
@@ -6,7 +6,11 @@ use crate::{
         Checked,
     },
     interpreter::MemoryInstance,
-    prelude::*,
+    prelude::{
+        predicates::estimate_predicates,
+        *,
+    },
+    storage::predicate::EmptyStorage,
 };
 use alloc::{
     vec,
@@ -58,7 +62,7 @@ fn estimate_gas_gives_proper_gas_used() {
 
     let transaction_without_predicate = builder
         .finalize_checked_basic(Default::default())
-        .check_predicates(&params.into(), MemoryInstance::new())
+        .check_predicates(&params.into(), MemoryInstance::new(), &EmptyStorage)
         .expect("Predicate check failed even if we don't have any predicates");
 
     let mut client = MemoryClient::default();
@@ -98,10 +102,11 @@ fn estimate_gas_gives_proper_gas_used() {
         .into_checked(Default::default(), params)
         .is_err());
 
-    Interpreter::estimate_predicates(
+    estimate_predicates(
         &mut transaction,
         &params.into(),
         MemoryInstance::new(),
+        &EmptyStorage,
     )
     .expect("Should successfully estimate predicates");
 

--- a/fuel-vm/src/interpreter/executors/predicate.rs
+++ b/fuel-vm/src/interpreter/executors/predicate.rs
@@ -14,19 +14,16 @@ use crate::{
     },
     storage::PredicateStorage,
 };
-use core::fmt::Debug;
 
-use crate::storage::BlobData;
+use crate::storage::predicate::PredicateBlobStorage;
 use fuel_asm::PanicReason;
-use fuel_storage::StorageRead;
 
 impl<M, Tx, Ecal, S> Interpreter<M, PredicateStorage<S>, Tx, Ecal>
 where
     M: Memory,
     Tx: ExecutableTransaction,
     Ecal: EcalHandler,
-    S: StorageRead<BlobData>,
-    S::Error: Debug,
+    S: PredicateBlobStorage,
 {
     /// Verify a predicate that has been initialized already
     pub(crate) fn verify_predicate(

--- a/fuel-vm/src/interpreter/executors/predicate.rs
+++ b/fuel-vm/src/interpreter/executors/predicate.rs
@@ -12,19 +12,18 @@ use crate::{
         ExecuteState,
         ProgramState,
     },
-    storage::PredicateStorage,
+    storage::predicate::PredicateStorage,
 };
 
-use crate::storage::BlobData;
+use crate::storage::predicate::PredicateStorageRequirements;
 use fuel_asm::PanicReason;
-use fuel_storage::StorageRead;
 
 impl<M, Tx, Ecal, S> Interpreter<M, PredicateStorage<S>, Tx, Ecal>
 where
     M: Memory,
     Tx: ExecutableTransaction,
     Ecal: EcalHandler,
-    S: StorageRead<BlobData>,
+    S: PredicateStorageRequirements,
 {
     /// Verify a predicate that has been initialized already
     pub(crate) fn verify_predicate(

--- a/fuel-vm/src/interpreter/executors/predicate.rs
+++ b/fuel-vm/src/interpreter/executors/predicate.rs
@@ -14,17 +14,19 @@ use crate::{
     },
     storage::PredicateStorage,
 };
+use core::fmt::Debug;
 
-use fuel_asm::{
-    PanicReason,
-    RegId,
-};
+use crate::storage::BlobData;
+use fuel_asm::PanicReason;
+use fuel_storage::StorageRead;
 
-impl<M, Tx, Ecal> Interpreter<M, PredicateStorage, Tx, Ecal>
+impl<M, Tx, Ecal, S> Interpreter<M, PredicateStorage<S>, Tx, Ecal>
 where
     M: Memory,
     Tx: ExecutableTransaction,
     Ecal: EcalHandler,
+    S: StorageRead<BlobData>,
+    S::Error: Debug,
 {
     /// Verify a predicate that has been initialized already
     pub(crate) fn verify_predicate(

--- a/fuel-vm/src/interpreter/executors/predicate.rs
+++ b/fuel-vm/src/interpreter/executors/predicate.rs
@@ -24,7 +24,7 @@ where
     M: Memory,
     Tx: ExecutableTransaction,
     Ecal: EcalHandler,
-    S: StorageRead<BlobData> + Clone,
+    S: StorageRead<BlobData>,
 {
     /// Verify a predicate that has been initialized already
     pub(crate) fn verify_predicate(

--- a/fuel-vm/src/interpreter/executors/predicate.rs
+++ b/fuel-vm/src/interpreter/executors/predicate.rs
@@ -30,18 +30,7 @@ where
     pub(crate) fn verify_predicate(
         &mut self,
     ) -> Result<ProgramState, PredicateVerificationFailed> {
-        let range = self
-            .context
-            .predicate()
-            .expect("The predicate is not initialized")
-            .program()
-            .words();
-
         loop {
-            if range.end <= self.registers[RegId::PC] {
-                return Err(PanicReason::MemoryOverflow.into())
-            }
-
             match self.execute()? {
                 ExecuteState::Return(r) => {
                     if r == 1 {

--- a/fuel-vm/src/interpreter/executors/predicate.rs
+++ b/fuel-vm/src/interpreter/executors/predicate.rs
@@ -15,15 +15,16 @@ use crate::{
     storage::PredicateStorage,
 };
 
-use crate::storage::predicate::PredicateBlobStorage;
+use crate::storage::BlobData;
 use fuel_asm::PanicReason;
+use fuel_storage::StorageRead;
 
 impl<M, Tx, Ecal, S> Interpreter<M, PredicateStorage<S>, Tx, Ecal>
 where
     M: Memory,
     Tx: ExecutableTransaction,
     Ecal: EcalHandler,
-    S: PredicateBlobStorage,
+    S: StorageRead<BlobData> + Clone,
 {
     /// Verify a predicate that has been initialized already
     pub(crate) fn verify_predicate(

--- a/fuel-vm/src/lib.rs
+++ b/fuel-vm/src/lib.rs
@@ -18,7 +18,9 @@ pub extern crate alloc;
 
 extern crate core;
 #[cfg(feature = "std")]
-extern crate libm as _; // Not needed with stdlib
+extern crate libm as _;
+
+// Not needed with stdlib
 #[cfg(test)]
 use criterion as _;
 

--- a/fuel-vm/src/lib.rs
+++ b/fuel-vm/src/lib.rs
@@ -18,9 +18,8 @@ pub extern crate alloc;
 
 extern crate core;
 #[cfg(feature = "std")]
-extern crate libm as _;
+extern crate libm as _; // Not needed with stdlib
 
-// Not needed with stdlib
 #[cfg(test)]
 use criterion as _;
 
@@ -147,6 +146,7 @@ pub mod prelude {
             RuntimeError,
         },
         interpreter::{
+            predicates,
             ExecutableTransaction,
             Interpreter,
             Memory,
@@ -162,8 +162,8 @@ pub mod prelude {
             StateTransitionRef,
         },
         storage::{
+            predicate::PredicateStorage,
             InterpreterStorage,
-            PredicateStorage,
         },
         transactor::Transactor,
     };

--- a/fuel-vm/src/predicate.rs
+++ b/fuel-vm/src/predicate.rs
@@ -76,6 +76,7 @@ mod tests {
         constraints::reg_key::{
             HP,
             IS,
+            ONE,
             SSP,
             ZERO,
         },
@@ -383,6 +384,17 @@ mod tests {
                     PanicInstruction::error(
                         PanicReason::ContractInstructionNotAllowed,
                         op::time(0x20, 0x1).into(),
+                    ),
+                )),
+            ),
+            (
+                // Using a contract instruction
+                vec![op::ldc(ONE, ONE, ONE, 0)],
+                CORRECT_GAS,
+                Err(PredicateVerificationFailed::PanicInstruction(
+                    PanicInstruction::error(
+                        PanicReason::ContractInstructionNotAllowed,
+                        op::ldc(ONE, ONE, ONE, 0).into(),
                     ),
                 )),
             ),

--- a/fuel-vm/src/predicate.rs
+++ b/fuel-vm/src/predicate.rs
@@ -48,6 +48,7 @@ impl RuntimePredicate {
     }
 }
 
+#[allow(clippy::cast_possible_truncation)]
 #[cfg(test)]
 mod tests {
     use alloc::{
@@ -68,11 +69,26 @@ mod tests {
     };
 
     use crate::{
-        checked_transaction::CheckPredicateParams,
+        checked_transaction::{
+            CheckPredicateParams,
+            EstimatePredicates,
+        },
+        constraints::reg_key::{
+            HP,
+            IS,
+            SSP,
+            ZERO,
+        },
         error::PredicateVerificationFailed,
         interpreter::InterpreterParams,
-        prelude::*,
-        storage::PredicateStorage,
+        prelude::{
+            predicates::check_predicates,
+            *,
+        },
+        storage::{
+            predicate::empty_predicate_storage,
+            BlobData,
+        },
     };
 
     #[test]
@@ -147,7 +163,7 @@ mod tests {
 
             let mut interpreter = Interpreter::<_, _, _>::with_storage(
                 MemoryInstance::new(),
-                PredicateStorage,
+                empty_predicate_storage(),
                 InterpreterParams::default(),
             );
 
@@ -180,16 +196,29 @@ mod tests {
         }
     }
 
-    /// Verifies the runtime predicate validation rules outlined in the spec are actually
-    /// validated https://github.com/FuelLabs/fuel-specs/blob/master/src/fuel-vm/index.md#predicate-verification
-    #[test]
-    fn inputs_are_validated() {
+    fn assert_inputs_are_validated_for_predicates(
+        inputs: Vec<(
+            Vec<Instruction>,
+            bool,
+            Result<(), PredicateVerificationFailed>,
+        )>,
+        blob: Vec<Instruction>,
+    ) {
         let rng = &mut StdRng::seed_from_u64(2322u64);
 
         let height = 1.into();
         let predicate_data =
             b"If you think it's simple, then you have misunderstood the problem."
                 .to_vec();
+
+        let mut storage = MemoryStorage::new(Default::default(), Default::default());
+
+        let blob_id = BlobId::zeroed();
+        let blob: Vec<u8> = blob.into_iter().collect();
+        storage
+            .storage_as_mut::<BlobData>()
+            .insert(&blob_id, &blob)
+            .unwrap();
 
         macro_rules! predicate_input {
             ($predicate:expr) => {{
@@ -202,7 +231,7 @@ mod tests {
                         rng.gen(),
                         rng.gen(),
                         rng.gen(),
-                        15,
+                        0,
                         predicate.clone(),
                         predicate_data.clone(),
                     ),
@@ -211,7 +240,7 @@ mod tests {
                         owner,
                         rng.gen(),
                         rng.gen(),
-                        15,
+                        0,
                         predicate.clone(),
                         predicate_data.clone(),
                     ),
@@ -220,7 +249,7 @@ mod tests {
                         owner,
                         rng.gen(),
                         rng.gen(),
-                        15,
+                        0,
                         vec![rng.gen(); rng.gen_range(1..100)],
                         predicate.clone(),
                         predicate_data.clone(),
@@ -229,31 +258,127 @@ mod tests {
             }};
         }
 
+        for (i, (input_predicate, correct_gas, expected)) in
+            inputs.into_iter().enumerate()
+        {
+            let input_group = predicate_input!(input_predicate);
+            for mut input in input_group {
+                if !correct_gas {
+                    input.set_predicate_gas_used(1234);
+                }
+
+                let mut script = TransactionBuilder::script(
+                    [op::ret(0x01)].into_iter().collect(),
+                    vec![],
+                )
+                .add_input(input)
+                .add_fee_input()
+                .finalize();
+
+                if correct_gas {
+                    script
+                        .estimate_predicates(
+                            &CheckPredicateParams::default(),
+                            MemoryInstance::new(),
+                            &storage,
+                        )
+                        .unwrap();
+                }
+
+                let tx = script
+                    .into_checked_basic(height, &Default::default())
+                    .unwrap();
+
+                let result = check_predicates(
+                    &tx,
+                    &CheckPredicateParams::default(),
+                    MemoryInstance::new(),
+                    &storage,
+                );
+
+                assert_eq!(result.map(|_| ()), expected, "failed at input {}", i);
+            }
+        }
+    }
+
+    /// Verifies the runtime predicate validation rules outlined in the spec are actually
+    /// validated https://github.com/FuelLabs/fuel-specs/blob/master/src/fuel-vm/index.md#predicate-verification
+    #[test]
+    fn inputs_are_validated_for_good_predicate_inputs() {
+        const CORRECT_GAS: bool = true;
+        let good_blob = vec![op::noop(), op::ret(0x01)];
+
         let inputs = vec![
             (
                 // A valid predicate
-                predicate_input!(vec![
+                vec![
                     op::addi(0x10, 0x00, 0x01),
                     op::addi(0x10, 0x10, 0x01),
                     op::ret(0x01),
-                ]),
+                ],
+                CORRECT_GAS,
                 Ok(()),
             ),
             (
+                // PC exceeding predicate bounds
+                vec![
+                    // Allocate 32 byte on the heap.
+                    op::movi(0x10, 32),
+                    op::aloc(0x10),
+                    // This will be our zeroed blob id
+                    op::move_(0x10, HP),
+                    // Store the size of the blob
+                    op::bsiz(0x11, 0x10),
+                    // Store start of the blob code
+                    op::move_(0x12, SSP),
+                    // Subtract the start of the code from the end of the code
+                    op::sub(0x12, 0x12, IS),
+                    // Divide the code by the instruction size to get the number of
+                    // instructions
+                    op::divi(0x12, 0x12, Instruction::SIZE as u16),
+                    // Load the blob by `0x10` ID with the `0x11` size
+                    op::ldc(0x10, ZERO, 0x11, 1),
+                    // Jump to a new code location
+                    op::jmp(0x12),
+                ],
+                CORRECT_GAS,
+                Ok(()),
+            ),
+        ];
+
+        assert_inputs_are_validated_for_predicates(inputs, good_blob)
+    }
+
+    #[test]
+    fn inputs_are_validated_for_bad_predicate_inputs() {
+        const CORRECT_GAS: bool = true;
+        const INCORRECT_GAS: bool = false;
+
+        let bad_blob = vec![op::noop(), op::ret(0x00)];
+
+        let inputs = vec![
+            (
                 // A valid predicate, but gas amount mismatches
-                predicate_input!(vec![op::ret(0x01),]),
+                vec![
+                    op::addi(0x10, 0x00, 0x01),
+                    op::addi(0x10, 0x10, 0x01),
+                    op::ret(0x01),
+                ],
+                INCORRECT_GAS,
                 Err(PredicateVerificationFailed::GasMismatch),
             ),
             (
                 // Returning an invalid value
-                predicate_input!(vec![op::ret(0x0)]),
+                vec![op::ret(0x0)],
+                CORRECT_GAS,
                 Err(PredicateVerificationFailed::Panic(
                     PanicReason::PredicateReturnedNonOne,
                 )),
             ),
             (
                 // Using a contract instruction
-                predicate_input!(vec![op::time(0x20, 0x1), op::ret(0x1)]),
+                vec![op::time(0x20, 0x1), op::ret(0x1)],
+                CORRECT_GAS,
                 Err(PredicateVerificationFailed::PanicInstruction(
                     PanicInstruction::error(
                         PanicReason::ContractInstructionNotAllowed,
@@ -263,31 +388,33 @@ mod tests {
             ),
             (
                 // PC exceeding predicate bounds
-                predicate_input!(vec![op::ji(0x100), op::ret(0x1)]),
+                vec![
+                    // Allocate 32 byte on the heap.
+                    op::movi(0x10, 32),
+                    op::aloc(0x10),
+                    // This will be our zeroed blob id
+                    op::move_(0x10, HP),
+                    // Store the size of the blob
+                    op::bsiz(0x11, 0x10),
+                    // Store start of the blob code
+                    op::move_(0x12, SSP),
+                    // Subtract the start of the code from the end of the code
+                    op::sub(0x12, 0x12, IS),
+                    // Divide the code by the instruction size to get the number of
+                    // instructions
+                    op::divi(0x12, 0x12, Instruction::SIZE as u16),
+                    // Load the blob by `0x10` ID with the `0x11` size
+                    op::ldc(0x10, ZERO, 0x11, 1),
+                    // Jump to a new code location
+                    op::jmp(0x12),
+                ],
+                CORRECT_GAS,
                 Err(PredicateVerificationFailed::Panic(
-                    PanicReason::MemoryOverflow,
+                    PanicReason::PredicateReturnedNonOne,
                 )),
             ),
         ];
 
-        for (input_group, expected) in inputs {
-            for input in input_group {
-                let tx = TransactionBuilder::script(
-                    [op::ret(0x01)].into_iter().collect(),
-                    vec![],
-                )
-                .add_input(input)
-                .add_fee_input()
-                .finalize_checked_basic(height);
-
-                let result = Interpreter::check_predicates(
-                    &tx,
-                    &CheckPredicateParams::default(),
-                    MemoryInstance::new(),
-                );
-
-                assert_eq!(result.map(|_| ()), expected);
-            }
-        }
+        assert_inputs_are_validated_for_predicates(inputs, bad_blob)
     }
 }

--- a/fuel-vm/src/storage.rs
+++ b/fuel-vm/src/storage.rs
@@ -13,7 +13,7 @@ mod contracts_state;
 mod interpreter;
 #[cfg(feature = "test-helpers")]
 mod memory;
-pub(crate) mod predicate;
+pub mod predicate;
 
 pub use blob_data::{
     BlobBytes,

--- a/fuel-vm/src/storage.rs
+++ b/fuel-vm/src/storage.rs
@@ -34,7 +34,6 @@ pub use interpreter::{
 };
 #[cfg(feature = "test-helpers")]
 pub use memory::MemoryStorage;
-pub use predicate::PredicateStorage;
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;

--- a/fuel-vm/src/storage/memory.rs
+++ b/fuel-vm/src/storage/memory.rs
@@ -35,18 +35,18 @@ use fuel_types::{
 };
 use tai64::Tai64;
 
+use super::{
+    interpreter::ContractsAssetsStorage,
+    BlobBytes,
+    BlobData,
+};
+use crate::storage::predicate::PredicateBlobStorage;
 use alloc::{
     borrow::Cow,
     collections::BTreeMap,
     vec::Vec,
 };
 use core::convert::Infallible;
-
-use super::{
-    interpreter::ContractsAssetsStorage,
-    BlobBytes,
-    BlobData,
-};
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 struct MemoryStorageInner {
@@ -199,6 +199,8 @@ impl Default for MemoryStorage {
         Self::new(block_height, coinbase)
     }
 }
+
+impl PredicateBlobStorage for MemoryStorage {}
 
 impl StorageInspect<ContractsRawCode> for MemoryStorage {
     type Error = Infallible;

--- a/fuel-vm/src/storage/memory.rs
+++ b/fuel-vm/src/storage/memory.rs
@@ -41,6 +41,7 @@ use super::{
     BlobData,
 };
 
+use crate::storage::predicate::PredicateStorageRequirements;
 use alloc::{
     borrow::Cow,
     collections::BTreeMap,
@@ -721,6 +722,12 @@ impl InterpreterStorage for MemoryStorage {
             c != contract || !r
         });
         Ok((all_set_key && values.is_empty()).then_some(()))
+    }
+}
+
+impl PredicateStorageRequirements for MemoryStorage {
+    fn storage_error_to_string(error: Self::Error) -> alloc::string::String {
+        alloc::format!("{:?}", error)
     }
 }
 

--- a/fuel-vm/src/storage/memory.rs
+++ b/fuel-vm/src/storage/memory.rs
@@ -40,7 +40,7 @@ use super::{
     BlobBytes,
     BlobData,
 };
-use crate::storage::predicate::PredicateBlobStorage;
+
 use alloc::{
     borrow::Cow,
     collections::BTreeMap,
@@ -199,8 +199,6 @@ impl Default for MemoryStorage {
         Self::new(block_height, coinbase)
     }
 }
-
-impl PredicateBlobStorage for MemoryStorage {}
 
 impl StorageInspect<ContractsRawCode> for MemoryStorage {
     type Error = Infallible;

--- a/fuel-vm/src/storage/predicate.rs
+++ b/fuel-vm/src/storage/predicate.rs
@@ -86,23 +86,6 @@ impl From<PredicateStorageError> for RuntimeError<PredicateStorageError> {
     }
 }
 
-/// Storage is unavailable in predicate context.
-#[derive(Debug, Clone, Copy)]
-pub struct StorageUnavailable;
-
-impl From<StorageUnavailable> for InterpreterError<StorageUnavailable> {
-    fn from(val: StorageUnavailable) -> Self {
-        let rt: RuntimeError<StorageUnavailable> = val.into();
-        rt.into()
-    }
-}
-
-impl From<StorageUnavailable> for RuntimeError<StorageUnavailable> {
-    fn from(val: StorageUnavailable) -> Self {
-        RuntimeError::Storage(val)
-    }
-}
-
 /// Storage requirements for predicates.
 pub trait PredicateStorageRequirements
 where

--- a/fuel-vm/src/storage/predicate.rs
+++ b/fuel-vm/src/storage/predicate.rs
@@ -52,6 +52,7 @@ impl<D: StorageRead<BlobData>> PredicateStorage<D> {
     }
 }
 
+/// Errors that happen when using predicate storage
 #[derive(Debug, Clone, Copy)]
 pub enum PredicateStorageError {
     /// Storage operation is unavailable in predicate context.

--- a/fuel-vm/src/storage/predicate.rs
+++ b/fuel-vm/src/storage/predicate.rs
@@ -1,8 +1,3 @@
-use alloc::{
-    borrow::Cow,
-    vec::Vec,
-};
-
 use crate::{
     prelude::{
         InterpreterError,
@@ -10,10 +5,16 @@ use crate::{
     },
     storage::InterpreterStorage,
 };
+use alloc::{
+    borrow::Cow,
+    vec::Vec,
+};
+use core::fmt::Debug;
 
 use fuel_asm::Word;
 use fuel_storage::{
     Mappable,
+    StorageAsMut,
     StorageInspect,
     StorageMutate,
     StorageRead,
@@ -40,11 +41,44 @@ use super::{
 /// The storage implementations are expected to provide KV-like operations for contract
 /// operations. However, predicates, as defined in the protocol, cannot execute contract
 /// opcodes. This means its storage backend for predicate execution shouldn't provide any
-/// functionality.
-///
-/// TODO: blob storage should be implemented
+/// functionality. Unless the storage access is limited to immutable data and read-only.
 #[derive(Debug, Default, Clone, Copy)]
-pub struct PredicateStorage;
+pub struct PredicateStorage<D: PredicateBlobStorage> {
+    storage: D,
+}
+
+impl<D: PredicateBlobStorage> PredicateStorage<D> {
+    pub fn new(storage: D) -> Self {
+        Self { storage }
+    }
+}
+
+pub trait PredicateBlobStorage: StorageRead<BlobData> + Clone
+where
+    Self::Error: Debug,
+{
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum PredicateStorageError<E> {
+    /// Storage operation is unavailable in predicate context.
+    UnsupportedStorageOperation,
+    /// An storage error occurred
+    WrappedError(E),
+}
+
+impl<E> From<PredicateStorageError<E>> for InterpreterError<PredicateStorageError<E>> {
+    fn from(val: PredicateStorageError<E>) -> Self {
+        let rt: RuntimeError<StorageUnavailable> = val.into();
+        rt.into()
+    }
+}
+
+impl<E> From<PredicateStorageError<E>> for RuntimeError<PredicateStorageError<E>> {
+    fn from(val: PredicateStorageError<E>) -> Self {
+        RuntimeError::Storage(val)
+    }
+}
 
 /// Storage is unavailable in predicate context.
 #[derive(Debug, Clone, Copy)]
@@ -63,71 +97,85 @@ impl From<StorageUnavailable> for RuntimeError<StorageUnavailable> {
     }
 }
 
-impl<Type: Mappable> StorageInspect<Type> for PredicateStorage {
-    type Error = StorageUnavailable;
+impl<Type, D> StorageInspect<Type> for PredicateStorage<D>
+where
+    Type: Mappable,
+    D: StorageRead<BlobData>,
+{
+    type Error = PredicateStorageError<D::Error>;
 
     fn get(
         &self,
         _key: &Type::Key,
-    ) -> Result<Option<Cow<'_, Type::OwnedValue>>, StorageUnavailable> {
-        Err(StorageUnavailable)
+    ) -> Result<Option<Cow<'_, Type::OwnedValue>>, Self::Error> {
+        Err(Self::Error::UnsupportedStorageOperation)
     }
 
-    fn contains_key(&self, _key: &Type::Key) -> Result<bool, StorageUnavailable> {
-        Err(StorageUnavailable)
+    fn contains_key(&self, _key: &Type::Key) -> Result<bool, Self::Error> {
+        Err(Self::Error::UnsupportedStorageOperation)
     }
 }
 
-impl<Type: Mappable> StorageMutate<Type> for PredicateStorage {
+impl<Type, D> StorageMutate<Type> for PredicateStorage<D>
+where
+    Type: Mappable,
+    D: StorageRead<BlobData>,
+{
     fn replace(
         &mut self,
         _key: &Type::Key,
         _value: &Type::Value,
-    ) -> Result<Option<Type::OwnedValue>, StorageUnavailable> {
-        Err(StorageUnavailable)
+    ) -> Result<Option<Type::OwnedValue>, Self::Error> {
+        Err(Self::Error::UnsupportedStorageOperation)
     }
 
     fn take(
         &mut self,
         _key: &Type::Key,
-    ) -> Result<Option<Type::OwnedValue>, StorageUnavailable> {
-        Err(StorageUnavailable)
+    ) -> Result<Option<Type::OwnedValue>, Self::Error> {
+        Err(Self::Error::UnsupportedStorageOperation)
     }
 }
 
-impl StorageSize<ContractsRawCode> for PredicateStorage {
-    fn size_of_value(
-        &self,
-        _key: &ContractId,
-    ) -> Result<Option<usize>, StorageUnavailable> {
-        Err(StorageUnavailable)
+impl<D> StorageSize<ContractsRawCode> for PredicateStorage<D>
+where
+    D: StorageRead<BlobData>,
+{
+    fn size_of_value(&self, _key: &ContractId) -> Result<Option<usize>, Self::Error> {
+        Err(Self::Error::UnsupportedStorageOperation)
     }
 }
 
-impl StorageRead<ContractsRawCode> for PredicateStorage {
+impl<D> StorageRead<ContractsRawCode> for PredicateStorage<D>
+where
+    D: StorageRead<BlobData>,
+{
     fn read(
         &self,
         _key: &<ContractsRawCode as Mappable>::Key,
         _buf: &mut [u8],
-    ) -> Result<Option<usize>, StorageUnavailable> {
-        Err(StorageUnavailable)
+    ) -> Result<Option<usize>, Self::Error> {
+        Err(Self::Error::UnsupportedStorageOperation)
     }
 
     fn read_alloc(
         &self,
         _key: &<ContractsRawCode as Mappable>::Key,
-    ) -> Result<Option<Vec<u8>>, StorageUnavailable> {
-        Err(StorageUnavailable)
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        Err(Self::Error::UnsupportedStorageOperation)
     }
 }
 
-impl StorageWrite<ContractsRawCode> for PredicateStorage {
+impl<D> StorageWrite<ContractsRawCode> for PredicateStorage<D>
+where
+    D: StorageRead<BlobData>,
+{
     fn write_bytes(
         &mut self,
         _key: &<ContractsRawCode as Mappable>::Key,
         _buf: &[u8],
     ) -> Result<usize, Self::Error> {
-        Err(StorageUnavailable)
+        Err(Self::Error::UnsupportedStorageOperation)
     }
 
     fn replace_bytes(
@@ -135,50 +183,59 @@ impl StorageWrite<ContractsRawCode> for PredicateStorage {
         _key: &<ContractsRawCode as Mappable>::Key,
         _buf: &[u8],
     ) -> Result<(usize, Option<Vec<u8>>), Self::Error> {
-        Err(StorageUnavailable)
+        Err(Self::Error::UnsupportedStorageOperation)
     }
 
     fn take_bytes(
         &mut self,
         _key: &<ContractsRawCode as Mappable>::Key,
     ) -> Result<Option<Vec<u8>>, Self::Error> {
-        Err(StorageUnavailable)
+        Err(Self::Error::UnsupportedStorageOperation)
     }
 }
 
-impl StorageSize<ContractsState> for PredicateStorage {
+impl<D> StorageSize<ContractsState> for PredicateStorage<D>
+where
+    D: StorageRead<BlobData>,
+{
     fn size_of_value(
         &self,
         _key: &<ContractsState as Mappable>::Key,
-    ) -> Result<Option<usize>, StorageUnavailable> {
-        Err(StorageUnavailable)
+    ) -> Result<Option<usize>, Self::Error> {
+        Err(Self::Error::UnsupportedStorageOperation)
     }
 }
 
-impl StorageRead<ContractsState> for PredicateStorage {
+impl<D> StorageRead<ContractsState> for PredicateStorage<D>
+where
+    D: StorageRead<BlobData>,
+{
     fn read(
         &self,
         _key: &<ContractsState as Mappable>::Key,
         _buf: &mut [u8],
-    ) -> Result<Option<usize>, StorageUnavailable> {
-        Err(StorageUnavailable)
+    ) -> Result<Option<usize>, Self::Error> {
+        Err(Self::Error::UnsupportedStorageOperation)
     }
 
     fn read_alloc(
         &self,
         _key: &<ContractsState as Mappable>::Key,
-    ) -> Result<Option<Vec<u8>>, StorageUnavailable> {
-        Err(StorageUnavailable)
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        Err(Self::Error::UnsupportedStorageOperation)
     }
 }
 
-impl StorageWrite<ContractsState> for PredicateStorage {
+impl<D> StorageWrite<ContractsState> for PredicateStorage<D>
+where
+    D: StorageRead<BlobData>,
+{
     fn write_bytes(
         &mut self,
         _key: &<ContractsState as Mappable>::Key,
         _buf: &[u8],
     ) -> Result<usize, Self::Error> {
-        Err(StorageUnavailable)
+        Err(Self::Error::UnsupportedStorageOperation)
     }
 
     fn replace_bytes(
@@ -186,50 +243,62 @@ impl StorageWrite<ContractsState> for PredicateStorage {
         _key: &<ContractsState as Mappable>::Key,
         _buf: &[u8],
     ) -> Result<(usize, Option<Vec<u8>>), Self::Error> {
-        Err(StorageUnavailable)
+        Err(Self::Error::UnsupportedStorageOperation)
     }
 
     fn take_bytes(
         &mut self,
         _key: &<ContractsState as Mappable>::Key,
     ) -> Result<Option<Vec<u8>>, Self::Error> {
-        Err(StorageUnavailable)
+        Err(Self::Error::UnsupportedStorageOperation)
     }
 }
 
-impl StorageSize<BlobData> for PredicateStorage {
+impl<D> StorageSize<BlobData> for PredicateStorage<D>
+where
+    D: StorageRead<BlobData>,
+{
     fn size_of_value(
         &self,
-        _key: &<BlobData as Mappable>::Key,
-    ) -> Result<Option<usize>, StorageUnavailable> {
-        Err(StorageUnavailable)
+        key: &<BlobData as Mappable>::Key,
+    ) -> Result<Option<usize>, Self::Error> {
+        StorageSize::<BlobData>::size_of_value(&self.storage, key)
+            .map_err(|e| Self::Error::WrappedError(e))
     }
 }
 
-impl StorageRead<BlobData> for PredicateStorage {
+impl<D> StorageRead<BlobData> for PredicateStorage<D>
+where
+    D: StorageRead<BlobData>,
+{
     fn read(
         &self,
-        _key: &<BlobData as Mappable>::Key,
-        _buf: &mut [u8],
-    ) -> Result<Option<usize>, StorageUnavailable> {
-        Err(StorageUnavailable)
+        key: &<BlobData as Mappable>::Key,
+        buf: &mut [u8],
+    ) -> Result<Option<usize>, Self::Error> {
+        StorageRead::<BlobData>::read(&self.storage, key, buf)
+            .map_err(|e| Self::Error::WrappedError(e))
     }
 
     fn read_alloc(
         &self,
-        _key: &<BlobData as Mappable>::Key,
-    ) -> Result<Option<Vec<u8>>, StorageUnavailable> {
-        Err(StorageUnavailable)
+        key: &<BlobData as Mappable>::Key,
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        StorageRead::<BlobData>::read_alloc(&self.storage, key)
+            .map_err(|e| Self::Error::WrappedError(e))
     }
 }
 
-impl StorageWrite<BlobData> for PredicateStorage {
+impl<D> StorageWrite<BlobData> for PredicateStorage<D>
+where
+    D: StorageRead<BlobData>,
+{
     fn write_bytes(
         &mut self,
         _key: &<BlobData as Mappable>::Key,
         _buf: &[u8],
     ) -> Result<usize, Self::Error> {
-        Err(StorageUnavailable)
+        Err(Self::Error::UnsupportedStorageOperation)
     }
 
     fn replace_bytes(
@@ -237,47 +306,48 @@ impl StorageWrite<BlobData> for PredicateStorage {
         _key: &<BlobData as Mappable>::Key,
         _buf: &[u8],
     ) -> Result<(usize, Option<Vec<u8>>), Self::Error> {
-        Err(StorageUnavailable)
+        Err(Self::Error::UnsupportedStorageOperation)
     }
 
     fn take_bytes(
         &mut self,
         _key: &<BlobData as Mappable>::Key,
     ) -> Result<Option<Vec<u8>>, Self::Error> {
-        Err(StorageUnavailable)
+        Err(Self::Error::UnsupportedStorageOperation)
     }
 }
 
-impl ContractsAssetsStorage for PredicateStorage {}
+impl<D> ContractsAssetsStorage for PredicateStorage<D> where D: StorageRead<BlobData> {}
 
-impl InterpreterStorage for PredicateStorage {
-    type DataError = StorageUnavailable;
+impl<D> InterpreterStorage for PredicateStorage<D>
+where
+    D: StorageRead<BlobData>,
+    D::Error: Debug,
+{
+    type DataError = PredicateStorageError<D::Error>;
 
-    fn block_height(&self) -> Result<BlockHeight, StorageUnavailable> {
-        Err(StorageUnavailable)
+    fn block_height(&self) -> Result<BlockHeight, Self::DataError> {
+        Err(Self::DataError::UnsupportedStorageOperation)
     }
 
     fn consensus_parameters_version(&self) -> Result<u32, Self::DataError> {
-        Err(StorageUnavailable)
+        Err(Self::DataError::UnsupportedStorageOperation)
     }
 
     fn state_transition_version(&self) -> Result<u32, Self::DataError> {
-        Err(StorageUnavailable)
+        Err(Self::DataError::UnsupportedStorageOperation)
     }
 
-    fn timestamp(&self, _height: BlockHeight) -> Result<Word, StorageUnavailable> {
-        Err(StorageUnavailable)
+    fn timestamp(&self, _height: BlockHeight) -> Result<Word, Self::DataError> {
+        Err(Self::DataError::UnsupportedStorageOperation)
     }
 
-    fn block_hash(
-        &self,
-        _block_height: BlockHeight,
-    ) -> Result<Bytes32, StorageUnavailable> {
-        Err(StorageUnavailable)
+    fn block_hash(&self, _block_height: BlockHeight) -> Result<Bytes32, Self::DataError> {
+        Err(Self::DataError::UnsupportedStorageOperation)
     }
 
-    fn coinbase(&self) -> Result<ContractId, StorageUnavailable> {
-        Err(StorageUnavailable)
+    fn coinbase(&self) -> Result<ContractId, Self::DataError> {
+        Err(Self::DataError::UnsupportedStorageOperation)
     }
 
     fn set_consensus_parameters(
@@ -285,7 +355,7 @@ impl InterpreterStorage for PredicateStorage {
         _version: u32,
         _consensus_parameters: &ConsensusParameters,
     ) -> Result<Option<ConsensusParameters>, Self::DataError> {
-        Err(StorageUnavailable)
+        Err(Self::DataError::UnsupportedStorageOperation)
     }
 
     fn set_state_transition_bytecode(
@@ -293,7 +363,7 @@ impl InterpreterStorage for PredicateStorage {
         _version: u32,
         _hash: &Bytes32,
     ) -> Result<Option<Bytes32>, Self::DataError> {
-        Err(StorageUnavailable)
+        Err(Self::DataError::UnsupportedStorageOperation)
     }
 
     fn contract_state_range(
@@ -301,8 +371,8 @@ impl InterpreterStorage for PredicateStorage {
         _id: &ContractId,
         _start_key: &Bytes32,
         _range: usize,
-    ) -> Result<Vec<Option<Cow<ContractsStateData>>>, StorageUnavailable> {
-        Err(StorageUnavailable)
+    ) -> Result<Vec<Option<Cow<ContractsStateData>>>, Self::DataError> {
+        Err(Self::DataError::UnsupportedStorageOperation)
     }
 
     fn contract_state_insert_range<'a, I>(
@@ -314,7 +384,7 @@ impl InterpreterStorage for PredicateStorage {
     where
         I: Iterator<Item = &'a [u8]>,
     {
-        Err(StorageUnavailable)
+        Err(Self::DataError::UnsupportedStorageOperation)
     }
 
     fn contract_state_remove_range(
@@ -322,7 +392,7 @@ impl InterpreterStorage for PredicateStorage {
         _contract: &ContractId,
         _start_key: &Bytes32,
         _range: usize,
-    ) -> Result<Option<()>, StorageUnavailable> {
-        Err(StorageUnavailable)
+    ) -> Result<Option<()>, Self::DataError> {
+        Err(Self::DataError::UnsupportedStorageOperation)
     }
 }

--- a/fuel-vm/src/storage/predicate.rs
+++ b/fuel-vm/src/storage/predicate.rs
@@ -47,6 +47,7 @@ pub struct PredicateStorage<D: StorageRead<BlobData>> {
 }
 
 impl<D: StorageRead<BlobData>> PredicateStorage<D> {
+    /// instantiate predicate storage with access to Blobs
     pub fn new(storage: D) -> Self {
         Self { storage }
     }

--- a/fuel-vm/src/storage/predicate.rs
+++ b/fuel-vm/src/storage/predicate.rs
@@ -43,17 +43,17 @@ use super::{
 /// opcodes. This means its storage backend for predicate execution shouldn't provide any
 /// functionality. Unless the storage access is limited to immutable data and read-only.
 #[derive(Debug, Default, Clone, Copy)]
-pub struct PredicateStorage<D: PredicateBlobStorage> {
+pub struct PredicateStorage<D: StorageRead<BlobData> + Clone> {
     storage: D,
 }
 
-impl<D: PredicateBlobStorage> PredicateStorage<D> {
+impl<D: StorageRead<BlobData> + Clone> PredicateStorage<D> {
     pub fn new(storage: D) -> Self {
         Self { storage }
     }
 }
 
-pub trait PredicateBlobStorage: StorageRead<BlobData> + Clone {}
+// pub trait StorageRead<BlobData> + Clone: StorageRead<BlobData> + Clone {}
 
 #[derive(Debug, Clone, Copy)]
 pub enum PredicateStorageError {
@@ -96,7 +96,7 @@ impl From<StorageUnavailable> for RuntimeError<StorageUnavailable> {
 impl<Type, D> StorageInspect<Type> for PredicateStorage<D>
 where
     Type: Mappable,
-    D: PredicateBlobStorage,
+    D: StorageRead<BlobData> + Clone,
 {
     type Error = PredicateStorageError;
 
@@ -115,7 +115,7 @@ where
 impl<Type, D> StorageMutate<Type> for PredicateStorage<D>
 where
     Type: Mappable,
-    D: PredicateBlobStorage,
+    D: StorageRead<BlobData> + Clone,
 {
     fn replace(
         &mut self,
@@ -135,7 +135,7 @@ where
 
 impl<D> StorageSize<ContractsRawCode> for PredicateStorage<D>
 where
-    D: PredicateBlobStorage,
+    D: StorageRead<BlobData> + Clone,
 {
     fn size_of_value(&self, _key: &ContractId) -> Result<Option<usize>, Self::Error> {
         Err(Self::Error::UnsupportedStorageOperation)
@@ -144,7 +144,7 @@ where
 
 impl<D> StorageRead<ContractsRawCode> for PredicateStorage<D>
 where
-    D: PredicateBlobStorage,
+    D: StorageRead<BlobData> + Clone,
 {
     fn read(
         &self,
@@ -164,7 +164,7 @@ where
 
 impl<D> StorageWrite<ContractsRawCode> for PredicateStorage<D>
 where
-    D: PredicateBlobStorage,
+    D: StorageRead<BlobData> + Clone,
 {
     fn write_bytes(
         &mut self,
@@ -192,7 +192,7 @@ where
 
 impl<D> StorageSize<ContractsState> for PredicateStorage<D>
 where
-    D: PredicateBlobStorage,
+    D: StorageRead<BlobData> + Clone,
 {
     fn size_of_value(
         &self,
@@ -204,7 +204,7 @@ where
 
 impl<D> StorageRead<ContractsState> for PredicateStorage<D>
 where
-    D: PredicateBlobStorage,
+    D: StorageRead<BlobData> + Clone,
 {
     fn read(
         &self,
@@ -224,7 +224,7 @@ where
 
 impl<D> StorageWrite<ContractsState> for PredicateStorage<D>
 where
-    D: PredicateBlobStorage,
+    D: StorageRead<BlobData> + Clone,
 {
     fn write_bytes(
         &mut self,
@@ -252,7 +252,7 @@ where
 
 impl<D> StorageSize<BlobData> for PredicateStorage<D>
 where
-    D: PredicateBlobStorage,
+    D: StorageRead<BlobData> + Clone,
 {
     fn size_of_value(
         &self,
@@ -265,7 +265,7 @@ where
 
 impl<D> StorageRead<BlobData> for PredicateStorage<D>
 where
-    D: PredicateBlobStorage,
+    D: StorageRead<BlobData> + Clone,
 {
     fn read(
         &self,
@@ -287,7 +287,7 @@ where
 
 impl<D> StorageWrite<BlobData> for PredicateStorage<D>
 where
-    D: PredicateBlobStorage,
+    D: StorageRead<BlobData> + Clone,
 {
     fn write_bytes(
         &mut self,
@@ -313,11 +313,14 @@ where
     }
 }
 
-impl<D> ContractsAssetsStorage for PredicateStorage<D> where D: PredicateBlobStorage {}
+impl<D> ContractsAssetsStorage for PredicateStorage<D> where
+    D: StorageRead<BlobData> + Clone
+{
+}
 
 impl<D> InterpreterStorage for PredicateStorage<D>
 where
-    D: PredicateBlobStorage,
+    D: StorageRead<BlobData> + Clone,
 {
     type DataError = PredicateStorageError;
 

--- a/fuel-vm/src/storage/predicate.rs
+++ b/fuel-vm/src/storage/predicate.rs
@@ -14,7 +14,6 @@ use core::fmt::Debug;
 use fuel_asm::Word;
 use fuel_storage::{
     Mappable,
-    StorageAsMut,
     StorageInspect,
     StorageMutate,
     StorageRead,
@@ -42,18 +41,16 @@ use super::{
 /// operations. However, predicates, as defined in the protocol, cannot execute contract
 /// opcodes. This means its storage backend for predicate execution shouldn't provide any
 /// functionality. Unless the storage access is limited to immutable data and read-only.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct PredicateStorage<D: StorageRead<BlobData> + Clone> {
+#[derive(Debug, Default)]
+pub struct PredicateStorage<D: StorageRead<BlobData>> {
     storage: D,
 }
 
-impl<D: StorageRead<BlobData> + Clone> PredicateStorage<D> {
+impl<D: StorageRead<BlobData>> PredicateStorage<D> {
     pub fn new(storage: D) -> Self {
         Self { storage }
     }
 }
-
-// pub trait StorageRead<BlobData> + Clone: StorageRead<BlobData> + Clone {}
 
 #[derive(Debug, Clone, Copy)]
 pub enum PredicateStorageError {
@@ -96,7 +93,7 @@ impl From<StorageUnavailable> for RuntimeError<StorageUnavailable> {
 impl<Type, D> StorageInspect<Type> for PredicateStorage<D>
 where
     Type: Mappable,
-    D: StorageRead<BlobData> + Clone,
+    D: StorageRead<BlobData>,
 {
     type Error = PredicateStorageError;
 
@@ -115,7 +112,7 @@ where
 impl<Type, D> StorageMutate<Type> for PredicateStorage<D>
 where
     Type: Mappable,
-    D: StorageRead<BlobData> + Clone,
+    D: StorageRead<BlobData>,
 {
     fn replace(
         &mut self,
@@ -135,7 +132,7 @@ where
 
 impl<D> StorageSize<ContractsRawCode> for PredicateStorage<D>
 where
-    D: StorageRead<BlobData> + Clone,
+    D: StorageRead<BlobData>,
 {
     fn size_of_value(&self, _key: &ContractId) -> Result<Option<usize>, Self::Error> {
         Err(Self::Error::UnsupportedStorageOperation)
@@ -144,7 +141,7 @@ where
 
 impl<D> StorageRead<ContractsRawCode> for PredicateStorage<D>
 where
-    D: StorageRead<BlobData> + Clone,
+    D: StorageRead<BlobData>,
 {
     fn read(
         &self,
@@ -164,7 +161,7 @@ where
 
 impl<D> StorageWrite<ContractsRawCode> for PredicateStorage<D>
 where
-    D: StorageRead<BlobData> + Clone,
+    D: StorageRead<BlobData>,
 {
     fn write_bytes(
         &mut self,
@@ -192,7 +189,7 @@ where
 
 impl<D> StorageSize<ContractsState> for PredicateStorage<D>
 where
-    D: StorageRead<BlobData> + Clone,
+    D: StorageRead<BlobData>,
 {
     fn size_of_value(
         &self,
@@ -204,7 +201,7 @@ where
 
 impl<D> StorageRead<ContractsState> for PredicateStorage<D>
 where
-    D: StorageRead<BlobData> + Clone,
+    D: StorageRead<BlobData>,
 {
     fn read(
         &self,
@@ -224,7 +221,7 @@ where
 
 impl<D> StorageWrite<ContractsState> for PredicateStorage<D>
 where
-    D: StorageRead<BlobData> + Clone,
+    D: StorageRead<BlobData>,
 {
     fn write_bytes(
         &mut self,
@@ -252,7 +249,7 @@ where
 
 impl<D> StorageSize<BlobData> for PredicateStorage<D>
 where
-    D: StorageRead<BlobData> + Clone,
+    D: StorageRead<BlobData>,
 {
     fn size_of_value(
         &self,
@@ -265,7 +262,7 @@ where
 
 impl<D> StorageRead<BlobData> for PredicateStorage<D>
 where
-    D: StorageRead<BlobData> + Clone,
+    D: StorageRead<BlobData>,
 {
     fn read(
         &self,
@@ -287,7 +284,7 @@ where
 
 impl<D> StorageWrite<BlobData> for PredicateStorage<D>
 where
-    D: StorageRead<BlobData> + Clone,
+    D: StorageRead<BlobData>,
 {
     fn write_bytes(
         &mut self,
@@ -313,14 +310,11 @@ where
     }
 }
 
-impl<D> ContractsAssetsStorage for PredicateStorage<D> where
-    D: StorageRead<BlobData> + Clone
-{
-}
+impl<D> ContractsAssetsStorage for PredicateStorage<D> where D: StorageRead<BlobData> {}
 
 impl<D> InterpreterStorage for PredicateStorage<D>
 where
-    D: StorageRead<BlobData> + Clone,
+    D: StorageRead<BlobData>,
 {
     type DataError = PredicateStorageError;
 

--- a/fuel-vm/src/tests/crypto.rs
+++ b/fuel-vm/src/tests/crypto.rs
@@ -35,6 +35,7 @@ use sha3::{
 
 use crate::{
     prelude::*,
+    storage::predicate::EmptyStorage,
     tests::test_helpers::set_full_word,
     util::test_helpers::check_expected_reason_for_instructions,
 };
@@ -233,7 +234,11 @@ async fn recover_tx_id_predicate() {
         // parallel version
         let mut tx_for_async = tx.clone();
         tx_for_async
-            .estimate_predicates_async::<TokioWithRayon>(&check_params, &DummyPool)
+            .estimate_predicates_async::<TokioWithRayon>(
+                &check_params,
+                &DummyPool,
+                &EmptyStorage,
+            )
             .await
             .expect("Should estimate predicate successfully");
 
@@ -243,7 +248,7 @@ async fn recover_tx_id_predicate() {
     }
 
     // sequential version
-    tx.estimate_predicates(&check_params, MemoryInstance::new())
+    tx.estimate_predicates(&check_params, MemoryInstance::new(), &EmptyStorage)
         .expect("Should estimate predicate successfully");
 
     tx.into_checked(maturity, &consensus_params)

--- a/fuel-vm/src/tests/validation.rs
+++ b/fuel-vm/src/tests/validation.rs
@@ -33,6 +33,7 @@ use rand::{
     SeedableRng,
 };
 
+use crate::storage::predicate::EmptyStorage;
 #[cfg(feature = "alloc")]
 use alloc::vec;
 
@@ -129,8 +130,12 @@ fn malleable_fields_do_not_affect_validity_of_create() {
             Default::default(),
         ))
         .finalize();
-    tx.estimate_predicates(&CheckPredicateParams::from(&params), MemoryInstance::new())
-        .expect("Should estimate predicate");
+    tx.estimate_predicates(
+        &CheckPredicateParams::from(&params),
+        MemoryInstance::new(),
+        &EmptyStorage,
+    )
+    .expect("Should estimate predicate");
 
     let run_tx = |tx: Create| tx.into_checked(0u32.into(), &params).map(|_| ());
     let result = run_tx(tx.clone());
@@ -225,8 +230,12 @@ fn malleable_fields_do_not_affect_validity_of_script() {
         .add_output(Output::contract(1, Default::default(), Default::default()))
         .script_gas_limit(1_000_000)
         .finalize();
-    tx.estimate_predicates(&CheckPredicateParams::from(&params), MemoryInstance::new())
-        .expect("Should estimate predicate");
+    tx.estimate_predicates(
+        &CheckPredicateParams::from(&params),
+        MemoryInstance::new(),
+        &EmptyStorage,
+    )
+    .expect("Should estimate predicate");
 
     let run_tx = |tx: Script| tx.into_checked(0u32.into(), &params).map(|_| ());
     let result = run_tx(tx.clone());

--- a/fuel-vm/src/util.rs
+++ b/fuel-vm/src/util.rs
@@ -119,7 +119,10 @@ pub mod test_helpers {
             Backtrace,
             Call,
         },
-        storage::BlobData,
+        storage::{
+            predicate::PredicateBlobStorage,
+            BlobData,
+        },
     };
     use fuel_asm::{
         op,
@@ -359,7 +362,7 @@ pub mod test_helpers {
 
         pub fn build<S>(&mut self, storage: S) -> Checked<Script>
         where
-            S: StorageRead<BlobData> + Clone,
+            S: PredicateBlobStorage,
         {
             self.builder.max_fee_limit(self.max_fee_limit);
             self.builder.with_tx_params(*self.get_tx_params());
@@ -424,7 +427,7 @@ pub mod test_helpers {
             storage: S,
         ) -> Checked<Script>
         where
-            S: StorageRead<BlobData> + Clone,
+            S: PredicateBlobStorage,
         {
             let (script, _) = script_with_data_offset!(
                 data_offset,
@@ -467,7 +470,7 @@ pub mod test_helpers {
             storage: S,
         ) -> CreatedContract
         where
-            S: StorageRead<BlobData> + Clone,
+            S: PredicateBlobStorage,
         {
             self.setup_contract_inner(contract, initial_balance, initial_state, storage)
         }
@@ -480,7 +483,7 @@ pub mod test_helpers {
             storage: S,
         ) -> CreatedContract
         where
-            S: StorageRead<BlobData> + Clone,
+            S: PredicateBlobStorage,
         {
             let contract = contract.into_iter().collect();
 
@@ -495,7 +498,7 @@ pub mod test_helpers {
             storage: S,
         ) -> CreatedContract
         where
-            S: StorageRead<BlobData> + Clone,
+            S: PredicateBlobStorage,
         {
             let storage_slots = initial_state.unwrap_or_default();
 
@@ -536,7 +539,7 @@ pub mod test_helpers {
 
         pub fn setup_blob<S>(&mut self, data: Vec<u8>, storage: S)
         where
-            S: StorageRead<BlobData> + Clone,
+            S: PredicateBlobStorage,
         {
             let id = BlobId::compute(data.as_slice());
 
@@ -667,7 +670,7 @@ pub mod test_helpers {
         /// Build test tx and execute it
         pub fn execute<S>(&mut self, storage: S) -> StateTransition<Script>
         where
-            S: StorageRead<BlobData> + Clone,
+            S: PredicateBlobStorage,
         {
             let tx = self.build(storage);
 
@@ -681,7 +684,7 @@ pub mod test_helpers {
 
         pub fn execute_get_outputs<S>(&mut self, storage: S) -> Vec<Output>
         where
-            S: StorageRead<BlobData> + Clone,
+            S: PredicateBlobStorage,
         {
             self.execute(storage).tx().outputs().to_vec()
         }
@@ -692,7 +695,7 @@ pub mod test_helpers {
             storage: S,
         ) -> Word
         where
-            S: StorageRead<BlobData> + Clone,
+            S: PredicateBlobStorage,
         {
             let outputs = self.execute_get_outputs(storage);
             find_change(outputs, find_asset_id)
@@ -705,7 +708,7 @@ pub mod test_helpers {
             storage: S,
         ) -> Word
         where
-            S: StorageRead<BlobData> + Clone,
+            S: PredicateBlobStorage,
         {
             let tx = TestBuilder::build_get_balance_tx(
                 contract_id,

--- a/fuel-vm/src/util.rs
+++ b/fuel-vm/src/util.rs
@@ -119,10 +119,7 @@ pub mod test_helpers {
             Backtrace,
             Call,
         },
-        storage::{
-            predicate::PredicateBlobStorage,
-            BlobData,
-        },
+        storage::BlobData,
     };
     use fuel_asm::{
         op,
@@ -362,7 +359,7 @@ pub mod test_helpers {
 
         pub fn build<S>(&mut self, storage: S) -> Checked<Script>
         where
-            S: PredicateBlobStorage,
+            S: StorageRead<BlobData> + Clone,
         {
             self.builder.max_fee_limit(self.max_fee_limit);
             self.builder.with_tx_params(*self.get_tx_params());
@@ -427,7 +424,7 @@ pub mod test_helpers {
             storage: S,
         ) -> Checked<Script>
         where
-            S: PredicateBlobStorage,
+            S: StorageRead<BlobData> + Clone,
         {
             let (script, _) = script_with_data_offset!(
                 data_offset,
@@ -470,7 +467,7 @@ pub mod test_helpers {
             storage: S,
         ) -> CreatedContract
         where
-            S: PredicateBlobStorage,
+            S: StorageRead<BlobData> + Clone,
         {
             self.setup_contract_inner(contract, initial_balance, initial_state, storage)
         }
@@ -483,7 +480,7 @@ pub mod test_helpers {
             storage: S,
         ) -> CreatedContract
         where
-            S: PredicateBlobStorage,
+            S: StorageRead<BlobData> + Clone,
         {
             let contract = contract.into_iter().collect();
 
@@ -498,7 +495,7 @@ pub mod test_helpers {
             storage: S,
         ) -> CreatedContract
         where
-            S: PredicateBlobStorage,
+            S: StorageRead<BlobData> + Clone,
         {
             let storage_slots = initial_state.unwrap_or_default();
 
@@ -539,7 +536,7 @@ pub mod test_helpers {
 
         pub fn setup_blob<S>(&mut self, data: Vec<u8>, storage: S)
         where
-            S: PredicateBlobStorage,
+            S: StorageRead<BlobData> + Clone,
         {
             let id = BlobId::compute(data.as_slice());
 
@@ -670,7 +667,7 @@ pub mod test_helpers {
         /// Build test tx and execute it
         pub fn execute<S>(&mut self, storage: S) -> StateTransition<Script>
         where
-            S: PredicateBlobStorage,
+            S: StorageRead<BlobData> + Clone,
         {
             let tx = self.build(storage);
 
@@ -684,7 +681,7 @@ pub mod test_helpers {
 
         pub fn execute_get_outputs<S>(&mut self, storage: S) -> Vec<Output>
         where
-            S: PredicateBlobStorage,
+            S: StorageRead<BlobData> + Clone,
         {
             self.execute(storage).tx().outputs().to_vec()
         }
@@ -695,7 +692,7 @@ pub mod test_helpers {
             storage: S,
         ) -> Word
         where
-            S: PredicateBlobStorage,
+            S: StorageRead<BlobData> + Clone,
         {
             let outputs = self.execute_get_outputs(storage);
             find_change(outputs, find_asset_id)
@@ -708,7 +705,7 @@ pub mod test_helpers {
             storage: S,
         ) -> Word
         where
-            S: PredicateBlobStorage,
+            S: StorageRead<BlobData> + Clone,
         {
             let tx = TestBuilder::build_get_balance_tx(
                 contract_id,

--- a/fuel-vm/src/util.rs
+++ b/fuel-vm/src/util.rs
@@ -359,7 +359,7 @@ pub mod test_helpers {
 
         pub fn build<S>(&mut self, storage: S) -> Checked<Script>
         where
-            S: StorageRead<BlobData> + Clone,
+            S: StorageRead<BlobData>,
         {
             self.builder.max_fee_limit(self.max_fee_limit);
             self.builder.with_tx_params(*self.get_tx_params());
@@ -424,7 +424,7 @@ pub mod test_helpers {
             storage: S,
         ) -> Checked<Script>
         where
-            S: StorageRead<BlobData> + Clone,
+            S: StorageRead<BlobData>,
         {
             let (script, _) = script_with_data_offset!(
                 data_offset,
@@ -467,7 +467,7 @@ pub mod test_helpers {
             storage: S,
         ) -> CreatedContract
         where
-            S: StorageRead<BlobData> + Clone,
+            S: StorageRead<BlobData>,
         {
             self.setup_contract_inner(contract, initial_balance, initial_state, storage)
         }
@@ -480,7 +480,7 @@ pub mod test_helpers {
             storage: S,
         ) -> CreatedContract
         where
-            S: StorageRead<BlobData> + Clone,
+            S: StorageRead<BlobData>,
         {
             let contract = contract.into_iter().collect();
 
@@ -495,7 +495,7 @@ pub mod test_helpers {
             storage: S,
         ) -> CreatedContract
         where
-            S: StorageRead<BlobData> + Clone,
+            S: StorageRead<BlobData>,
         {
             let storage_slots = initial_state.unwrap_or_default();
 
@@ -536,7 +536,7 @@ pub mod test_helpers {
 
         pub fn setup_blob<S>(&mut self, data: Vec<u8>, storage: S)
         where
-            S: StorageRead<BlobData> + Clone,
+            S: StorageRead<BlobData>,
         {
             let id = BlobId::compute(data.as_slice());
 
@@ -667,7 +667,7 @@ pub mod test_helpers {
         /// Build test tx and execute it
         pub fn execute<S>(&mut self, storage: S) -> StateTransition<Script>
         where
-            S: StorageRead<BlobData> + Clone,
+            S: StorageRead<BlobData>,
         {
             let tx = self.build(storage);
 
@@ -681,7 +681,7 @@ pub mod test_helpers {
 
         pub fn execute_get_outputs<S>(&mut self, storage: S) -> Vec<Output>
         where
-            S: StorageRead<BlobData> + Clone,
+            S: StorageRead<BlobData>,
         {
             self.execute(storage).tx().outputs().to_vec()
         }
@@ -692,7 +692,7 @@ pub mod test_helpers {
             storage: S,
         ) -> Word
         where
-            S: StorageRead<BlobData> + Clone,
+            S: StorageRead<BlobData>,
         {
             let outputs = self.execute_get_outputs(storage);
             find_change(outputs, find_asset_id)
@@ -705,7 +705,7 @@ pub mod test_helpers {
             storage: S,
         ) -> Word
         where
-            S: StorageRead<BlobData> + Clone,
+            S: StorageRead<BlobData>,
         {
             let tx = TestBuilder::build_get_balance_tx(
                 contract_id,


### PR DESCRIPTION
Enables predicates to load immutable blobs of code from storage. This helps reduce bloating blockspace with large predicates.

Core changes:

- `$PC` can now jump outside of predicate memory range
- `ldc`, `bldd`, and `bsiz` instructions are allowed inside of predicates (but only for blobs, no contracts)
- verifying or estimating predicates now requires access to blob storage
