### PR TITLE
chore: bump wasm-bindgen from `0.2.88` to `0.2.97`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - [870](https://github.com/FuelLabs/fuel-vm/pull/870): Add 3 new ZK-related opcodes: eadd (ecAdd on EVM), emul (ecMul on EVM), epar (ecPairing on EVM)
+- [875](https://github.com/FuelLabs/fuel-vm/pull/875): Updated `wasm-bindgen` to `0.2.97`
 
 ### Fixed
 - [860](https://github.com/FuelLabs/fuel-vm/pull/860): Fixed missing fuzzing coverage report in CI.

--- a/fuel-asm/Cargo.toml
+++ b/fuel-asm/Cargo.toml
@@ -15,7 +15,7 @@ bitflags = { workspace = true }
 fuel-types = { workspace = true, default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 strum = { version = "0.24", default-features = false, features = ["derive"] }
-wasm-bindgen = { version = "0.2.88", optional = true }
+wasm-bindgen = { version = "0.2.97", optional = true }
 
 [dev-dependencies]
 bincode = { workspace = true }

--- a/fuel-tx/Cargo.toml
+++ b/fuel-tx/Cargo.toml
@@ -29,7 +29,7 @@ serde-wasm-bindgen = { version = "0.6", optional = true }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"], optional = true }
 strum = { version = "0.24", default-features = false, optional = true }
 strum_macros = { version = "0.24", optional = true }
-wasm-bindgen = { version = "0.2.88", optional = true }
+wasm-bindgen = { version = "0.2.97", optional = true }
 
 [dev-dependencies]
 bimap = "0.6"

--- a/fuel-types/Cargo.toml
+++ b/fuel-types/Cargo.toml
@@ -15,7 +15,7 @@ fuel-derive = { workspace = true }
 hex = { version = "0.4", default-features = false }
 rand = { version = "0.8", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
-wasm-bindgen = { version = "0.2.88", optional = true }
+wasm-bindgen = { version = "0.2.97", optional = true }
 
 [dev-dependencies]
 bincode = { workspace = true }


### PR DESCRIPTION
Bump `wasm-bindgen` from `0.2.88` to `0.2.97`

## Checklist
- [X] Breaking changes are clearly marked as such in the PR description and changelog
- [X] New behavior is reflected in tests
- [X] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
- [X] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [X] I have reviewed the code myself
- [X] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

N/A
