### PR TITLE
Add the possibility to specify an offset for the read value in StorageRead::read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking 
 - [863](https://github.com/FuelLabs/fuel-vm/pull/863): Changed StorageRead::read to load a serialized value starting from a offset. The function returns an optional value equal to the number of bytes read when defined, or none if the offset specified in input is outside the boundaries of the serialized value read.
+
 ## [Version 0.58.2]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - [860](https://github.com/FuelLabs/fuel-vm/pull/860): Fixed missing fuzzing coverage report in CI.
 
+### Breaking 
+- [863](https://github.com/FuelLabs/fuel-vm/pull/863): Changed StorageRead::read to load a serialized value starting from a offset. The function returns an optional value equal to the number of bytes read when defined, or none if the offset specified in input is outside the boundaries of the serialized value read.
 ## [Version 0.58.2]
 
 ### Fixed

--- a/fuel-storage/src/impls.rs
+++ b/fuel-storage/src/impls.rs
@@ -101,9 +101,10 @@ impl<'a, T: StorageRead<Type> + StorageSize<Type> + ?Sized, Type: Mappable>
     fn read(
         &self,
         key: &<Type as Mappable>::Key,
+        offset: usize,
         buf: &mut [u8],
     ) -> Result<Option<usize>, Self::Error> {
-        <T as StorageRead<Type>>::read(self, key, buf)
+        <T as StorageRead<Type>>::read(self, key, offset, buf)
     }
 
     fn read_alloc(
@@ -120,9 +121,10 @@ impl<'a, T: StorageRead<Type> + StorageSize<Type> + ?Sized, Type: Mappable>
     fn read(
         &self,
         key: &<Type as Mappable>::Key,
+        offset: usize,
         buf: &mut [u8],
     ) -> Result<Option<usize>, Self::Error> {
-        <T as StorageRead<Type>>::read(self, key, buf)
+        <T as StorageRead<Type>>::read(self, key, offset, buf)
     }
 
     fn read_alloc(
@@ -201,7 +203,7 @@ impl<'a, T: StorageRead<Type>, Type: Mappable> StorageRef<'a, T, Type> {
         key: &<Type as Mappable>::Key,
         buf: &mut [u8],
     ) -> Result<Option<usize>, T::Error> {
-        self.0.read(key, buf)
+        self.0.read(key, 0, buf)
     }
 
     #[inline(always)]

--- a/fuel-storage/src/impls.rs
+++ b/fuel-storage/src/impls.rs
@@ -201,9 +201,10 @@ impl<'a, T: StorageRead<Type>, Type: Mappable> StorageRef<'a, T, Type> {
     pub fn read(
         &self,
         key: &<Type as Mappable>::Key,
+        offset: usize,
         buf: &mut [u8],
     ) -> Result<Option<usize>, T::Error> {
-        self.0.read(key, 0, buf)
+        self.0.read(key, offset, buf)
     }
 
     #[inline(always)]

--- a/fuel-storage/src/lib.rs
+++ b/fuel-storage/src/lib.rs
@@ -127,8 +127,12 @@ pub trait StorageRead<Type: Mappable>: StorageInspect<Type> + StorageSize<Type> 
     ///
     /// Returns None if the value does not exist.
     /// Otherwise, returns the number of bytes read.
-    fn read(&self, key: &Type::Key, buf: &mut [u8])
-        -> Result<Option<usize>, Self::Error>;
+    fn read(
+        &self,
+        key: &Type::Key,
+        offset: usize,
+        buf: &mut [u8],
+    ) -> Result<Option<usize>, Self::Error>;
 
     /// Same as `read` but allocates a new buffer and returns it.
     ///

--- a/fuel-vm/src/interpreter/blockchain/code_tests.rs
+++ b/fuel-vm/src/interpreter/blockchain/code_tests.rs
@@ -1,17 +1,19 @@
 #![allow(clippy::cast_possible_truncation)]
-use core::convert::Infallible;
 
 use alloc::vec;
 
 use super::*;
 use crate::{
     interpreter::PanicContext,
-    storage::MemoryStorage,
+    storage::{
+        MemoryStorage,
+        MemoryStorageError,
+    },
 };
 use fuel_tx::Contract;
 
 #[test]
-fn test_load_contract_in_script() -> IoResult<(), Infallible> {
+fn test_load_contract_in_script() -> IoResult<(), MemoryStorageError> {
     let mut storage = MemoryStorage::default();
     let mut memory: MemoryInstance = vec![1u8; MEM_SIZE].try_into().unwrap();
     let mut pc = 4;
@@ -70,7 +72,7 @@ fn test_load_contract_in_script() -> IoResult<(), Infallible> {
     Ok(())
 }
 #[test]
-fn test_load_contract_in_call() -> IoResult<(), Infallible> {
+fn test_load_contract_in_call() -> IoResult<(), MemoryStorageError> {
     let mut storage = MemoryStorage::default();
     let mut memory: MemoryInstance = vec![1u8; MEM_SIZE].try_into().unwrap();
     let mut pc = 4;
@@ -130,7 +132,7 @@ fn test_load_contract_in_call() -> IoResult<(), Infallible> {
 }
 
 #[test]
-fn test_code_copy() -> IoResult<(), Infallible> {
+fn test_code_copy() -> IoResult<(), MemoryStorageError> {
     let mut storage = MemoryStorage::default();
     let mut memory: MemoryInstance = vec![1u8; MEM_SIZE].try_into().unwrap();
     let mut cgas = 1000;

--- a/fuel-vm/src/interpreter/blockchain/other_tests.rs
+++ b/fuel-vm/src/interpreter/blockchain/other_tests.rs
@@ -2,8 +2,10 @@
 
 use alloc::vec;
 
-use crate::storage::MemoryStorage;
-use core::convert::Infallible;
+use crate::storage::{
+    MemoryStorage,
+    MemoryStorageError,
+};
 
 use super::*;
 use crate::interpreter::PanicContext;
@@ -25,7 +27,7 @@ fn test_burn(
     initialize: impl Into<Option<Word>>,
     amount: Word,
     sub_id: [u8; 32],
-) -> IoResult<(), Infallible> {
+) -> IoResult<(), MemoryStorageError> {
     let mut storage = MemoryStorage::default();
     let mut memory: MemoryInstance = vec![1u8; MEM_SIZE].try_into().unwrap();
     let contract_id = ContractId::from([3u8; 32]);
@@ -103,7 +105,7 @@ fn test_mint(
     initialize: impl Into<Option<Word>>,
     amount: Word,
     sub_id: [u8; 32],
-) -> IoResult<(), Infallible> {
+) -> IoResult<(), MemoryStorageError> {
     let mut storage = MemoryStorage::default();
     let mut memory: MemoryInstance = vec![1u8; MEM_SIZE].try_into().unwrap();
     let contract_id = ContractId::from([3u8; 32]);

--- a/fuel-vm/src/interpreter/blockchain/smo_tests.rs
+++ b/fuel-vm/src/interpreter/blockchain/smo_tests.rs
@@ -1,7 +1,5 @@
 #![allow(clippy::arithmetic_side_effects, clippy::cast_possible_truncation)]
 
-use core::convert::Infallible;
-
 use alloc::{
     vec,
     vec::Vec,
@@ -9,7 +7,10 @@ use alloc::{
 
 use crate::{
     interpreter::contract::balance as contract_balance,
-    storage::MemoryStorage,
+    storage::{
+        MemoryStorage,
+        MemoryStorageError,
+    },
 };
 
 use super::*;
@@ -206,7 +207,7 @@ fn test_smo(
         max_message_data_length,
         initial_balance,
     }: Input,
-) -> Result<Output, RuntimeError<Infallible>> {
+) -> Result<Output, RuntimeError<MemoryStorageError>> {
     let mut rng = StdRng::seed_from_u64(100);
     let base_asset_id = rng.gen();
 

--- a/fuel-vm/src/interpreter/blockchain/test.rs
+++ b/fuel-vm/src/interpreter/blockchain/test.rs
@@ -4,16 +4,14 @@ use alloc::{
     vec::Vec,
 };
 
-use core::{
-    convert::Infallible,
-    ops::Range,
-};
+use core::ops::Range;
 
 use crate::{
     context::Context,
     storage::{
         ContractsStateData,
         MemoryStorage,
+        MemoryStorageError,
     },
 };
 use test_case::test_case;
@@ -64,7 +62,7 @@ fn test_state_read_word(
     fp: Word,
     insert: impl Into<Option<Word>>,
     key: Word,
-) -> Result<(Word, Word), RuntimeError<Infallible>> {
+) -> Result<(Word, Word), RuntimeError<MemoryStorageError>> {
     let mut storage = MemoryStorage::default();
     let mut memory: MemoryInstance = vec![1u8; MEM_SIZE].try_into().unwrap();
     memory[0..ContractId::LEN].copy_from_slice(&[3u8; ContractId::LEN][..]);
@@ -134,7 +132,7 @@ fn test_state_write_word(
     fp: Word,
     insert: bool,
     key: Word,
-) -> Result<Word, RuntimeError<Infallible>> {
+) -> Result<Word, RuntimeError<MemoryStorageError>> {
     let mut storage = MemoryStorage::default();
     let mut memory: MemoryInstance = vec![1u8; MEM_SIZE].try_into().unwrap();
     memory[0..ContractId::LEN].copy_from_slice(&[3u8; ContractId::LEN][..]);

--- a/fuel-vm/src/interpreter/blockchain/test/scwq.rs
+++ b/fuel-vm/src/interpreter/blockchain/test/scwq.rs
@@ -9,6 +9,7 @@ use crate::storage::{
     ContractsState,
     ContractsStateData,
     MemoryStorage,
+    MemoryStorageError,
 };
 
 use super::*;
@@ -95,7 +96,8 @@ struct SCWQInput {
 )]
 fn test_state_clear_qword(
     input: SCWQInput,
-) -> Result<(Vec<([u8; 32], ContractsStateData)>, bool), RuntimeError<Infallible>> {
+) -> Result<(Vec<([u8; 32], ContractsStateData)>, bool), RuntimeError<MemoryStorageError>>
+{
     let SCWQInput {
         input,
         storage_slots,

--- a/fuel-vm/src/interpreter/blockchain/test/srwq.rs
+++ b/fuel-vm/src/interpreter/blockchain/test/srwq.rs
@@ -2,6 +2,7 @@ use crate::storage::{
     ContractsState,
     ContractsStateData,
     MemoryStorage,
+    MemoryStorageError,
 };
 
 use super::*;
@@ -163,7 +164,7 @@ struct SRWQInput {
 )]
 fn test_state_read_qword(
     input: SRWQInput,
-) -> Result<(MemoryInstance, bool), RuntimeError<Infallible>> {
+) -> Result<(MemoryInstance, bool), RuntimeError<MemoryStorageError>> {
     let SRWQInput {
         storage_slots,
         context,

--- a/fuel-vm/src/interpreter/blockchain/test/swwq.rs
+++ b/fuel-vm/src/interpreter/blockchain/test/swwq.rs
@@ -9,6 +9,7 @@ use crate::storage::{
     ContractsState,
     ContractsStateData,
     MemoryStorage,
+    MemoryStorageError,
 };
 
 use super::*;
@@ -215,7 +216,8 @@ struct SWWQInput {
 )]
 fn test_state_write_qword(
     input: SWWQInput,
-) -> Result<(Vec<([u8; 32], ContractsStateData)>, u64), RuntimeError<Infallible>> {
+) -> Result<(Vec<([u8; 32], ContractsStateData)>, u64), RuntimeError<MemoryStorageError>>
+{
     let SWWQInput {
         input,
         storage_slots,

--- a/fuel-vm/src/interpreter/diff/storage.rs
+++ b/fuel-vm/src/interpreter/diff/storage.rs
@@ -369,9 +369,10 @@ where
     fn read(
         &self,
         key: &<Type as Mappable>::Key,
+        offset: usize,
         buf: &mut [u8],
     ) -> Result<Option<usize>, Self::Error> {
-        <S as StorageRead<Type>>::read(&self.0, key, buf)
+        <S as StorageRead<Type>>::read(&self.0, key, offset, buf)
     }
 
     fn read_alloc(

--- a/fuel-vm/src/interpreter/flow.rs
+++ b/fuel-vm/src/interpreter/flow.rs
@@ -638,7 +638,7 @@ where
 {
     let bytes_read = storage
         .storage::<ContractsRawCode>()
-        .read(contract, dst)
+        .read(contract, 0, dst)
         .map_err(RuntimeError::Storage)?
         .ok_or(PanicReason::ContractNotFound)?;
     if bytes_read != dst.len() {

--- a/fuel-vm/src/interpreter/flow/tests.rs
+++ b/fuel-vm/src/interpreter/flow/tests.rs
@@ -1,13 +1,14 @@
 #![allow(clippy::arithmetic_side_effects, clippy::cast_possible_truncation)]
 
-use core::convert::Infallible;
-
 use alloc::{
     vec,
     vec::Vec,
 };
 
-use crate::storage::MemoryStorage;
+use crate::storage::{
+    MemoryStorage,
+    MemoryStorageError,
+};
 
 use super::*;
 use crate::crypto;
@@ -325,7 +326,7 @@ fn mem(set: &[(usize, Vec<u8>)]) -> MemoryInstance {
         ..Default::default()
     } => using check_output(Err(RuntimeError::Recoverable(PanicReason::NotEnoughBalance))); "Transfer too many coins internally"
 )]
-fn test_prepare_call(input: Input) -> Result<Output, RuntimeError<Infallible>> {
+fn test_prepare_call(input: Input) -> Result<Output, RuntimeError<MemoryStorageError>> {
     let Input {
         params,
         mut reg,
@@ -395,8 +396,8 @@ fn test_prepare_call(input: Input) -> Result<Output, RuntimeError<Infallible>> {
 }
 
 fn check_output(
-    expected: Result<Output, RuntimeError<Infallible>>,
-) -> impl FnOnce(Result<Output, RuntimeError<Infallible>>) {
+    expected: Result<Output, RuntimeError<MemoryStorageError>>,
+) -> impl FnOnce(Result<Output, RuntimeError<MemoryStorageError>>) {
     move |result| match (expected, result) {
         (Ok(e), Ok(r)) => {
             assert_eq!(e.reg, r.reg);

--- a/fuel-vm/src/memory_client.rs
+++ b/fuel-vm/src/memory_client.rs
@@ -11,10 +11,12 @@ use crate::{
         NotSupportedEcal,
     },
     state::StateTransitionRef,
-    storage::MemoryStorage,
+    storage::{
+        MemoryStorage,
+        MemoryStorageError,
+    },
     transactor::Transactor,
 };
-use core::convert::Infallible;
 use fuel_tx::{
     Blob,
     Create,
@@ -103,7 +105,7 @@ where
     pub fn deploy(
         &mut self,
         tx: Checked<Create>,
-    ) -> Result<Create, InterpreterError<Infallible>> {
+    ) -> Result<Create, InterpreterError<MemoryStorageError>> {
         self.transactor.deploy(tx)
     }
 
@@ -111,7 +113,7 @@ where
     pub fn upgrade(
         &mut self,
         tx: Checked<Upgrade>,
-    ) -> Result<Upgrade, InterpreterError<Infallible>> {
+    ) -> Result<Upgrade, InterpreterError<MemoryStorageError>> {
         self.transactor.upgrade(tx)
     }
 

--- a/fuel-vm/src/storage.rs
+++ b/fuel-vm/src/storage.rs
@@ -34,6 +34,8 @@ pub use interpreter::{
 };
 #[cfg(feature = "test-helpers")]
 pub use memory::MemoryStorage;
+#[cfg(feature = "test-helpers")]
+pub use memory::MemoryStorageError;
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;

--- a/fuel-vm/src/storage.rs
+++ b/fuel-vm/src/storage.rs
@@ -33,9 +33,10 @@ pub use interpreter::{
     InterpreterStorage,
 };
 #[cfg(feature = "test-helpers")]
-pub use memory::MemoryStorage;
-#[cfg(feature = "test-helpers")]
-pub use memory::MemoryStorageError;
+pub use memory::{
+    MemoryStorage,
+    MemoryStorageError,
+};
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;

--- a/fuel-vm/src/storage/interpreter.rs
+++ b/fuel-vm/src/storage/interpreter.rs
@@ -167,9 +167,13 @@ pub trait InterpreterStorage:
     fn read_contract(
         &self,
         id: &ContractId,
+        offset: usize,
         writer: &mut [u8],
     ) -> Result<Option<Word>, Self::DataError> {
-        Ok(StorageRead::<ContractsRawCode>::read(self, id, writer)?.map(|r| r as Word))
+        Ok(
+            StorageRead::<ContractsRawCode>::read(self, id, offset, writer)?
+                .map(|r| r as Word),
+        )
     }
 
     /// Append a contract to the chain, provided its identifier.
@@ -370,9 +374,10 @@ where
     fn read_contract(
         &self,
         id: &ContractId,
+        offset: usize,
         writer: &mut [u8],
     ) -> Result<Option<Word>, Self::DataError> {
-        <S as InterpreterStorage>::read_contract(self.deref(), id, writer)
+        <S as InterpreterStorage>::read_contract(self.deref(), id, offset, writer)
     }
 
     fn contract_state_range(

--- a/fuel-vm/src/storage/memory.rs
+++ b/fuel-vm/src/storage/memory.rs
@@ -271,9 +271,8 @@ impl StorageRead<ContractsRawCode> for MemoryStorage {
             // We need to handle the case where the offset is greater than the length of
             // the contract In this case we follow the same approach as
             // `copy_from_slice_zero_fill`
-            if offset >= c.as_ref().len() {
+            if offset > c.as_ref().len() {
                 buf.fill(0);
-                // TODO: Do we want to return `None` or `Some(0)` here?
                 return None;
             }
             let starting_from_offset = &c.as_ref()[offset..];
@@ -465,7 +464,7 @@ impl StorageRead<ContractsState> for MemoryStorage {
             // We need to handle the case where the offset is greater than the length of
             // the serialized ContractState. In this case we follow the same approach as
             // `copy_from_slice_zero_fill` and fill the input buffer with zeros.
-            if offset >= data.as_ref().len() {
+            if offset > data.as_ref().len() {
                 buf.fill(0);
                 return None;
             }
@@ -509,7 +508,7 @@ impl StorageRead<BlobData> for MemoryStorage {
             // We need to handle the case where the offset is greater than the length of
             // the serialized ContractState. In this case we follow the same approach as
             // `copy_from_slice_zero_fill` and fill the input buffer with zeros.
-            if offset >= data.as_ref().len() {
+            if offset > data.as_ref().len() {
                 buf.fill(0);
                 return None;
             }
@@ -823,9 +822,12 @@ mod tests {
     #[test_case(28, 0 => Some(0))]
     #[test_case(28, 4 => Some(4))]
     #[test_case(28, 8 => Some(4))]
-    #[test_case(32, 0 => None)]
-    #[test_case(32, 4 => None)]
-    #[test_case(32, 8 => None)]
+    #[test_case(32, 0 => Some(0))]
+    #[test_case(32, 4 => Some(0))]
+    #[test_case(32, 8 => Some(0))]
+    #[test_case(33, 0 => None)]
+    #[test_case(33, 4 => None)]
+    #[test_case(33, 8 => None)]
     fn test_contract_read(offset: usize, load_buf_size: usize) -> Option<usize> {
         // Given
         let raw_contract = [1u8; 32];

--- a/fuel-vm/src/storage/memory.rs
+++ b/fuel-vm/src/storage/memory.rs
@@ -264,11 +264,20 @@ impl StorageRead<ContractsRawCode> for MemoryStorage {
     fn read(
         &self,
         key: &ContractId,
+        offset: usize,
         buf: &mut [u8],
     ) -> Result<Option<usize>, Self::Error> {
         Ok(self.memory.contracts.get(key).map(|c| {
-            let len = buf.len().min(c.as_ref().len());
-            buf.copy_from_slice(&c.as_ref()[..len]);
+            // We need to handle the case where the offset is greater than the length of
+            // the contract In this case we follow the same approach as
+            // `copy_from_slice_zero_fill`
+            if offset >= c.as_ref().len() {
+                buf.fill(0);
+            }
+            let starting_from_offset = &c.as_ref()[offset..];
+            let len = buf.len().min(starting_from_offset.as_ref().len());
+            buf[..len].copy_from_slice(&starting_from_offset.as_ref()[..len]);
+            buf[len..].fill(0);
             len
         }))
     }
@@ -447,11 +456,20 @@ impl StorageRead<ContractsState> for MemoryStorage {
     fn read(
         &self,
         key: &<ContractsState as Mappable>::Key,
+        offset: usize,
         buf: &mut [u8],
     ) -> Result<Option<usize>, Self::Error> {
         Ok(self.memory.contract_state.get(key).map(|data| {
-            let len = buf.len().min(data.as_ref().len());
-            buf.copy_from_slice(&data.as_ref()[..len]);
+            // We need to handle the case where the offset is greater than the length of
+            // the serialized ContractState. In this case we follow the same approach as
+            // `copy_from_slice_zero_fill` and fill the input buffer with zeros.
+            if offset >= data.as_ref().len() {
+                buf.fill(0);
+            }
+            let starting_from_offset = &data.as_ref()[offset..];
+            let len = buf.len().min(starting_from_offset.as_ref().len());
+            buf[..len].copy_from_slice(&starting_from_offset.as_ref()[..len]);
+            buf[len..].fill(0);
             len
         }))
     }
@@ -481,11 +499,20 @@ impl StorageRead<BlobData> for MemoryStorage {
     fn read(
         &self,
         key: &<BlobData as Mappable>::Key,
+        offset: usize,
         buf: &mut [u8],
     ) -> Result<Option<usize>, Self::Error> {
         Ok(self.memory.blobs.get(key).map(|data| {
-            let len = buf.len().min(data.as_ref().len());
-            buf.copy_from_slice(&data.as_ref()[..len]);
+            // We need to handle the case where the offset is greater than the length of
+            // the serialized ContractState. In this case we follow the same approach as
+            // `copy_from_slice_zero_fill` and fill the input buffer with zeros.
+            if offset >= data.as_ref().len() {
+                buf.fill(0);
+            }
+            let starting_from_offset = &data.as_ref()[offset..];
+            let len = buf.len().min(starting_from_offset.as_ref().len());
+            buf[..len].copy_from_slice(&starting_from_offset.as_ref()[..len]);
+            buf[len..].fill(0);
             len
         }))
     }

--- a/fuel-vm/src/storage/memory.rs
+++ b/fuel-vm/src/storage/memory.rs
@@ -1,15 +1,21 @@
 #![allow(clippy::cast_possible_truncation)]
 
-use crate::storage::{
-    ContractsAssetKey,
-    ContractsAssets,
-    ContractsRawCode,
-    ContractsState,
-    ContractsStateData,
-    ContractsStateKey,
-    InterpreterStorage,
-    UploadedBytecode,
-    UploadedBytecodes,
+use crate::{
+    error::{
+        InterpreterError,
+        RuntimeError,
+    },
+    storage::{
+        ContractsAssetKey,
+        ContractsAssets,
+        ContractsRawCode,
+        ContractsState,
+        ContractsStateData,
+        ContractsStateKey,
+        InterpreterStorage,
+        UploadedBytecode,
+        UploadedBytecodes,
+    },
 };
 
 use fuel_crypto::Hasher;
@@ -47,7 +53,26 @@ use alloc::{
     collections::BTreeMap,
     vec::Vec,
 };
-use core::convert::Infallible;
+
+/// Errors arising from accessing the memory storage.
+#[derive(Debug, Clone, PartialEq, Eq, derive_more::Display)]
+pub enum MemoryStorageError {
+    /// The offset specified for the serialized value exceeds its length
+    #[display(fmt = "Offset {_0} is greater than the length of the value {_1}")]
+    OffsetOutOfBounds(usize, usize),
+}
+
+impl From<MemoryStorageError> for RuntimeError<MemoryStorageError> {
+    fn from(e: MemoryStorageError) -> Self {
+        RuntimeError::Storage(e)
+    }
+}
+
+impl From<MemoryStorageError> for InterpreterError<MemoryStorageError> {
+    fn from(e: MemoryStorageError) -> Self {
+        InterpreterError::Storage(e)
+    }
+}
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 struct MemoryStorageInner {
@@ -202,13 +227,13 @@ impl Default for MemoryStorage {
 }
 
 impl StorageInspect<ContractsRawCode> for MemoryStorage {
-    type Error = Infallible;
+    type Error = MemoryStorageError;
 
-    fn get(&self, key: &ContractId) -> Result<Option<Cow<'_, Contract>>, Infallible> {
+    fn get(&self, key: &ContractId) -> Result<Option<Cow<'_, Contract>>, Self::Error> {
         Ok(self.memory.contracts.get(key).map(Cow::Borrowed))
     }
 
-    fn contains_key(&self, key: &ContractId) -> Result<bool, Infallible> {
+    fn contains_key(&self, key: &ContractId) -> Result<bool, Self::Error> {
         Ok(self.memory.contracts.contains_key(key))
     }
 }
@@ -218,17 +243,21 @@ impl StorageMutate<ContractsRawCode> for MemoryStorage {
         &mut self,
         key: &ContractId,
         value: &[u8],
-    ) -> Result<Option<Contract>, Infallible> {
+    ) -> Result<Option<Contract>, Self::Error> {
         Ok(self.memory.contracts.insert(*key, value.into()))
     }
 
-    fn take(&mut self, key: &ContractId) -> Result<Option<Contract>, Infallible> {
+    fn take(&mut self, key: &ContractId) -> Result<Option<Contract>, Self::Error> {
         Ok(self.memory.contracts.remove(key))
     }
 }
 
 impl StorageWrite<ContractsRawCode> for MemoryStorage {
-    fn write_bytes(&mut self, key: &ContractId, buf: &[u8]) -> Result<usize, Infallible> {
+    fn write_bytes(
+        &mut self,
+        key: &ContractId,
+        buf: &[u8],
+    ) -> Result<usize, Self::Error> {
         let size = buf.len();
         self.memory.contracts.insert(*key, Contract::from(buf));
         Ok(size)
@@ -255,7 +284,7 @@ impl StorageWrite<ContractsRawCode> for MemoryStorage {
 }
 
 impl StorageSize<ContractsRawCode> for MemoryStorage {
-    fn size_of_value(&self, key: &ContractId) -> Result<Option<usize>, Infallible> {
+    fn size_of_value(&self, key: &ContractId) -> Result<Option<usize>, Self::Error> {
         Ok(self.memory.contracts.get(key).map(|c| c.as_ref().len()))
     }
 }
@@ -267,20 +296,27 @@ impl StorageRead<ContractsRawCode> for MemoryStorage {
         offset: usize,
         buf: &mut [u8],
     ) -> Result<Option<usize>, Self::Error> {
-        Ok(self.memory.contracts.get(key).and_then(|c| {
-            // We need to handle the case where the offset is greater than the length of
-            // the contract In this case we follow the same approach as
-            // `copy_from_slice_zero_fill`
-            if offset > c.as_ref().len() {
-                buf.fill(0);
-                return None;
-            }
-            let starting_from_offset = &c.as_ref()[offset..];
-            let len = buf.len().min(starting_from_offset.len());
-            buf[..len].copy_from_slice(&starting_from_offset[..len]);
-            buf[len..].fill(0);
-            Some(len)
-        }))
+        self.memory
+            .contracts
+            .get(key)
+            .map(|c| {
+                let contract_len = c.as_ref().len();
+                // We need to handle the case where the offset is greater than the length
+                // of the contract In this case we follow the same
+                // approach as `copy_from_slice_zero_fill`
+                if offset > contract_len {
+                    return Err(MemoryStorageError::OffsetOutOfBounds(
+                        offset,
+                        contract_len,
+                    ));
+                }
+                let starting_from_offset = &c.as_ref()[offset..];
+                let len = buf.len().min(starting_from_offset.len());
+                buf[..len].copy_from_slice(&starting_from_offset[..len]);
+                buf[len..].fill(0);
+                Ok(len)
+            })
+            .transpose()
     }
 
     fn read_alloc(&self, key: &ContractId) -> Result<Option<Vec<u8>>, Self::Error> {
@@ -289,12 +325,12 @@ impl StorageRead<ContractsRawCode> for MemoryStorage {
 }
 
 impl StorageInspect<UploadedBytecodes> for MemoryStorage {
-    type Error = Infallible;
+    type Error = MemoryStorageError;
 
     fn get(
         &self,
         key: &<UploadedBytecodes as Mappable>::Key,
-    ) -> Result<Option<Cow<'_, UploadedBytecode>>, Infallible> {
+    ) -> Result<Option<Cow<'_, UploadedBytecode>>, Self::Error> {
         Ok(self
             .memory
             .state_transition_bytecodes
@@ -305,7 +341,7 @@ impl StorageInspect<UploadedBytecodes> for MemoryStorage {
     fn contains_key(
         &self,
         key: &<UploadedBytecodes as Mappable>::Key,
-    ) -> Result<bool, Infallible> {
+    ) -> Result<bool, Self::Error> {
         Ok(self.memory.state_transition_bytecodes.contains_key(key))
     }
 }
@@ -315,7 +351,7 @@ impl StorageMutate<UploadedBytecodes> for MemoryStorage {
         &mut self,
         key: &<UploadedBytecodes as Mappable>::Key,
         value: &<UploadedBytecodes as Mappable>::Value,
-    ) -> Result<Option<UploadedBytecode>, Infallible> {
+    ) -> Result<Option<UploadedBytecode>, Self::Error> {
         Ok(self
             .memory
             .state_transition_bytecodes
@@ -325,25 +361,25 @@ impl StorageMutate<UploadedBytecodes> for MemoryStorage {
     fn take(
         &mut self,
         key: &<UploadedBytecodes as Mappable>::Key,
-    ) -> Result<Option<UploadedBytecode>, Infallible> {
+    ) -> Result<Option<UploadedBytecode>, Self::Error> {
         Ok(self.memory.state_transition_bytecodes.remove(key))
     }
 }
 
 impl StorageInspect<ContractsAssets> for MemoryStorage {
-    type Error = Infallible;
+    type Error = MemoryStorageError;
 
     fn get(
         &self,
         key: &<ContractsAssets as Mappable>::Key,
-    ) -> Result<Option<Cow<'_, Word>>, Infallible> {
+    ) -> Result<Option<Cow<'_, Word>>, Self::Error> {
         Ok(self.memory.balances.get(key).map(Cow::Borrowed))
     }
 
     fn contains_key(
         &self,
         key: &<ContractsAssets as Mappable>::Key,
-    ) -> Result<bool, Infallible> {
+    ) -> Result<bool, Self::Error> {
         Ok(self.memory.balances.contains_key(key))
     }
 }
@@ -353,25 +389,25 @@ impl StorageMutate<ContractsAssets> for MemoryStorage {
         &mut self,
         key: &<ContractsAssets as Mappable>::Key,
         value: &Word,
-    ) -> Result<Option<Word>, Infallible> {
+    ) -> Result<Option<Word>, Self::Error> {
         Ok(self.memory.balances.insert(*key, *value))
     }
 
     fn take(
         &mut self,
         key: &<ContractsAssets as Mappable>::Key,
-    ) -> Result<Option<Word>, Infallible> {
+    ) -> Result<Option<Word>, Self::Error> {
         Ok(self.memory.balances.remove(key))
     }
 }
 
 impl StorageInspect<ContractsState> for MemoryStorage {
-    type Error = Infallible;
+    type Error = MemoryStorageError;
 
     fn get(
         &self,
         key: &<ContractsState as Mappable>::Key,
-    ) -> Result<Option<Cow<'_, <ContractsState as Mappable>::OwnedValue>>, Infallible>
+    ) -> Result<Option<Cow<'_, <ContractsState as Mappable>::OwnedValue>>, Self::Error>
     {
         Ok(self.memory.contract_state.get(key).map(Cow::Borrowed))
     }
@@ -379,7 +415,7 @@ impl StorageInspect<ContractsState> for MemoryStorage {
     fn contains_key(
         &self,
         key: &<ContractsState as Mappable>::Key,
-    ) -> Result<bool, Infallible> {
+    ) -> Result<bool, Self::Error> {
         Ok(self.memory.contract_state.contains_key(key))
     }
 }
@@ -389,14 +425,14 @@ impl StorageMutate<ContractsState> for MemoryStorage {
         &mut self,
         key: &<ContractsState as Mappable>::Key,
         value: &<ContractsState as Mappable>::Value,
-    ) -> Result<Option<<ContractsState as Mappable>::OwnedValue>, Infallible> {
+    ) -> Result<Option<<ContractsState as Mappable>::OwnedValue>, Self::Error> {
         Ok(self.memory.contract_state.insert(*key, value.into()))
     }
 
     fn take(
         &mut self,
         key: &<ContractsState as Mappable>::Key,
-    ) -> Result<Option<ContractsStateData>, Infallible> {
+    ) -> Result<Option<ContractsStateData>, Self::Error> {
         Ok(self.memory.contract_state.remove(key))
     }
 }
@@ -406,7 +442,7 @@ impl StorageWrite<ContractsState> for MemoryStorage {
         &mut self,
         key: &<ContractsState as Mappable>::Key,
         buf: &[u8],
-    ) -> Result<usize, Infallible> {
+    ) -> Result<usize, Self::Error> {
         let size = buf.len();
         self.memory
             .contract_state
@@ -444,7 +480,7 @@ impl StorageSize<ContractsState> for MemoryStorage {
     fn size_of_value(
         &self,
         key: &<ContractsState as Mappable>::Key,
-    ) -> Result<Option<usize>, Infallible> {
+    ) -> Result<Option<usize>, Self::Error> {
         Ok(self
             .memory
             .contract_state
@@ -460,20 +496,28 @@ impl StorageRead<ContractsState> for MemoryStorage {
         offset: usize,
         buf: &mut [u8],
     ) -> Result<Option<usize>, Self::Error> {
-        Ok(self.memory.contract_state.get(key).and_then(|data| {
-            // We need to handle the case where the offset is greater than the length of
-            // the serialized ContractState. In this case we follow the same approach as
-            // `copy_from_slice_zero_fill` and fill the input buffer with zeros.
-            if offset > data.as_ref().len() {
-                buf.fill(0);
-                return None;
-            }
-            let starting_from_offset = &data.as_ref()[offset..];
-            let len = buf.len().min(starting_from_offset.len());
-            buf[..len].copy_from_slice(&starting_from_offset[..len]);
-            buf[len..].fill(0);
-            Some(len)
-        }))
+        self.memory
+            .contract_state
+            .get(key)
+            .map(|data| {
+                let contract_state_len = data.as_ref().len();
+                // We need to handle the case where the offset is greater than the length
+                // of the serialized ContractState. In this case we follow
+                // the same approach as `copy_from_slice_zero_fill` and
+                // fill the input buffer with zeros.
+                if offset > contract_state_len {
+                    return Err(MemoryStorageError::OffsetOutOfBounds(
+                        offset,
+                        contract_state_len,
+                    ));
+                }
+                let starting_from_offset = &data.as_ref()[offset..];
+                let len = buf.len().min(starting_from_offset.len());
+                buf[..len].copy_from_slice(&starting_from_offset[..len]);
+                buf[len..].fill(0);
+                Ok(len)
+            })
+            .transpose()
     }
 
     fn read_alloc(
@@ -492,7 +536,7 @@ impl StorageSize<BlobData> for MemoryStorage {
     fn size_of_value(
         &self,
         key: &<BlobData as Mappable>::Key,
-    ) -> Result<Option<usize>, Infallible> {
+    ) -> Result<Option<usize>, Self::Error> {
         Ok(self.memory.blobs.get(key).map(|c| c.as_ref().len()))
     }
 }
@@ -504,20 +548,25 @@ impl StorageRead<BlobData> for MemoryStorage {
         offset: usize,
         buf: &mut [u8],
     ) -> Result<Option<usize>, Self::Error> {
-        Ok(self.memory.blobs.get(key).and_then(|data| {
-            // We need to handle the case where the offset is greater than the length of
-            // the serialized ContractState. In this case we follow the same approach as
-            // `copy_from_slice_zero_fill` and fill the input buffer with zeros.
-            if offset > data.as_ref().len() {
-                buf.fill(0);
-                return None;
-            }
-            let starting_from_offset = &data.as_ref()[offset..];
-            let len = buf.len().min(starting_from_offset.len());
-            buf[..len].copy_from_slice(&starting_from_offset[..len]);
-            buf[len..].fill(0);
-            Some(len)
-        }))
+        self.memory
+            .blobs
+            .get(key)
+            .map(|data| {
+                let blob_len = data.as_ref().len();
+                // We need to handle the case where the offset is greater than the length
+                // of the serialized ContractState. In this case we follow
+                // the same approach as `copy_from_slice_zero_fill` and
+                // fill the input buffer with zeros.
+                if offset > blob_len {
+                    return Err(MemoryStorageError::OffsetOutOfBounds(offset, blob_len));
+                }
+                let starting_from_offset = &data.as_ref()[offset..];
+                let len = buf.len().min(starting_from_offset.len());
+                buf[..len].copy_from_slice(&starting_from_offset[..len]);
+                buf[len..].fill(0);
+                Ok(len)
+            })
+            .transpose()
     }
 
     fn read_alloc(
@@ -529,19 +578,19 @@ impl StorageRead<BlobData> for MemoryStorage {
 }
 
 impl StorageInspect<BlobData> for MemoryStorage {
-    type Error = Infallible;
+    type Error = MemoryStorageError;
 
     fn get(
         &self,
         key: &<BlobData as Mappable>::Key,
-    ) -> Result<Option<Cow<'_, <BlobData as Mappable>::OwnedValue>>, Infallible> {
+    ) -> Result<Option<Cow<'_, <BlobData as Mappable>::OwnedValue>>, Self::Error> {
         Ok(self.memory.blobs.get(key).map(Cow::Borrowed))
     }
 
     fn contains_key(
         &self,
         key: &<BlobData as Mappable>::Key,
-    ) -> Result<bool, Infallible> {
+    ) -> Result<bool, Self::Error> {
         Ok(self.memory.blobs.contains_key(key))
     }
 }
@@ -551,14 +600,14 @@ impl StorageMutate<BlobData> for MemoryStorage {
         &mut self,
         key: &<BlobData as Mappable>::Key,
         value: &<BlobData as Mappable>::Value,
-    ) -> Result<Option<<BlobData as Mappable>::OwnedValue>, Infallible> {
+    ) -> Result<Option<<BlobData as Mappable>::OwnedValue>, Self::Error> {
         Ok(self.memory.blobs.insert(*key, value.into()))
     }
 
     fn take(
         &mut self,
         key: &<BlobData as Mappable>::Key,
-    ) -> Result<Option<BlobBytes>, Infallible> {
+    ) -> Result<Option<BlobBytes>, Self::Error> {
         Ok(self.memory.blobs.remove(key))
     }
 }
@@ -568,7 +617,7 @@ impl StorageWrite<BlobData> for MemoryStorage {
         &mut self,
         key: &<BlobData as Mappable>::Key,
         buf: &[u8],
-    ) -> Result<usize, Infallible> {
+    ) -> Result<usize, Self::Error> {
         let size = buf.len();
         self.memory.blobs.insert(*key, BlobBytes::from(buf));
         Ok(size)
@@ -603,9 +652,9 @@ impl StorageWrite<BlobData> for MemoryStorage {
 impl ContractsAssetsStorage for MemoryStorage {}
 
 impl InterpreterStorage for MemoryStorage {
-    type DataError = Infallible;
+    type DataError = MemoryStorageError;
 
-    fn block_height(&self) -> Result<BlockHeight, Infallible> {
+    fn block_height(&self) -> Result<BlockHeight, Self::DataError> {
         Ok(self.block_height)
     }
 
@@ -625,11 +674,11 @@ impl InterpreterStorage for MemoryStorage {
         Ok((GENESIS + (*height as Word * INTERVAL)).0)
     }
 
-    fn block_hash(&self, block_height: BlockHeight) -> Result<Bytes32, Infallible> {
+    fn block_hash(&self, block_height: BlockHeight) -> Result<Bytes32, Self::DataError> {
         Ok(Hasher::hash(block_height.to_be_bytes()))
     }
 
-    fn coinbase(&self) -> Result<ContractId, Infallible> {
+    fn coinbase(&self) -> Result<ContractId, Self::DataError> {
         Ok(self.coinbase)
     }
 
@@ -813,22 +862,25 @@ mod tests {
             .collect()
     }
 
-    #[test_case(0, 32 => Some(32))]
-    #[test_case(4, 32 => Some(28))]
-    #[test_case(8, 32 => Some(24))]
-    #[test_case(0, 28 => Some(28))]
-    #[test_case(4, 28 => Some(28))]
-    #[test_case(8, 28 => Some(24))]
-    #[test_case(28, 0 => Some(0))]
-    #[test_case(28, 4 => Some(4))]
-    #[test_case(28, 8 => Some(4))]
-    #[test_case(32, 0 => Some(0))]
-    #[test_case(32, 4 => Some(0))]
-    #[test_case(32, 8 => Some(0))]
-    #[test_case(33, 0 => None)]
-    #[test_case(33, 4 => None)]
-    #[test_case(33, 8 => None)]
-    fn test_contract_read(offset: usize, load_buf_size: usize) -> Option<usize> {
+    #[test_case(0, 32 => Ok(Some(32)))]
+    #[test_case(4, 32 => Ok(Some(28)))]
+    #[test_case(8, 32 => Ok(Some(24)))]
+    #[test_case(0, 28 => Ok(Some(28)))]
+    #[test_case(4, 28 => Ok(Some(28)))]
+    #[test_case(8, 28 => Ok(Some(24)))]
+    #[test_case(28, 0 => Ok(Some(0)))]
+    #[test_case(28, 4 => Ok(Some(4)))]
+    #[test_case(28, 8 => Ok(Some(4)))]
+    #[test_case(32, 0 => Ok(Some(0)))]
+    #[test_case(32, 4 => Ok(Some(0)))]
+    #[test_case(32, 8 => Ok(Some(0)))]
+    #[test_case(33, 0 => Err(MemoryStorageError::OffsetOutOfBounds(33,32)))]
+    #[test_case(33, 4 => Err(MemoryStorageError::OffsetOutOfBounds(33,32)))]
+    #[test_case(33, 8 => Err(MemoryStorageError::OffsetOutOfBounds(33,32)))]
+    fn test_contract_read(
+        offset: usize,
+        load_buf_size: usize,
+    ) -> Result<Option<usize>, MemoryStorageError> {
         // Given
         let raw_contract = [1u8; 32];
         let mut mem = MemoryStorage::default();
@@ -845,13 +897,16 @@ mod tests {
             &ContractId::default(),
             offset,
             &mut buf,
-        )
-        .unwrap();
+        );
 
         // Then
-        let contract_bytes_in_buffer = bytes_read.unwrap_or(0);
-        assert!(buf[0..contract_bytes_in_buffer].iter().all(|&v| v == 1));
-        assert!(buf[contract_bytes_in_buffer..].iter().all(|&v| v == 0));
+
+        if let Ok(bytes_read) = bytes_read {
+            let contract_bytes_in_buffer = bytes_read.unwrap_or(0);
+            assert!(buf[0..contract_bytes_in_buffer].iter().all(|&v| v == 1));
+            assert!(buf[contract_bytes_in_buffer..].iter().all(|&v| v == 0));
+        }
+
         bytes_read
     }
 }

--- a/fuel-vm/src/storage/memory.rs
+++ b/fuel-vm/src/storage/memory.rs
@@ -275,8 +275,8 @@ impl StorageRead<ContractsRawCode> for MemoryStorage {
                 buf.fill(0);
             }
             let starting_from_offset = &c.as_ref()[offset..];
-            let len = buf.len().min(starting_from_offset.as_ref().len());
-            buf[..len].copy_from_slice(&starting_from_offset.as_ref()[..len]);
+            let len = buf.len().min(starting_from_offset.len());
+            buf[..len].copy_from_slice(&starting_from_offset[..len]);
             buf[len..].fill(0);
             len
         }))
@@ -467,8 +467,8 @@ impl StorageRead<ContractsState> for MemoryStorage {
                 buf.fill(0);
             }
             let starting_from_offset = &data.as_ref()[offset..];
-            let len = buf.len().min(starting_from_offset.as_ref().len());
-            buf[..len].copy_from_slice(&starting_from_offset.as_ref()[..len]);
+            let len = buf.len().min(starting_from_offset.len());
+            buf[..len].copy_from_slice(&starting_from_offset[..len]);
             buf[len..].fill(0);
             len
         }))
@@ -510,8 +510,8 @@ impl StorageRead<BlobData> for MemoryStorage {
                 buf.fill(0);
             }
             let starting_from_offset = &data.as_ref()[offset..];
-            let len = buf.len().min(starting_from_offset.as_ref().len());
-            buf[..len].copy_from_slice(&starting_from_offset.as_ref()[..len]);
+            let len = buf.len().min(starting_from_offset.len());
+            buf[..len].copy_from_slice(&starting_from_offset[..len]);
             buf[len..].fill(0);
             len
         }))

--- a/fuel-vm/src/storage/predicate.rs
+++ b/fuel-vm/src/storage/predicate.rs
@@ -139,7 +139,12 @@ impl StorageSize<BlobData> for EmptyStorage {
 }
 
 impl StorageRead<BlobData> for EmptyStorage {
-    fn read(&self, _: &BlobId, _: &mut [u8]) -> Result<Option<usize>, Self::Error> {
+    fn read(
+        &self,
+        _: &BlobId,
+        _: usize,
+        _: &mut [u8],
+    ) -> Result<Option<usize>, Self::Error> {
         Err(Self::Error::UnsupportedStorageOperation)
     }
 
@@ -241,6 +246,7 @@ impl<D> StorageRead<ContractsRawCode> for PredicateStorage<D> {
     fn read(
         &self,
         _key: &<ContractsRawCode as Mappable>::Key,
+        _offset: usize,
         _buf: &mut [u8],
     ) -> Result<Option<usize>, Self::Error> {
         Err(Self::Error::UnsupportedStorageOperation)
@@ -292,6 +298,7 @@ impl<D> StorageRead<ContractsState> for PredicateStorage<D> {
     fn read(
         &self,
         _key: &<ContractsState as Mappable>::Key,
+        _offset: usize,
         _buf: &mut [u8],
     ) -> Result<Option<usize>, Self::Error> {
         Err(Self::Error::UnsupportedStorageOperation)
@@ -350,9 +357,10 @@ where
     fn read(
         &self,
         key: &<BlobData as Mappable>::Key,
+        offset: usize,
         buf: &mut [u8],
     ) -> Result<Option<usize>, Self::Error> {
-        StorageRead::<BlobData>::read(&self.storage, key, buf)
+        StorageRead::<BlobData>::read(&self.storage, key, offset, buf)
             .map_err(|e| Self::Error::StorageError(D::storage_error_to_string(e)))
     }
 


### PR DESCRIPTION
[Link to related issue(s) here, if any]

[Short description of the changes.]

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
