### PR TITLE
Release  v0.59.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.59.0]
+
 ### Added
 - [871](https://github.com/FuelLabs/fuel-vm/pull/871): Add `expiration` policy that prevent a transaction to be inserted after a given block height.
 - [870](https://github.com/FuelLabs/fuel-vm/pull/870): Add 3 new ZK-related opcodes: eadd (ecAdd on EVM), emul (ecMul on EVM), epar (ecPairing on EVM)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,18 +18,18 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.58.2"
+version = "0.59.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.58.2", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.58.2", path = "fuel-crypto", default-features = false }
-fuel-compression = { version = "0.58.2", path = "fuel-compression", default-features = false }
-fuel-derive = { version = "0.58.2", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.58.2", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.58.2", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.58.2", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.58.2", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.58.2", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.59.0", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.59.0", path = "fuel-crypto", default-features = false }
+fuel-compression = { version = "0.59.0", path = "fuel-compression", default-features = false }
+fuel-derive = { version = "0.59.0", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.59.0", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.59.0", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.59.0", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.59.0", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.59.0", path = "fuel-vm", default-features = false }
 bitflags = "2"
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
## Version v0.59.0

### Added
- [871](https://github.com/FuelLabs/fuel-vm/pull/871): Add `expiration` policy that prevent a transaction to be inserted after a given block height.
- [870](https://github.com/FuelLabs/fuel-vm/pull/870): Add 3 new ZK-related opcodes: eadd (ecAdd on EVM), emul (ecMul on EVM), epar (ecPairing on EVM)
- [875](https://github.com/FuelLabs/fuel-vm/pull/875): Updated `wasm-bindgen` to `0.2.97`

### Fixed
- [860](https://github.com/FuelLabs/fuel-vm/pull/860): Fixed missing fuzzing coverage report in CI.

### Breaking 
- [863](https://github.com/FuelLabs/fuel-vm/pull/863): Changed StorageRead::read to load a serialized value starting from a offset. The function returns an optional value equal to the number of bytes read when defined, or none if the offset specified in input is outside the boundaries of the serialized value read.
- [868](https://github.com/FuelLabs/fuel-vm/pull/868): Fixed error message when having a nonexistent contract in inputs. Instead of saying "contract was in inputs, but doesn't exist", the message was just "contract not in inputs". Now there's a separate error for that.
- [837](https://github.com/FuelLabs/fuel-vm/pull/837): Change `diff` function to get VM instance diff to a `rollback_to` that allow to fetch changes to make self -> previous state. However, this support the new memory management that allow memory to grow between instances instead of fixed memory size.

### Changed
- [847](https://github.com/FuelLabs/fuel-vm/pull/847): Changed `interpreter::blockchain::load_contract_code` and `interpreter::blockchain::code_copy` to use the new version of `StorageRead::read` where the contract is loaded into a buffer starting from an offset. The contract is copied directly into the portion of memory starting at the destination address, rather than having to be copied indirectly after being fetched from storage.


## What's Changed
* Create SECURITY.md by @Voxelot in https://github.com/FuelLabs/fuel-vm/pull/858
* fix(fuzz_coverage): Don't specify compiler version to avoid raw profile version mismatch by @netrome in https://github.com/FuelLabs/fuel-vm/pull/860
* Update packages versions to remove dependency to proc-macro-error by @AurelienFT in https://github.com/FuelLabs/fuel-vm/pull/861
* Add the possibility to specify an offset for the read value in StorageRead::read by @acerone85 in https://github.com/FuelLabs/fuel-vm/pull/863
* Add new ZK opcodes by @AurelienFT in https://github.com/FuelLabs/fuel-vm/pull/870
* chore: bump wasm-bindgen from `0.2.88` to `0.2.97` by @petertonysmith94 in https://github.com/FuelLabs/fuel-vm/pull/875
* Add expiration policy by @AurelienFT in https://github.com/FuelLabs/fuel-vm/pull/871
* Add a separate error for nonexistent contract input by @Dentosal in https://github.com/FuelLabs/fuel-vm/pull/868
* Optimize `interpreter::blockchain::{load_contract_code, code_copy}` to read contract starting from offset by @acerone85 in https://github.com/FuelLabs/fuel-vm/pull/847
* Rollback memory changes by @xgreenx in https://github.com/FuelLabs/fuel-vm/pull/837

## New Contributors
* @AurelienFT made their first contribution in https://github.com/FuelLabs/fuel-vm/pull/861
* @petertonysmith94 made their first contribution in https://github.com/FuelLabs/fuel-vm/pull/875

**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.58.2...v0.59.0