### PR TITLE
Release 0.59.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.59.1]
+
 ### Fixed
 - [879](https://github.com/FuelLabs/fuel-vm/pull/879): Debugger state wasn't propagated in contract contexts.
 - [878](https://github.com/FuelLabs/fuel-vm/pull/878): Fix the transaction de/serialization that wasn't backward compatible with the addition of the new policy.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,18 +19,18 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.59.0"
+version = "0.59.1"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.59.0", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.59.0", path = "fuel-crypto", default-features = false }
-fuel-compression = { version = "0.59.0", path = "fuel-compression", default-features = false }
-fuel-derive = { version = "0.59.0", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.59.0", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.59.0", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.59.0", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.59.0", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.59.0", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.59.1", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.59.1", path = "fuel-crypto", default-features = false }
+fuel-compression = { version = "0.59.1", path = "fuel-compression", default-features = false }
+fuel-derive = { version = "0.59.1", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.59.1", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.59.1", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.59.1", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.59.1", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.59.1", path = "fuel-vm", default-features = false }
 bitflags = "2"
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
## Version 0.59.1

### Fixed
- [879](https://github.com/FuelLabs/fuel-vm/pull/879): Debugger state wasn't propagated in contract contexts.
- [878](https://github.com/FuelLabs/fuel-vm/pull/878): Fix the transaction de/serialization that wasn't backward compatible with the addition of the new policy.

(The tests that was failing on `fuel-core` doesn't fail anymore on this branch)
