### PR TITLE
Fix incorrect padding of LDC mode 2 and release 0.58.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [Version 0.58.1]
+## [Version 0.58.2]
 
 ### Fixed
 - [#854](https://github.com/FuelLabs/fuel-vm/pull/854): Fixed a bug where LDC mode 2 padding bytes would be copied from memory instead of using zeroes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Version 0.58.1]
 
 ### Fixed
+- [#854](https://github.com/FuelLabs/fuel-vm/pull/854): Fixed a bug where LDC mode 2 padding bytes would be copied from memory instead of using zeroes.
+
+## [Version 0.58.1]
+
+### Fixed
 - [#852](https://github.com/FuelLabs/fuel-vm/pull/852): Fixed incorrect predicate estimation when max predicate gas is less than max tx gas.
 
 ## [Version 0.58.0]

--- a/fuel-vm/src/interpreter/blockchain.rs
+++ b/fuel-vm/src/interpreter/blockchain.rs
@@ -809,9 +809,7 @@ where
         let current_contract = current_contract(self.context, self.fp, self.memory)?;
 
         let length = bytes::padded_len_word(length_unpadded).unwrap_or(Word::MAX);
-        #[allow(clippy::arithmetic_side_effects)]
-        // length >= length_unpadded as per line above
-        let length_padding = length - length_unpadded;
+        let length_padding = length.saturating_sub(length_unpadded);
 
         // Fetch the storage blob
         let profiler = ProfileGas {

--- a/fuel-vm/src/tests/blockchain/ldc_mode_2.rs
+++ b/fuel-vm/src/tests/blockchain/ldc_mode_2.rs
@@ -16,6 +16,11 @@ use crate::{
         MemoryStorage,
         Transactor,
     },
+    tests::test_helpers::{
+        assert_success,
+        run_script,
+        set_full_word,
+    },
 };
 use alloc::{
     vec,
@@ -34,6 +39,50 @@ use fuel_tx::{
     Receipt,
     TransactionBuilder,
 };
+use test_case::test_case;
+
+fn ldcv2_data_init() -> Vec<Instruction> {
+    vec![
+        // Write bytes 0..16 to end of the heap
+        op::move_(0x11, RegId::HP),
+        op::movi(0x10, 16),
+        op::aloc(0x10),
+        // loop:
+        op::sub(0x10, 0x10, 1),
+        op::sub(0x11, 0x11, 1),
+        op::sb(0x11, 0x10, 0),
+        op::jnzb(0x10, RegId::ZERO, 2), // jmp loop
+    ]
+}
+
+#[test_case(0, 0 => Vec::<u8>::new())]
+#[test_case(0, 1 => vec![0; 8])]
+#[test_case(0, 2 => vec![0, 1, 0, 0, 0, 0, 0, 0])]
+#[test_case(0, 16 => vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])]
+#[test_case(1, 15 => vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0])]
+#[test_case(4, 12 => vec![4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 0, 0, 0])]
+#[test_case(7, 9 => vec![7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 0, 0, 0, 0, 0, 0])]
+#[test_case(8, 8 => vec![8, 9, 10, 11, 12, 13, 14, 15])]
+#[test_case(9, 7 => vec![9, 10, 11, 12, 13, 14, 15, 0])]
+fn ldcv2__has_correct_padding(offset: u32, len: u32) -> Vec<u8> {
+    let mut script = ldcv2_data_init();
+    let padded_len = len.next_multiple_of(8) as u64;
+    script.extend(set_full_word(0x14, padded_len));
+    script.extend([
+        op::movi(0x11, offset),
+        op::movi(0x12, len),
+        op::move_(0x13, RegId::SSP),
+        op::ldc(RegId::HP, 0x11, 0x12, 2),
+        op::logd(RegId::SSP, RegId::ZERO, 0x13, 0x14),
+        op::ret(0x1),
+    ]);
+    let receipts = run_script(script);
+    assert_success(&receipts);
+    let Some(Receipt::LogData { data, .. }) = receipts.first() else {
+        panic!("Expected LogData receipt");
+    };
+    data.clone().unwrap()
+}
 
 fn ldcv2_reason_helper(script: Vec<Instruction>) -> Result<(), PanicReason> {
     let gas_price = 0;


### PR DESCRIPTION
The following bug was reported:

> I think we should only copy length_unpadded instead of length [here](https://github.com/FuelLabs/fuel-vm/blob/4310f2e81d679dee046c2438ce43ff03808aad42/fuel-vm/src/interpreter/blockchain.rs#L837), and the remaining length-length_padded should be filled with null bytes.

This PR fixes the issue and adds a test case to show that the padding works correcty. While technically breaking, this is a bugfix release. The patch is released immediately.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [ ] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here
