### PR TITLE
Replace derivative by educe

### DIFF
--- a/fuel-tx/Cargo.toml
+++ b/fuel-tx/Cargo.toml
@@ -12,8 +12,8 @@ description = "FuelVM transaction."
 
 [dependencies]
 bitflags = { workspace = true, features = ["serde"], optional = true }
-derivative = { version = "2.2.0", default-features = false, features = ["use_core"], optional = true }
-derive_more = { version = "0.99", default-features = false, features = ["display"], optional = true }
+educe = { version = "0.6", features = ["Eq", "PartialEq", "Hash", "Debug"], default-features = false, optional = true }
+derive_more = { version = "1", default-features = false, features = ["display"], optional = true }
 fuel-asm = { workspace = true, default-features = false }
 fuel-compression = { workspace = true, optional = true }
 fuel-crypto = { workspace = true, default-features = false }
@@ -55,7 +55,7 @@ internals = []
 typescript = ["dep:serde_json", "alloc", "js-sys", "wasm-bindgen", "serde-wasm-bindgen", "fuel-types/typescript"]
 random = ["fuel-crypto/random", "fuel-types/random", "rand"]
 std = ["alloc", "fuel-asm/std", "fuel-crypto/std", "fuel-merkle/std", "fuel-types/std", "itertools/default", "rand?/default", "serde/default", "hex/std"]
-alloc = ["hashbrown", "fuel-types/alloc", "itertools/use_alloc", "derivative", "fuel-merkle", "strum", "strum_macros", "bitflags", "postcard", "derive_more", "fuel-asm/serde", "fuel-types/serde"]
+alloc = ["hashbrown", "fuel-types/alloc", "itertools/use_alloc", "fuel-merkle", "strum", "strum_macros", "bitflags", "postcard", "educe", "derive_more", "fuel-asm/serde", "fuel-types/serde"]
 da-compression = ["fuel-compression"]
 
 [lints.rust]

--- a/fuel-tx/Cargo.toml
+++ b/fuel-tx/Cargo.toml
@@ -12,8 +12,8 @@ description = "FuelVM transaction."
 
 [dependencies]
 bitflags = { workspace = true, features = ["serde"], optional = true }
-educe = { version = "0.6", features = ["Eq", "PartialEq", "Hash", "Debug"], default-features = false, optional = true }
 derive_more = { version = "1", default-features = false, features = ["display"], optional = true }
+educe = { version = "0.6", features = ["Eq", "PartialEq", "Hash", "Debug"], default-features = false, optional = true }
 fuel-asm = { workspace = true, default-features = false }
 fuel-compression = { workspace = true, optional = true }
 fuel-crypto = { workspace = true, default-features = false }

--- a/fuel-tx/src/contract.rs
+++ b/fuel-tx/src/contract.rs
@@ -4,7 +4,7 @@ use crate::{
     ValidityError,
 };
 
-use derivative::Derivative;
+use educe::Educe;
 use fuel_crypto::Hasher;
 use fuel_merkle::{
     binary::root_calculator::MerkleRootCalculator as BinaryMerkleTree,
@@ -34,8 +34,8 @@ const LEAF_SIZE: usize = 16 * 1024;
 const PADDING_BYTE: u8 = 0u8;
 const MULTIPLE: usize = 8;
 
-#[derive(Default, Derivative, Clone, PartialEq, Eq, Hash)]
-#[derivative(Debug)]
+#[derive(Default, Clone, PartialEq, Eq, Hash, Educe)]
+#[educe(Debug)]
 #[derive(
     serde::Serialize,
     serde::Deserialize,
@@ -43,9 +43,7 @@ const MULTIPLE: usize = 8;
     fuel_types::canonical::Serialize,
 )]
 /// Deployable representation of a contract code.
