### PR TITLE
Release v0.58.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.58.0]
+
 ### Added
 - [#849](https://github.com/FuelLabs/fuel-vm/pull/849): Add a new mode `2` to the LDC that allows to use the memory as a source for code.
 - [#848](https://github.com/FuelLabs/fuel-vm/pull/848): Allow usage of the blob opcode `BSIZ`, `BLDD`, and `LDC` with mode `1` in the predicates.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,18 +18,18 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.57.1"
+version = "0.58.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.57.1", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.57.1", path = "fuel-crypto", default-features = false }
-fuel-compression = { version = "0.57.1", path = "fuel-compression", default-features = false }
-fuel-derive = { version = "0.57.1", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.57.1", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.57.1", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.57.1", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.57.1", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.57.1", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.58.0", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.58.0", path = "fuel-crypto", default-features = false }
+fuel-compression = { version = "0.58.0", path = "fuel-compression", default-features = false }
+fuel-derive = { version = "0.58.0", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.58.0", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.58.0", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.58.0", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.58.0", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.58.0", path = "fuel-vm", default-features = false }
 bitflags = "2"
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
## Version v0.58.0

### Added
- [#849](https://github.com/FuelLabs/fuel-vm/pull/849): Add a new mode `2` to the LDC that allows to use the memory as a source for code.
- [#848](https://github.com/FuelLabs/fuel-vm/pull/848): Allow usage of the blob opcode `BSIZ`, `BLDD`, and `LDC` with mode `1` in the predicates.
- [#838](https://github.com/FuelLabs/fuel-vm/pull/838): Implemented `AsRef<[u8]>` and `TryFrom<&[u8]>` for DA compression types: ScriptCode, PredicateCode, RegistryKey.
- [#820](https://github.com/FuelLabs/fuel-vm/pull/820): Add fuzzing in CI with ClusterFuzzLite.

### Removed

#### Breaking
- [#848](https://github.com/FuelLabs/fuel-vm/pull/848): All estimation and verification of predicate functionality is reworked and now requires the instance of the storage with predicates.
- [#843](https://github.com/FuelLabs/fuel-vm/pull/843): Remove `serde` feature from the `fuel-tx` crate. It is default behaviour now if you enable `alloc` feature.
- [#766](https://github.com/FuelLabs/fuel-vm/pull/766): Use correct gas price when validating native signatures

### Changed

#### Breaking
- [#829](https://github.com/FuelLabs/fuel-vm/pull/829): Updated `add_random_fee_input()` to accept an `rng` for true randomization. Introduced `add_fee_input()` to retain the previous behavior of `add_random_fee_input()`.
- [#845](https://github.com/FuelLabs/fuel-vm/pull/845): Removed `Default` implementation of `SecretKey`.
- [#844](https://github.com/FuelLabs/fuel-vm/pull/844): `WDCM` and `WQCM` reset `$of` and `$err`.

## What's Changed
* Add `fn add_fee_input()` and make `fn add_random_fee_input()` truly random by @rafal-ch in https://github.com/FuelLabs/fuel-vm/pull/829
* Add `Display` and `Error` impls to custom error type `SettingBlockTransactionSizeLimitNotSupported` by @rafal-ch in https://github.com/FuelLabs/fuel-vm/pull/833
* Fixing WASM-NPM packaging and publishing by @arboleya in https://github.com/FuelLabs/fuel-vm/pull/835
* Implemented `AsRef<[u8]>` and `TryFrom<&[u8]>` for DA compression types by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/838
* Update changelog to cover breaking changes around `add_random_fee_input()` by @rafal-ch in https://github.com/FuelLabs/fuel-vm/pull/836
* Remove `serde` feature from the `fuel-tx` crate by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/843
* Cherry pick Release v0.57.1 (#840) by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/841
* fix(SecretKey): remove Default implementation by @rymnc in https://github.com/FuelLabs/fuel-vm/pull/845
* WDCM and WQCM: reset $of and $err by @acerone85 in https://github.com/FuelLabs/fuel-vm/pull/844
* Add ClusterFuzzLite in CI featuring PR fuzzing, batch fuzzing and fuzz coverage reports by @netrome in https://github.com/FuelLabs/fuel-vm/pull/820
* Correct the price to verify native signatures by @Voxelot in https://github.com/FuelLabs/fuel-vm/pull/766
* LDC support in predicates by @Voxelot in https://github.com/FuelLabs/fuel-vm/pull/848
* Add a new mode `2` to the LDC that allows to use the memory as a source for code by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/849

## New Contributors
* @rymnc made their first contribution in https://github.com/FuelLabs/fuel-vm/pull/845

**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.57.0...v0.58.0