### PR TITLE
fix(fuzz_coverage): Don't specify compiler version to avoid raw profile version mismatch

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,7 +1,4 @@
 FROM gcr.io/oss-fuzz-base/base-builder-rust:v1
-RUN rustup install nightly-2024-09-24 && rustup default nightly-2024-09-24
-RUN rustup component add rust-src --toolchain nightly-2024-09-24
-ENV RUSTUP_TOOLCHAIN=nightly-2024-09-24
 COPY . $SRC/fuel-vm
 WORKDIR fuel-vm
 COPY .clusterfuzzlite/build.sh $SRC/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- [860](https://github.com/FuelLabs/fuel-vm/pull/860): Fixed missing fuzzing coverage report in CI.
+
 ## [Version 0.58.2]
 
 ### Fixed


### PR DESCRIPTION
- Closes #856 

This PR fixes the missing coverage reports by removing an unnecessary nightly version pinning. As the OSS-FUZZ base builder image already comes with the latest rust nightly compiler (docs https://google.github.io/oss-fuzz/getting-started/new-project-guide/rust-lang/#dockerfile), this version pinning which causes a version conflict in the generated raw profile file.

The fix is to simply remove the pinned compiler version from the dockerfile.

This has been tested and a successful CI run can be observed [here](https://github.com/FuelLabs/fuel-vm/actions/runs/11381732377/job/31663774675), with the generated coverage reports visible [here](https://fuellabs.github.io/fuel-fuzzing-corpus/coverage/latest/report_target/grammar_aware_advanced/linux/src/fuel-vm/report.html).