-pub struct Contract(
-    #[derivative(Debug(format_with = "fmt_truncated_hex::<16>"))] Vec<u8>,
-);
+pub struct Contract(#[educe(Debug(method(fmt_truncated_hex::<16>)))] Vec<u8>);
 
 impl Contract {
     /// The `ContractId` of the contract with empty bytecode, zero salt, and empty state

--- a/fuel-tx/src/receipt.rs
+++ b/fuel-tx/src/receipt.rs
@@ -1,6 +1,6 @@
 use crate::Output;
 use alloc::vec::Vec;
-use derivative::Derivative;
+use educe::Educe;
 use fuel_asm::PanicInstruction;
 use fuel_crypto::Hasher;
 use fuel_types::{
@@ -24,10 +24,8 @@ mod script_result;
 use crate::input::message::compute_message_id;
 pub use script_result::ScriptExecutionResult;
 
-#[derive(
-    Clone, Derivative, serde::Serialize, serde::Deserialize, Deserialize, Serialize,
-)]
-#[derivative(Eq, PartialEq, Hash, Debug)]
+#[derive(Clone, Educe, serde::Serialize, serde::Deserialize, Deserialize, Serialize)]
+#[educe(Eq, PartialEq, Hash, Debug)]
 pub enum Receipt {
     Call {
         id: ContractId,
@@ -55,8 +53,9 @@ pub enum Receipt {
         digest: Bytes32,
         pc: Word,
         is: Word,
-        #[derivative(Debug(format_with = "fmt_option_truncated_hex::<16>"))]
-        #[derivative(PartialEq = "ignore", Hash = "ignore")]
+        #[educe(Debug(method("fmt_option_truncated_hex::<16>")))]
+        #[educe(PartialEq(ignore))]
+        #[educe(Hash(ignore))]
         #[canonical(skip)]
         data: Option<Vec<u8>>,
     },
@@ -66,7 +65,8 @@ pub enum Receipt {
         reason: PanicInstruction,
         pc: Word,
         is: Word,
-        #[derivative(PartialEq = "ignore", Hash = "ignore")]
+        #[educe(PartialEq(ignore))]
+        #[educe(Hash(ignore))]
         #[canonical(skip)]
         contract_id: Option<ContractId>,
     },
@@ -97,8 +97,9 @@ pub enum Receipt {
         digest: Bytes32,
         pc: Word,
         is: Word,
-        #[derivative(Debug(format_with = "fmt_option_truncated_hex::<16>"))]
-        #[derivative(PartialEq = "ignore", Hash = "ignore")]
+        #[educe(Debug(method("fmt_option_truncated_hex::<16>")))]
+        #[educe(PartialEq(ignore))]
+        #[educe(Hash(ignore))]
         #[canonical(skip)]
         data: Option<Vec<u8>>,
     },
@@ -133,8 +134,9 @@ pub enum Receipt {
         nonce: Nonce,
         len: Word,
         digest: Bytes32,
-        #[derivative(Debug(format_with = "fmt_option_truncated_hex::<16>"))]
-        #[derivative(PartialEq = "ignore", Hash = "ignore")]
+        #[educe(Debug(method("fmt_option_truncated_hex::<16>")))]
+        #[educe(PartialEq(ignore))]
+        #[educe(Hash(ignore))]
         #[canonical(skip)]
         data: Option<Vec<u8>>,
     },

--- a/fuel-tx/src/transaction/consensus_parameters.rs
+++ b/fuel-tx/src/transaction/consensus_parameters.rs
@@ -23,7 +23,7 @@ const MAX_GAS: u64 = 100_000_000;
 const MAX_SIZE: u64 = 110 * 1024;
 
 #[derive(Debug, derive_more::Display)]
-#[display(fmt = "setting block transaction size limit is not supported")]
+#[display("setting block transaction size limit is not supported")]
 pub struct SettingBlockTransactionSizeLimitNotSupported;
 #[cfg(feature = "std")]
 impl std::error::Error for SettingBlockTransactionSizeLimitNotSupported {}

--- a/fuel-tx/src/transaction/types/blob.rs
+++ b/fuel-tx/src/transaction/types/blob.rs
@@ -18,7 +18,7 @@ use crate::{
     TransactionRepr,
     ValidityError,
 };
-use derivative::Derivative;
+use educe::Educe;
 use fuel_types::{
     bytes::WORD_SIZE,
     canonical::Serialize,
@@ -45,14 +45,14 @@ pub type Blob = ChargeableTransaction<BlobBody, BlobMetadata>;
 pub struct BlobMetadata;
 
 /// The body of the [`Blob`] transaction.
-#[derive(Clone, Default, Derivative, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Default, Educe, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(
     feature = "da-compression",
     derive(fuel_compression::Compress, fuel_compression::Decompress)
 )]
 #[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
 #[canonical(prefix = TransactionRepr::Blob)]
-#[derivative(Eq, PartialEq, Hash, Debug)]
+#[educe(Eq, PartialEq, Hash, Debug)]
 pub struct BlobBody {
     /// Hash of the bytecode. Used both as a unique identifier and to verify the
     /// bytecode.

--- a/fuel-tx/src/transaction/types/chargeable_transaction.rs
+++ b/fuel-tx/src/transaction/types/chargeable_transaction.rs
@@ -23,7 +23,7 @@ use crate::{
     ValidityError,
     Witness,
 };
-use derivative::Derivative;
+use educe::Educe;
 use fuel_types::{
     bytes,
     canonical::Serialize,
@@ -74,8 +74,8 @@ pub trait BodyConstraints {}
 #[cfg(not(feature = "da-compression"))]
 impl<T> BodyConstraints for T {}
 
-#[derive(Clone, Derivative)]
-#[derivative(Eq, PartialEq, Hash, Debug)]
+#[derive(Clone, Educe)]
+#[educe(Eq, PartialEq, Hash, Debug)]
 #[derive(serde::Serialize, serde::Deserialize)]
 #[cfg_attr(
     feature = "da-compression",
@@ -94,7 +94,8 @@ where
     pub(crate) witnesses: Vec<Witness>,
     #[serde(skip)]
     #[cfg_attr(feature = "da-compression", compress(skip))]
-    #[derivative(PartialEq = "ignore", Hash = "ignore")]
+    #[educe(PartialEq(ignore))]
+    #[educe(Hash(ignore))]
     #[canonical(skip)]
     pub(crate) metadata: Option<ChargeableMetadata<MetadataBody>>,
 }

--- a/fuel-tx/src/transaction/types/create.rs
+++ b/fuel-tx/src/transaction/types/create.rs
@@ -23,7 +23,7 @@ use crate::{
     TransactionRepr,
     ValidityError,
 };
-use derivative::Derivative;
+use educe::Educe;
 use fuel_types::{
     bytes::WORD_SIZE,
     canonical,
@@ -43,8 +43,8 @@ mod ser_de_tests;
 
 pub type Create = ChargeableTransaction<CreateBody, CreateMetadata>;
 
-#[derive(Default, Debug, Clone, Derivative)]
-#[derivative(Eq, PartialEq, Hash)]
+#[derive(Default, Debug, Clone, Educe)]
+#[educe(Eq, PartialEq, Hash)]
 pub struct CreateMetadata {
     pub contract_id: ContractId,
     pub contract_root: Bytes32,
@@ -69,14 +69,14 @@ impl CreateMetadata {
     }
 }
 
-#[derive(Default, Debug, Clone, Derivative, serde::Serialize, serde::Deserialize)]
+#[derive(Default, Debug, Clone, Educe, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(
     feature = "da-compression",
     derive(fuel_compression::Compress, fuel_compression::Decompress)
 )]
 #[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
 #[canonical(prefix = TransactionRepr::Create)]
-#[derivative(Eq, PartialEq, Hash)]
+#[educe(Eq, PartialEq, Hash)]
 pub struct CreateBody {
     pub(crate) bytecode_witness_index: u16,
     pub(crate) salt: Salt,

--- a/fuel-tx/src/transaction/types/input/coin.rs
+++ b/fuel-tx/src/transaction/types/input/coin.rs
@@ -10,7 +10,7 @@ use crate::{
     UtxoId,
 };
 use alloc::vec::Vec;
-use derivative::Derivative;
+use educe::Educe;
 #[cfg(feature = "da-compression")]
 use fuel_compression::Compressible;
 use fuel_types::{
@@ -143,8 +143,8 @@ impl CoinSpecification for Full {
 /// - [`Full`] - is used during the deserialization of the coin. It should be transformed
 ///   into [`Signed`] or [`Predicate`] sub-coin. If the `predicate` is empty, it is
 ///   [`Signed`], else [`Predicate`].
-#[derive(Default, Derivative, Clone, PartialEq, Eq, Hash)]
-#[derivative(Debug)]
+#[derive(Default, Educe, Clone, PartialEq, Eq, Hash)]
+#[educe(Debug)]
 #[derive(serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "da-compression", derive(fuel_compression::Compress))]
 #[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
@@ -161,16 +161,16 @@ where
     pub asset_id: AssetId,
     #[cfg_attr(feature = "da-compression", compress(skip))]
     pub tx_pointer: TxPointer,
-    #[derivative(Debug(format_with = "fmt_as_field"))]
+    #[educe(Debug(method(fmt_as_field)))]
     pub witness_index: Specification::Witness,
     /// Exact amount of gas used by the predicate.
     /// If the predicate consumes different amount of gas,
     /// it's considered to be false.
-    #[derivative(Debug(format_with = "fmt_as_field"))]
+    #[educe(Debug(method(fmt_as_field)))]
     pub predicate_gas_used: Specification::PredicateGasUsed,
-    #[derivative(Debug(format_with = "fmt_as_field"))]
+    #[educe(Debug(method(fmt_as_field)))]
     pub predicate: Specification::Predicate,
-    #[derivative(Debug(format_with = "fmt_as_field"))]
+    #[educe(Debug(method(fmt_as_field)))]
     pub predicate_data: Specification::PredicateData,
 }
 

--- a/fuel-tx/src/transaction/types/input/message.rs
+++ b/fuel-tx/src/transaction/types/input/message.rs
@@ -3,7 +3,7 @@ use crate::{
     transaction::types::input::AsField,
 };
 use alloc::vec::Vec;
-use derivative::Derivative;
+use educe::Educe;
 #[cfg(feature = "da-compression")]
 use fuel_compression::Compressible;
 use fuel_types::{
@@ -205,8 +205,8 @@ pub mod specifications {
 /// - [`specifications::MessageData`] with [`specifications::Signed`] usage rules.
 /// - [`specifications::MessageData`] with [`specifications::Predicate`] usage rules.
 /// - [`specifications::Full`].
-#[derive(Default, Derivative, Clone, PartialEq, Eq, Hash)]
-#[derivative(Debug)]
+#[derive(Default, Educe, Clone, PartialEq, Eq, Hash)]
+#[educe(Debug)]
 #[derive(serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "da-compression", derive(fuel_compression::Compress))]
 #[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
@@ -224,19 +224,19 @@ where
     pub amount: Word,
     // Unique identifier of the message
     pub nonce: Nonce,
-    #[derivative(Debug(format_with = "fmt_as_field"))]
+    #[educe(Debug(method(fmt_as_field)))]
     pub witness_index: Specification::Witness,
     /// Exact amount of gas used by the predicate.
     /// If the predicate consumes different amount of gas,
     /// it's considered to be false.
-    #[derivative(Debug(format_with = "fmt_as_field"))]
+    #[educe(Debug(method(fmt_as_field)))]
     pub predicate_gas_used: Specification::PredicateGasUsed,
     #[cfg_attr(feature = "da-compression", compress(skip))]
-    #[derivative(Debug(format_with = "fmt_as_field"))]
+    #[educe(Debug(method(fmt_as_field)))]
     pub data: Specification::Data,
-    #[derivative(Debug(format_with = "fmt_as_field"))]
+    #[educe(Debug(method(fmt_as_field)))]
     pub predicate: Specification::Predicate,
-    #[derivative(Debug(format_with = "fmt_as_field"))]
+    #[educe(Debug(method(fmt_as_field)))]
     pub predicate_data: Specification::PredicateData,
 }
 

--- a/fuel-tx/src/transaction/types/input/predicate.rs
+++ b/fuel-tx/src/transaction/types/input/predicate.rs
@@ -2,17 +2,17 @@ use core::ops::{
     Deref,
     DerefMut,
 };
-use derivative::Derivative;
+use educe::Educe;
 use fuel_types::fmt_truncated_hex;
 
 use alloc::vec::Vec;
 
-#[derive(Clone, Default, Derivative, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Default, Educe, serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
 #[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
-#[derivative(Eq, PartialEq, Hash, Debug)]
+#[educe(Eq, PartialEq, Hash, Debug)]
 pub struct PredicateCode {
-    #[derivative(Debug(format_with = "fmt_truncated_hex::<16>"))]
+    #[educe(Debug(method(fmt_truncated_hex::<16>)))]
     pub bytes: Vec<u8>,
 }
 

--- a/fuel-tx/src/transaction/types/mint.rs
+++ b/fuel-tx/src/transaction/types/mint.rs
@@ -13,7 +13,7 @@ use crate::{
     TxPointer,
     ValidityError,
 };
-use derivative::Derivative;
+use educe::Educe;
 use fuel_asm::Word;
 use fuel_types::{
     bytes::WORD_SIZE,
@@ -47,11 +47,11 @@ impl MintMetadata {
 ///
 /// This transaction can be created by the block producer and included in the block only
 /// by it.
-#[derive(Default, Debug, Clone, Derivative, serde::Serialize, serde::Deserialize)]
+#[derive(Default, Debug, Clone, Educe, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "da-compression", derive(fuel_compression::Compress))]
 #[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
 #[canonical(prefix = TransactionRepr::Mint)]
-#[derivative(Eq, PartialEq, Hash)]
+#[educe(Eq, PartialEq, Hash)]
 pub struct Mint {
     /// The location of the transaction in the block.
     #[cfg_attr(feature = "da-compression", compress(skip))]
@@ -67,7 +67,8 @@ pub struct Mint {
     /// Gas Price used for current block
     pub(crate) gas_price: Word,
     #[serde(skip)]
-    #[derivative(PartialEq = "ignore", Hash = "ignore")]
+    #[educe(PartialEq(ignore))]
+    #[educe(Hash(ignore))]
     #[canonical(skip)]
     #[cfg_attr(feature = "da-compression", compress(skip))]
     pub(crate) metadata: Option<MintMetadata>,

--- a/fuel-tx/src/transaction/types/script.rs
+++ b/fuel-tx/src/transaction/types/script.rs
@@ -29,7 +29,7 @@ use crate::{
     TransactionRepr,
     ValidityError,
 };
-use derivative::Derivative;
+use educe::Educe;
 use fuel_types::{
     bytes,
     bytes::WORD_SIZE,
@@ -50,12 +50,12 @@ pub struct ScriptMetadata {
     pub script_data_offset: usize,
 }
 
-#[derive(Clone, Default, Derivative, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Default, Educe, serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
 #[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
-#[derivative(Eq, PartialEq, Hash, Debug)]
+#[educe(Eq, PartialEq, Hash, Debug)]
 pub struct ScriptCode {
-    #[derivative(Debug(format_with = "fmt_truncated_hex::<16>"))]
+    #[educe(Debug(method(fmt_truncated_hex::<16>)))]
     pub bytes: Vec<u8>,
 }
 
@@ -106,7 +106,7 @@ impl fuel_compression::Compressible for ScriptCode {
 
 #[derive(
     Clone,
-    Derivative,
+    Educe,
     serde::Serialize,
     serde::Deserialize,
     fuel_types::canonical::Deserialize,
@@ -117,13 +117,13 @@ impl fuel_compression::Compressible for ScriptCode {
     derive(fuel_compression::Compress, fuel_compression::Decompress)
 )]
 #[canonical(prefix = TransactionRepr::Script)]
-#[derivative(Eq, PartialEq, Hash, Debug)]
+#[educe(Eq, PartialEq, Hash, Debug)]
 pub struct ScriptBody {
     pub(crate) script_gas_limit: Word,
     #[cfg_attr(feature = "da-compression", compress(skip))]
     pub(crate) receipts_root: Bytes32,
     pub(crate) script: ScriptCode,
-    #[derivative(Debug(format_with = "fmt_truncated_hex::<16>"))]
+    #[educe(Debug(method(fmt_truncated_hex::<16>)))]
     pub(crate) script_data: Vec<u8>,
 }
 

--- a/fuel-tx/src/transaction/types/upgrade.rs
+++ b/fuel-tx/src/transaction/types/upgrade.rs
@@ -16,7 +16,7 @@ use crate::{
     TransactionRepr,
     ValidityError,
 };
-use derivative::Derivative;
+use educe::Educe;
 use fuel_types::{
     bytes::WORD_SIZE,
     canonical::Serialize,
@@ -95,14 +95,14 @@ impl UpgradeMetadata {
 /// The types describe the purpose of the upgrade performed by the [`Upgrade`]
 /// transaction.
 #[derive(
-    Copy, Clone, Derivative, strum_macros::EnumCount, serde::Serialize, serde::Deserialize,
+    Copy, Clone, Educe, strum_macros::EnumCount, serde::Serialize, serde::Deserialize,
 )]
 #[cfg_attr(
     feature = "da-compression",
     derive(fuel_compression::Compress, fuel_compression::Decompress)
 )]
 #[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
-#[derivative(Eq, PartialEq, Hash, Debug)]
+#[educe(Eq, PartialEq, Hash, Debug)]
 pub enum UpgradePurpose {
     /// The upgrade is performed to change the consensus parameters.
     ConsensusParameters {
@@ -125,14 +125,14 @@ pub enum UpgradePurpose {
 }
 
 /// The body of the [`Upgrade`] transaction.
-#[derive(Clone, Derivative, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Educe, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(
     feature = "da-compression",
     derive(fuel_compression::Compress, fuel_compression::Decompress)
 )]
 #[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
 #[canonical(prefix = TransactionRepr::Upgrade)]
-#[derivative(Eq, PartialEq, Hash, Debug)]
+#[educe(Eq, PartialEq, Hash, Debug)]
 pub struct UpgradeBody {
     /// The purpose of the upgrade.
     pub(crate) purpose: UpgradePurpose,

--- a/fuel-tx/src/transaction/types/upload.rs
+++ b/fuel-tx/src/transaction/types/upload.rs
@@ -19,7 +19,7 @@ use crate::{
     ValidityError,
 };
 use core::ops::Deref;
-use derivative::Derivative;
+use educe::Educe;
 use fuel_types::{
     bytes::WORD_SIZE,
     canonical::Serialize,
@@ -37,14 +37,14 @@ pub type Upload = ChargeableTransaction<UploadBody, UploadMetadata>;
 pub struct UploadMetadata;
 
 /// The body of the [`Upload`] transaction.
-#[derive(Clone, Default, Derivative, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Default, Educe, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(
     feature = "da-compression",
     derive(fuel_compression::Compress, fuel_compression::Decompress)
 )]
 #[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
 #[canonical(prefix = TransactionRepr::Upload)]
-#[derivative(Eq, PartialEq, Hash, Debug)]
+#[educe(Eq, PartialEq, Hash, Debug)]
 pub struct UploadBody {
     /// The root of the Merkle tree is created over the bytecode.
     pub root: Bytes32,

--- a/fuel-tx/src/transaction/types/witness.rs
+++ b/fuel-tx/src/transaction/types/witness.rs
@@ -1,4 +1,4 @@
-use derivative::Derivative;
+use educe::Educe;
 use fuel_types::fmt_truncated_hex;
 
 use alloc::vec::Vec;
@@ -22,8 +22,8 @@ use rand::{
     Rng,
 };
 
-#[derive(Derivative, Default, Clone, PartialEq, Eq, Hash)]
-#[derivative(Debug)]
+#[derive(Educe, Default, Clone, PartialEq, Eq, Hash)]
+#[educe(Debug)]
 #[cfg_attr(feature = "typescript", wasm_bindgen::prelude::wasm_bindgen)]
 #[derive(serde::Serialize, serde::Deserialize)]
 #[cfg_attr(
@@ -32,7 +32,7 @@ use rand::{
 )]
 #[derive(fuel_types::canonical::Deserialize, fuel_types::canonical::Serialize)]
 pub struct Witness {
-    #[derivative(Debug(format_with = "fmt_truncated_hex::<16>"))]
+    #[educe(Debug(method(fmt_truncated_hex::<16>)))]
     data: Vec<u8>,
 }
 

--- a/fuel-tx/src/transaction/validity/error.rs
+++ b/fuel-tx/src/transaction/validity/error.rs
@@ -141,7 +141,7 @@ pub enum ValidityError {
     /// The transaction doesn't provide enough input amount of the native chain asset to
     /// cover all potential execution fees
     #[display(
-        fmt = "Insufficient fee amount: expected {}, provided {}",
+        "Insufficient fee amount: expected {}, provided {}",
         expected,
         provided
     )]
@@ -154,7 +154,7 @@ pub enum ValidityError {
     /// The transaction doesn't provide enough input amount of the given asset to cover
     /// the amounts used in the outputs.
     #[display(
-        fmt = "Insufficient input amount: asset {}, expected {}, provided {}",
+        "Insufficient input amount: asset {}, expected {}, provided {}",
         asset,
         expected,
         provided

--- a/fuel-vm/Cargo.toml
+++ b/fuel-vm/Cargo.toml
@@ -21,11 +21,11 @@ async-trait = "0.1"
 backtrace = { version = "0.3", optional = true } # requires debug symbols to work
 bitflags = { workspace = true }
 bn = { package = "substrate-bn", version = "0.6", default-features = false }
-educe = { version = "0.6", default-features = false, features = ["Debug"] }
 derive_more = { version = "0.99", default-features = false, features = [
     "display",
 ] }
 dyn-clone = { version = "1.0", optional = true }
+educe = { version = "0.6", default-features = false, features = ["Debug"] }
 ethnum = "1.3"
 fuel-asm = { workspace = true, default-features = false }
 fuel-compression = { workspace = true, default-features = false, optional = true }

--- a/fuel-vm/Cargo.toml
+++ b/fuel-vm/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = "0.1"
 backtrace = { version = "0.3", optional = true } # requires debug symbols to work
 bitflags = { workspace = true }
 bn = { package = "substrate-bn", version = "0.6", default-features = false }
-derivative = "2.2"
+educe = { version = "0.6", default-features = false, features = ["Debug"] }
 derive_more = { version = "0.99", default-features = false, features = [
     "display",
 ] }

--- a/fuel-vm/src/backtrace.rs
+++ b/fuel-vm/src/backtrace.rs
@@ -15,7 +15,7 @@ use crate::{
         Interpreter,
     },
 };
-use derivative::Derivative;
+use educe::Educe;
 
 use crate::interpreter::{
     Memory,
@@ -27,8 +27,8 @@ use fuel_types::{
     Word,
 };
 
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Educe)]
+#[educe(Debug)]
 /// Runtime description derived from a VM error.
 pub struct Backtrace {
     call_stack: Vec<CallFrame>,

--- a/fuel-vm/src/storage/blob_data.rs
+++ b/fuel-vm/src/storage/blob_data.rs
@@ -5,7 +5,7 @@ use fuel_types::{
 };
 
 use alloc::vec::Vec;
-use derivative::Derivative;
+use educe::Educe;
 
 #[cfg(feature = "random")]
 use rand::{
@@ -27,12 +27,10 @@ impl Mappable for BlobData {
 }
 
 /// Storage type for blob bytes
-#[derive(Derivative, Clone, PartialEq, Eq, Hash)]
-#[derivative(Debug)]
+#[derive(Educe, Clone, PartialEq, Eq, Hash)]
+#[educe(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct BlobBytes(
-    #[derivative(Debug(format_with = "fmt_truncated_hex::<16>"))] pub Vec<u8>,
-);
+pub struct BlobBytes(#[educe(Debug(method(fmt_truncated_hex::<16>)))] pub Vec<u8>);
 
 impl From<Vec<u8>> for BlobBytes {
     fn from(c: Vec<u8>) -> Self {

--- a/fuel-vm/src/storage/contracts_state.rs
+++ b/fuel-vm/src/storage/contracts_state.rs
@@ -10,7 +10,7 @@ use alloc::{
     vec,
     vec::Vec,
 };
-use derivative::Derivative;
+use educe::Educe;
 
 #[cfg(feature = "random")]
 use rand::{
@@ -44,11 +44,11 @@ double_key!(
 );
 
 /// Storage type for contract state
-#[derive(Derivative, Clone, PartialEq, Eq, Hash)]
-#[derivative(Debug)]
+#[derive(Educe, Clone, PartialEq, Eq, Hash)]
+#[educe(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ContractsStateData(
-    #[derivative(Debug(format_with = "fmt_truncated_hex::<16>"))] pub Vec<u8>,
+    #[educe(Debug(method(fmt_truncated_hex::<16>)))] pub Vec<u8>,
 );
 
 // TODO: Remove fixed size default when adding support for dynamic storage


### PR DESCRIPTION
Fix https://github.com/FuelLabs/fuel-vm/issues/869

Alternative studied : 

- `derive_more` most maintained but doesn't features we need such as `PartialEq` (https://github.com/JelteF/derive_more/issues/414) might be a good fit in the future.
- `derive-where` same issue and even less maintained.

Educe is nearly a drop-in replacement, one of the maintainer is still pretty active.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here