### PR TITLE
Add new tx specific GTFArgs and make new generic GTFArgs to replace duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - [896](https://github.com/FuelLabs/fuel-vm/pull/896): Expose `leaf_sum` and allow binary `MerkleTree` to be built from existing precomputed leafs.
+- [882](https://github.com/FuelLabs/fuel-vm/pull/882): Add a lot of new `GTFArgs` including generic ones that will replace old tx type specific.
 
 ### Breaking
 - [900](https://github.com/FuelLabs/fuel-vm/pull/900): Change the error variant `DuplicateMessageInputId` to `DuplicateInputNonce` which now contains a nonce instead of `MessageId` for performance improvements.

--- a/fuel-asm/src/args.rs
+++ b/fuel-asm/src/args.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 pub mod wideint;
 
 /// 12-bits immediate value type
@@ -64,12 +66,15 @@ crate::enum_try_from! {
         ScriptDataLength = 0x004,
 
         /// Set `$rA` to `tx.inputsCount`
+        #[deprecated(since = "0.60.0", note = "Use the generic `TxInputsCount` instead")]
         ScriptInputsCount = 0x005,
 
         /// Set `$rA` to `tx.outputsCount`
+        #[deprecated(since = "0.60.0", note = "Use the generic `TxOutputsCount` instead")]
         ScriptOutputsCount = 0x006,
 
         /// Set `$rA` to `tx.witnessesCount`
+        #[deprecated(since = "0.60.0", note = "Use the generic `TxWitnessesCount` instead")]
         ScriptWitnessesCount = 0x007,
 
         /// Set `$rA` to `Memory address of tx.script`
@@ -79,12 +84,15 @@ crate::enum_try_from! {
         ScriptData = 0x00A,
 
         /// Set `$rA` to `Memory address of tx.inputs[$rB]`
+        #[deprecated(since = "0.60.0", note = "Use the generic `TxInputAtIndex` instead")]
         ScriptInputAtIndex = 0x00B,
 
         /// Set `$rA` to `Memory address of t.outputs[$rB]`
+        #[deprecated(since = "0.60.0", note = "Use the generic `TxOutputAtIndex` instead")]
         ScriptOutputAtIndex = 0x00C,
 
         /// Set `$rA` to `Memory address of tx.witnesses[$rB]`
+        #[deprecated(since = "0.60.0", note = "Use the generic `TxWitnessAtIndex` instead")]
         ScriptWitnessAtIndex = 0x00D,
 
         /// Set `$rA` to size of the transaction in memory, in bytes
@@ -97,12 +105,15 @@ crate::enum_try_from! {
         CreateStorageSlotsCount = 0x102,
 
         /// Set `$rA` to `tx.inputsCount`
+        #[deprecated(since = "0.60.0", note = "Use the generic `TxInputsCount` instead")]
         CreateInputsCount = 0x103,
 
         /// Set `$rA` to `tx.outputsCount`
+        #[deprecated(since = "0.60.0", note = "Use the generic `TxOutputsCount` instead")]
         CreateOutputsCount = 0x104,
 
         /// Set `$rA` to `tx.witnessesCount`
+        #[deprecated(since = "0.60.0", note = "Use the generic `TxWitnessesCount` instead")]
         CreateWitnessesCount = 0x105,
 
         /// Set `$rA` to `Memory address of tx.salt`
@@ -112,12 +123,15 @@ crate::enum_try_from! {
         CreateStorageSlotAtIndex = 0x107,
 
         /// Set `$rA` to `Memory address of tx.inputs[$rB]`
+        #[deprecated(since = "0.60.0", note = "Use the generic `TxInputAtIndex` instead")]
         CreateInputAtIndex = 0x108,
 
         /// Set `$rA` to `Memory address of t.outputs[$rB]`
+        #[deprecated(since = "0.60.0", note = "Use the generic `TxOutputAtIndex` instead")]
         CreateOutputAtIndex = 0x109,
 
         /// Set `$rA` to `Memory address of tx.witnesses[$rB]`
+        #[deprecated(since = "0.60.0", note = "Use the generic `TxWitnessAtIndex` instead")]
         CreateWitnessAtIndex = 0x10A,
 
         /// Set `$rA` to `tx.inputs[$rB].type`
@@ -248,6 +262,57 @@ crate::enum_try_from! {
 
         /// Set `$rA` to `tx.policies[count_ones(0b11111 & tx.policyTypes) - 1].expiration`
         PolicyExpiration = 0x505,
+
+        /// Set `$rA` to `Memory address of tx.root`
+        UploadRoot = 0x600,
+
+        /// Set `$rA` to `tx.witnessIndex`
+        UploadWitnessIndex = 0x601,
+
+        /// Set `$rA` to `tx.subsectionIndex`
+        UploadSubsectionIndex = 0x602,
+
+        /// Set `$rA` to `tx.subsectionsNumber`
+        UploadSubsectionsCount = 0x603,
+
+        /// Set `$rA` to `tx.proofSetCount`
+        UploadProofSetCount = 0x604,
+
+        /// Set `$rA` to `Memory address of tx.proofSet[$rB]`
+        UploadProofSetAtIndex = 0x605,
+
+        /// Set `$rA` to `Memory address of tx.id`
+        BlobId = 0x700,
+
+        /// Set `$rA` to `tx.witnessIndex`
+        BlobWitnessIndex = 0x701,
+
+        /// Set `$rA` to `tx.purpose.root` if `tx.purpose.type == StateTransition`
+        UpgradeStateTransitionRoot = 0x800,
+
+        /// Set `$rA` to `tx.purpose.witnessIndex` if `tx.purpose.type == ConsensusParameters`
+        UpgradeConsensusParametersWitnessIndex = 0x801,
+
+        /// Set `$rA` to `Memory address of tx.purpose.checksum` if `tx.purpose.type == ConsensusParameters`
+        UpgradeConsensusParametersChecksum = 0x802,
+
+        /// Set `$rA` to `tx.inputsCount`
+        TxInputsCount = 0x900,
+
+        /// Set `$rA` to `tx.outputsCount`
+        TxOutputsCount = 0x901,
+
+        /// Set `$rA` to `tx.witnessesCount`
+        TxWitnessesCount = 0x902,
+
+        /// Set `$rA` to `Memory address of tx.inputs[$rB]`
+        TxInputAtIndex = 0x903,
+
+        /// Set `$rA` to `Memory address of t.outputs[$rB]`
+        TxOutputAtIndex = 0x904,
+
+        /// Set `$rA` to `Memory address of tx.witnesses[$rB]`
+        TxWitnessAtIndex = 0x905,
     },
     Immediate12
 }

--- a/fuel-asm/src/args.rs
+++ b/fuel-asm/src/args.rs
@@ -287,14 +287,8 @@ crate::enum_try_from! {
         /// Set `$rA` to `tx.witnessIndex`
         BlobWitnessIndex = 0x701,
 
-        /// Set `$rA` to `tx.purpose.root` if `tx.purpose.type == StateTransition`
-        UpgradeStateTransitionRoot = 0x800,
-
-        /// Set `$rA` to `tx.purpose.witnessIndex` if `tx.purpose.type == ConsensusParameters`
-        UpgradeConsensusParametersWitnessIndex = 0x801,
-
-        /// Set `$rA` to `Memory address of tx.purpose.checksum` if `tx.purpose.type == ConsensusParameters`
-        UpgradeConsensusParametersChecksum = 0x802,
+        /// Set `$rA` to `Memory address of tx.purpose`
+        UpgradePurpose = 0x800,
 
         /// Set `$rA` to `tx.inputsCount`
         TxInputsCount = 0x900,
@@ -410,6 +404,21 @@ fn encode_gtf_args() {
         GTFArgs::PolicyMaturity,
         GTFArgs::PolicyExpiration,
         GTFArgs::PolicyMaxFee,
+        GTFArgs::UploadRoot,
+        GTFArgs::UploadWitnessIndex,
+        GTFArgs::UploadSubsectionIndex,
+        GTFArgs::UploadSubsectionsCount,
+        GTFArgs::UploadProofSetCount,
+        GTFArgs::UploadProofSetAtIndex,
+        GTFArgs::BlobId,
+        GTFArgs::BlobWitnessIndex,
+        GTFArgs::UpgradePurpose,
+        GTFArgs::TxInputsCount,
+        GTFArgs::TxOutputsCount,
+        GTFArgs::TxWitnessesCount,
+        GTFArgs::TxInputAtIndex,
+        GTFArgs::TxOutputAtIndex,
+        GTFArgs::TxWitnessAtIndex,
     ];
 
     args.into_iter().for_each(|a| {

--- a/fuel-asm/src/panic_reason.rs
+++ b/fuel-asm/src/panic_reason.rs
@@ -160,14 +160,12 @@ enum_from! {
         InvalidEllipticCurvePoint = 0x3b,
         /// Given input contract does not exist.
         InputContractDoesNotExist = 0x3c,
-        /// Invalid transaction type.
-        InvalidTransactionType = 0x3d,
         /// Storage slot in Create not found
-        StorageSlotsNotFound = 0x3e,
+        StorageSlotsNotFound = 0x3d,
         /// Proof in Upload not found
-        ProofInUploadNotFound = 0x3f,
+        ProofInUploadNotFound = 0x3e,
         /// Invalid purpose type in Upgrade
-        InvalidUpgradePurposeType = 0x40,
+        InvalidUpgradePurposeType = 0x3f,
     }
 }
 

--- a/fuel-asm/src/panic_reason.rs
+++ b/fuel-asm/src/panic_reason.rs
@@ -160,6 +160,14 @@ enum_from! {
         InvalidEllipticCurvePoint = 0x3b,
         /// Given input contract does not exist.
         InputContractDoesNotExist = 0x3c,
+        /// Invalid transaction type.
+        InvalidTransactionType = 0x3d,
+        /// Storage slot in Create not found
+        StorageSlotsNotFound = 0x3e,
+        /// Proof in Upload not found
+        ProofInUploadNotFound = 0x3f,
+        /// Invalid purpose type in Upgrade
+        InvalidUpgradePurposeType = 0x40,
     }
 }
 

--- a/fuel-tx/src/transaction.rs
+++ b/fuel-tx/src/transaction.rs
@@ -1099,6 +1099,9 @@ pub mod field {
         }
 
         fn proof_set_offset_static() -> usize;
+
+        /// Returns the offset to the `Bytes32` at `idx` index, if any.
+        fn proof_set_offset_at(&self, idx: usize) -> Option<usize>;
     }
 }
 

--- a/fuel-tx/src/transaction/repr.rs
+++ b/fuel-tx/src/transaction/repr.rs
@@ -1,3 +1,8 @@
+use fuel_asm::{
+    PanicReason,
+    Word,
+};
+
 use crate::Transaction;
 
 #[derive(
@@ -30,6 +35,22 @@ impl From<&Transaction> for TransactionRepr {
             Transaction::Upgrade { .. } => Self::Upgrade,
             Transaction::Upload { .. } => Self::Upload,
             Transaction::Blob { .. } => Self::Blob,
+        }
+    }
+}
+
+impl TryFrom<Word> for TransactionRepr {
+    type Error = PanicReason;
+
+    fn try_from(value: Word) -> Result<Self, Self::Error> {
+        match value {
+            0x00 => Ok(Self::Script),
+            0x01 => Ok(Self::Create),
+            0x02 => Ok(Self::Mint),
+            0x03 => Ok(Self::Upgrade),
+            0x04 => Ok(Self::Upload),
+            0x05 => Ok(Self::Blob),
+            _ => Err(PanicReason::InvalidTransactionType),
         }
     }
 }

--- a/fuel-tx/src/transaction/repr.rs
+++ b/fuel-tx/src/transaction/repr.rs
@@ -1,8 +1,3 @@
-use fuel_asm::{
-    PanicReason,
-    Word,
-};
-
 use crate::Transaction;
 
 #[derive(
@@ -35,22 +30,6 @@ impl From<&Transaction> for TransactionRepr {
             Transaction::Upgrade { .. } => Self::Upgrade,
             Transaction::Upload { .. } => Self::Upload,
             Transaction::Blob { .. } => Self::Blob,
-        }
-    }
-}
-
-impl TryFrom<Word> for TransactionRepr {
-    type Error = PanicReason;
-
-    fn try_from(value: Word) -> Result<Self, Self::Error> {
-        match value {
-            0x00 => Ok(Self::Script),
-            0x01 => Ok(Self::Create),
-            0x02 => Ok(Self::Mint),
-            0x03 => Ok(Self::Upgrade),
-            0x04 => Ok(Self::Upload),
-            0x05 => Ok(Self::Blob),
-            _ => Err(PanicReason::InvalidTransactionType),
         }
     }
 }

--- a/fuel-tx/src/transaction/types/upload.rs
+++ b/fuel-tx/src/transaction/types/upload.rs
@@ -389,6 +389,18 @@ mod field {
                 + WORD_SIZE, // Witnesses size
             )
         }
+
+        #[inline(always)]
+        fn proof_set_offset_at(&self, idx: usize) -> Option<usize> {
+            if idx < self.body.proof_set.len() {
+                Some(
+                    Self::proof_set_offset_static()
+                        .checked_add(idx.checked_mul(Bytes32::LEN)?)?,
+                )
+            } else {
+                None
+            }
+        }
     }
 
     impl ChargeableBody<UploadBody> for Upload {

--- a/fuel-vm/src/interpreter.rs
+++ b/fuel-vm/src/interpreter.rs
@@ -368,6 +368,20 @@ impl<M, S, Tx, Ecal> AsMut<S> for Interpreter<M, S, Tx, Ecal> {
     }
 }
 
+/// Enum of executable transactions.
+pub enum ExecutableTxType<'a> {
+    /// Reference to the `Script` transaction.
+    Script(&'a Script),
+    /// Reference to the `Create` transaction.
+    Create(&'a Create),
+    /// Reference to the `Blob` transaction.
+    Blob(&'a Blob),
+    /// Reference to the `Upgrade` transaction.
+    Upgrade(&'a Upgrade),
+    /// Reference to the `Upload` transaction.
+    Upload(&'a Upload),
+}
+
 /// The definition of the executable transaction supported by the `Interpreter`.
 pub trait ExecutableTransaction:
     Default
@@ -433,9 +447,11 @@ pub trait ExecutableTransaction:
         None
     }
 
-    /// Returns the type of the transaction like `Transaction::Create` or
-    /// `Transaction::Script`.
-    fn transaction_type() -> Word;
+    /// Returns `TransactionRepr` type associated with transaction.
+    fn transaction_type() -> TransactionRepr;
+
+    /// Returns `ExecutableTxType` type associated with transaction.
+    fn executable_type(&self) -> ExecutableTxType;
 
     /// Replaces the `Output::Variable` with the `output`(should be also
     /// `Output::Variable`) by the `idx` index.
@@ -547,8 +563,12 @@ impl ExecutableTransaction for Create {
         Some(self)
     }
 
-    fn transaction_type() -> Word {
-        TransactionRepr::Create as Word
+    fn transaction_type() -> TransactionRepr {
+        TransactionRepr::Create
+    }
+
+    fn executable_type(&self) -> ExecutableTxType {
+        ExecutableTxType::Create(self)
     }
 }
 
@@ -561,8 +581,12 @@ impl ExecutableTransaction for Script {
         Some(self)
     }
 
-    fn transaction_type() -> Word {
-        TransactionRepr::Script as Word
+    fn transaction_type() -> TransactionRepr {
+        TransactionRepr::Script
+    }
+
+    fn executable_type(&self) -> ExecutableTxType {
+        ExecutableTxType::Script(self)
     }
 }
 
@@ -575,8 +599,12 @@ impl ExecutableTransaction for Upgrade {
         Some(self)
     }
 
-    fn transaction_type() -> Word {
-        TransactionRepr::Upgrade as Word
+    fn transaction_type() -> TransactionRepr {
+        TransactionRepr::Upgrade
+    }
+
+    fn executable_type(&self) -> ExecutableTxType {
+        ExecutableTxType::Upgrade(self)
     }
 }
 
@@ -589,8 +617,12 @@ impl ExecutableTransaction for Upload {
         Some(self)
     }
 
-    fn transaction_type() -> Word {
-        TransactionRepr::Upload as Word
+    fn transaction_type() -> TransactionRepr {
+        TransactionRepr::Upload
+    }
+
+    fn executable_type(&self) -> ExecutableTxType {
+        ExecutableTxType::Upload(self)
     }
 }
 
@@ -603,8 +635,12 @@ impl ExecutableTransaction for Blob {
         Some(self)
     }
 
-    fn transaction_type() -> Word {
-        TransactionRepr::Blob as Word
+    fn transaction_type() -> TransactionRepr {
+        TransactionRepr::Blob
+    }
+
+    fn executable_type(&self) -> ExecutableTxType {
+        ExecutableTxType::Blob(self)
     }
 }
 

--- a/fuel-vm/src/interpreter/metadata.rs
+++ b/fuel-vm/src/interpreter/metadata.rs
@@ -21,18 +21,29 @@ use fuel_asm::{
 };
 use fuel_tx::{
     field::{
+        BlobId,
+        BytecodeRoot,
         BytecodeWitnessIndex,
+        ProofSet,
         Salt,
         Script as ScriptField,
         ScriptData,
         ScriptGasLimit,
         StorageSlots,
+        SubsectionIndex,
+        SubsectionsNumber,
     },
     policies::PolicyType,
+    Blob,
+    Create,
     Input,
     InputRepr,
     Output,
     OutputRepr,
+    Script,
+    TransactionRepr,
+    Upgrade,
+    Upload,
     UtxoId,
 };
 use fuel_types::{
@@ -145,6 +156,7 @@ struct GTFInput<'vm, Tx> {
 }
 
 impl<Tx> GTFInput<'_, Tx> {
+    #[allow(deprecated)]
     pub(crate) fn get_transaction_field(
         self,
         result: &mut Word,
@@ -193,29 +205,31 @@ impl<Tx> GTFInput<'_, Tx> {
                 .policies()
                 .get(PolicyType::MaxFee)
                 .ok_or(PanicReason::PolicyIsNotSet)?,
-            GTFArgs::ScriptInputsCount | GTFArgs::CreateInputsCount => {
-                tx.inputs().len() as Word
-            }
-            GTFArgs::ScriptOutputsCount | GTFArgs::CreateOutputsCount => {
-                tx.outputs().len() as Word
-            }
-            GTFArgs::ScriptWitnessesCount | GTFArgs::CreateWitnessesCount => {
-                tx.witnesses().len() as Word
-            }
-            GTFArgs::ScriptInputAtIndex | GTFArgs::CreateInputAtIndex => ofs
+            GTFArgs::ScriptInputsCount
+            | GTFArgs::CreateInputsCount
+            | GTFArgs::TxInputsCount => tx.inputs().len() as Word,
+            GTFArgs::ScriptOutputsCount
+            | GTFArgs::CreateOutputsCount
+            | GTFArgs::TxOutputsCount => tx.outputs().len() as Word,
+            GTFArgs::ScriptWitnessesCount
+            | GTFArgs::CreateWitnessesCount
+            | GTFArgs::TxWitnessesCount => tx.witnesses().len() as Word,
+            GTFArgs::ScriptInputAtIndex
+            | GTFArgs::CreateInputAtIndex
+            | GTFArgs::TxInputAtIndex => ofs
                 .saturating_add(tx.inputs_offset_at(b).ok_or(PanicReason::InputNotFound)?)
                 as Word,
-            GTFArgs::ScriptOutputAtIndex | GTFArgs::CreateOutputAtIndex => {
-                ofs.saturating_add(
-                    tx.outputs_offset_at(b).ok_or(PanicReason::OutputNotFound)?,
-                ) as Word
-            }
-            GTFArgs::ScriptWitnessAtIndex | GTFArgs::CreateWitnessAtIndex => {
-                ofs.saturating_add(
-                    tx.witnesses_offset_at(b)
-                        .ok_or(PanicReason::WitnessNotFound)?,
-                ) as Word
-            }
+            GTFArgs::ScriptOutputAtIndex
+            | GTFArgs::CreateOutputAtIndex
+            | GTFArgs::TxOutputAtIndex => ofs.saturating_add(
+                tx.outputs_offset_at(b).ok_or(PanicReason::OutputNotFound)?,
+            ) as Word,
+            GTFArgs::ScriptWitnessAtIndex
+            | GTFArgs::CreateWitnessAtIndex
+            | GTFArgs::TxWitnessAtIndex => ofs.saturating_add(
+                tx.witnesses_offset_at(b)
+                    .ok_or(PanicReason::WitnessNotFound)?,
+            ) as Word,
             GTFArgs::TxLength => self.tx_size,
 
             // Input
@@ -520,40 +534,82 @@ impl<Tx> GTFInput<'_, Tx> {
             // If it is not any above commands, it is something specific to the
             // transaction type.
             specific_args => {
-                let as_script = tx.as_script();
-                let as_create = tx.as_create();
-                match (as_script, as_create, specific_args) {
+                let tx_type = ExecutableTxType::from_executable(tx)?;
+
+                match (tx_type, specific_args) {
                     // Script
-                    (Some(script), None, GTFArgs::ScriptLength) => {
+                    (ExecutableTxType::Script(script), GTFArgs::ScriptLength) => {
                         script.script().len() as Word
                     }
-                    (Some(script), None, GTFArgs::ScriptDataLength) => {
+                    (ExecutableTxType::Script(script), GTFArgs::ScriptDataLength) => {
                         script.script_data().len() as Word
                     }
-                    (Some(script), None, GTFArgs::Script) => {
+                    (ExecutableTxType::Script(script), GTFArgs::Script) => {
                         ofs.saturating_add(script.script_offset()) as Word
                     }
-                    (Some(script), None, GTFArgs::ScriptData) => {
+                    (ExecutableTxType::Script(script), GTFArgs::ScriptData) => {
                         ofs.saturating_add(script.script_data_offset()) as Word
                     }
 
                     // Create
-                    (None, Some(create), GTFArgs::CreateBytecodeWitnessIndex) => {
-                        *create.bytecode_witness_index() as Word
-                    }
-                    (None, Some(create), GTFArgs::CreateStorageSlotsCount) => {
-                        create.storage_slots().len() as Word
-                    }
-                    (None, Some(create), GTFArgs::CreateSalt) => {
+                    (
+                        ExecutableTxType::Create(create),
+                        GTFArgs::CreateBytecodeWitnessIndex,
+                    ) => *create.bytecode_witness_index() as Word,
+                    (
+                        ExecutableTxType::Create(create),
+                        GTFArgs::CreateStorageSlotsCount,
+                    ) => create.storage_slots().len() as Word,
+                    (ExecutableTxType::Create(create), GTFArgs::CreateSalt) => {
                         ofs.saturating_add(create.salt_offset()) as Word
                     }
-                    (None, Some(create), GTFArgs::CreateStorageSlotAtIndex) => {
-                        // TODO: Maybe we need to return panic error
-                        // `StorageSlotsNotFound`?
+                    (
+                        ExecutableTxType::Create(create),
+                        GTFArgs::CreateStorageSlotAtIndex,
+                    ) => {
                         (ofs.saturating_add(
-                            create.storage_slots_offset_at(b).unwrap_or_default(),
+                            create
+                                .storage_slots_offset_at(b)
+                                .ok_or(PanicReason::StorageSlotsNotFound)?,
                         )) as Word
                     }
+
+                    // Blob
+                    (ExecutableTxType::Blob(blob), GTFArgs::BlobId) => {
+                        ofs.saturating_add(blob.blob_id_offset()) as Word
+                    }
+                    (ExecutableTxType::Blob(blob), GTFArgs::BlobWitnessIndex) => {
+                        *blob.bytecode_witness_index() as Word
+                    }
+
+                    // Upload
+                    (ExecutableTxType::Upload(upload), GTFArgs::UploadRoot) => {
+                        ofs.saturating_add(upload.bytecode_root_offset()) as Word
+                    }
+                    (ExecutableTxType::Upload(upload), GTFArgs::UploadWitnessIndex) => {
+                        *upload.bytecode_witness_index() as Word
+                    }
+                    (
+                        ExecutableTxType::Upload(upload),
+                        GTFArgs::UploadSubsectionIndex,
+                    ) => *upload.subsection_index() as Word,
+                    (
+                        ExecutableTxType::Upload(upload),
+                        GTFArgs::UploadSubsectionsCount,
+                    ) => *upload.subsections_number() as Word,
+                    (ExecutableTxType::Upload(upload), GTFArgs::UploadProofSetCount) => {
+                        upload.proof_set().len() as Word
+                    }
+                    (
+                        ExecutableTxType::Upload(upload),
+                        GTFArgs::UploadProofSetAtIndex,
+                    ) => ofs.saturating_add(
+                        upload
+                            .proof_set_offset_at(b)
+                            .ok_or(PanicReason::ProofInUploadNotFound)?,
+                    ) as Word,
+
+                    // Upgrade
                     _ => return Err(PanicReason::InvalidMetadataIdentifier.into()),
                 }
             }
@@ -563,5 +619,45 @@ impl<Tx> GTFInput<'_, Tx> {
 
         inc_pc(self.pc)?;
         Ok(())
+    }
+}
+
+/// Internal enum to be able to match on the transaction type of an executable
+/// transaction.
+enum ExecutableTxType<'a> {
+    Script(&'a Script),
+    Create(&'a Create),
+    Blob(&'a Blob),
+    Upgrade(&'a Upgrade),
+    Upload(&'a Upload),
+}
+
+impl<'a> ExecutableTxType<'a> {
+    /// Converts a transaction that implements `ExecutableTransaction` into an
+    /// `ExecutableTxType`.
+    fn from_executable<Tx>(tx: &'a Tx) -> Result<Self, PanicReason>
+    where
+        Tx: ExecutableTransaction,
+    {
+        let tx_type: TransactionRepr =
+            <Tx as ExecutableTransaction>::transaction_type().try_into()?;
+        match tx_type {
+            TransactionRepr::Script => Ok(ExecutableTxType::Script(
+                tx.as_script().ok_or(PanicReason::InvalidTransactionType)?,
+            )),
+            TransactionRepr::Create => Ok(ExecutableTxType::Create(
+                tx.as_create().ok_or(PanicReason::InvalidTransactionType)?,
+            )),
+            TransactionRepr::Blob => Ok(ExecutableTxType::Blob(
+                tx.as_blob().ok_or(PanicReason::InvalidTransactionType)?,
+            )),
+            TransactionRepr::Upgrade => Ok(ExecutableTxType::Upgrade(
+                tx.as_upgrade().ok_or(PanicReason::InvalidTransactionType)?,
+            )),
+            TransactionRepr::Upload => Ok(ExecutableTxType::Upload(
+                tx.as_upload().ok_or(PanicReason::InvalidTransactionType)?,
+            )),
+            TransactionRepr::Mint => Err(PanicReason::InvalidTransactionType),
+        }
     }
 }

--- a/fuel-vm/src/interpreter/metadata.rs
+++ b/fuel-vm/src/interpreter/metadata.rs
@@ -32,6 +32,7 @@ use fuel_tx::{
         StorageSlots,
         SubsectionIndex,
         SubsectionsNumber,
+        UpgradePurpose,
     },
     policies::PolicyType,
     Blob,
@@ -610,6 +611,10 @@ impl<Tx> GTFInput<'_, Tx> {
                     ) as Word,
 
                     // Upgrade
+                    (ExecutableTxType::Upgrade(upgrade), GTFArgs::UpgradePurpose) => {
+                        ofs.saturating_add(upgrade.upgrade_purpose_offset()) as Word
+                    }
+
                     _ => return Err(PanicReason::InvalidMetadataIdentifier.into()),
                 }
             }

--- a/fuel-vm/src/tests/metadata.rs
+++ b/fuel-vm/src/tests/metadata.rs
@@ -1096,17 +1096,15 @@ fn get__create_specific_transaction_fields__success() {
 
     predicate_code.extend(instructions_contract_id);
 
-    predicate_code.extend(
-        vec![
-            op::gtf_args(0x10, 0x00, GTFArgs::OutputContractCreatedContractId),
-            op::movi(0x12, 0x20),
-            // instructions_contract_id saved the value in a memory starting at value of
-            // `0x11`
-            op::meq(0x10, 0x10, 0x11, 0x12),
-            op::and(0x20, 0x20, 0x10),
-            op::ret(0x20),
-        ],
-    );
+    predicate_code.extend(vec![
+        op::gtf_args(0x10, 0x00, GTFArgs::OutputContractCreatedContractId),
+        op::movi(0x12, 0x20),
+        // instructions_contract_id saved the value in a memory starting at value of
+        // `0x11`
+        op::meq(0x10, 0x10, 0x11, 0x12),
+        op::and(0x20, 0x20, 0x10),
+        op::ret(0x20),
+    ]);
 
     let predicate_code = predicate_code.into_iter().collect();
 
@@ -1157,8 +1155,7 @@ fn get__upload_specific_transaction_fields__success() {
     let mut client = MemoryClient::default();
 
     // Given
-    let subsection =
-        UploadSubsection::split_bytecode(&[1; 10], 1).unwrap()[0].clone();
+    let subsection = UploadSubsection::split_bytecode(&[1; 10], 1).unwrap()[0].clone();
     let mut tx = TransactionBuilder::upload(UploadBody {
         root: subsection.root,
         witness_index: 0,
@@ -1170,39 +1167,35 @@ fn get__upload_specific_transaction_fields__success() {
     tx.add_fee_input();
 
     let instructions_root = alloc_bytearray(0x11, subsection.root.into());
-    let instructions_proof =
-        alloc_bytearray(0x11, subsection.proof_set[1].into());
+    let instructions_proof = alloc_bytearray(0x11, subsection.proof_set[1].into());
     // When
     #[rustfmt::skip]
     let mut predicate_code = vec![
         op::gtf_args(0x10, 0x00, GTFArgs::UploadRoot),
     ];
     predicate_code.extend(instructions_root);
-    predicate_code.extend(
-        vec![
-            op::meq(0x20, 0x10, 0x11, 0x20),
-            op::gtf_args(0x10, 0x00, GTFArgs::UploadWitnessIndex),
-            op::movi(0x11, 0x00),
-            op::eq(0x10, 0x10, 0x11),
-            op::and(0x20, 0x20, 0x10),
-            op::gtf_args(0x10, 0x00, GTFArgs::UploadSubsectionIndex),
-            op::movi(0x11, subsection.subsection_index as u32),
-            op::eq(0x10, 0x10, 0x11),
-            op::and(0x20, 0x20, 0x10),
-            op::gtf_args(0x10, 0x00, GTFArgs::UploadSubsectionsCount),
-            op::movi(0x11, subsection.subsections_number as u32),
-            op::eq(0x10, 0x10, 0x11),
-            op::and(0x20, 0x20, 0x10),
-            op::gtf_args(0x10, 0x00, GTFArgs::UploadProofSetCount),
-            op::movi(0x11, subsection.proof_set.len() as u32),
-            op::eq(0x10, 0x10, 0x11),
-            op::and(0x20, 0x20, 0x10),
-            op::gtf_args(0x10, 0x01, GTFArgs::UploadProofSetAtIndex),
-        ],
-    );
+    predicate_code.extend(vec![
+        op::meq(0x20, 0x10, 0x11, 0x20),
+        op::gtf_args(0x10, 0x00, GTFArgs::UploadWitnessIndex),
+        op::movi(0x11, 0x00),
+        op::eq(0x10, 0x10, 0x11),
+        op::and(0x20, 0x20, 0x10),
+        op::gtf_args(0x10, 0x00, GTFArgs::UploadSubsectionIndex),
+        op::movi(0x11, subsection.subsection_index as u32),
+        op::eq(0x10, 0x10, 0x11),
+        op::and(0x20, 0x20, 0x10),
+        op::gtf_args(0x10, 0x00, GTFArgs::UploadSubsectionsCount),
+        op::movi(0x11, subsection.subsections_number as u32),
+        op::eq(0x10, 0x10, 0x11),
+        op::and(0x20, 0x20, 0x10),
+        op::gtf_args(0x10, 0x00, GTFArgs::UploadProofSetCount),
+        op::movi(0x11, subsection.proof_set.len() as u32),
+        op::eq(0x10, 0x10, 0x11),
+        op::and(0x20, 0x20, 0x10),
+        op::gtf_args(0x10, 0x01, GTFArgs::UploadProofSetAtIndex),
+    ]);
     predicate_code.extend(instructions_proof);
-    predicate_code
-        .extend(vec![op::meq(0x20, 0x10, 0x11, 0x20), op::ret(0x20)]);
+    predicate_code.extend(vec![op::meq(0x20, 0x10, 0x11, 0x20), op::ret(0x20)]);
 
     let predicate_code = predicate_code.into_iter().collect();
 
@@ -1268,16 +1261,14 @@ fn get__blob_specific_transaction_fields__success() {
         op::gtf_args(0x10, 0x00, GTFArgs::BlobId),
     ];
     predicate_code.extend(blob_instructions);
-    predicate_code.extend(
-        vec![
-            op::meq(0x20, 0x10, 0x11, 0x20),
-            op::gtf_args(0x10, 0x00, GTFArgs::BlobWitnessIndex),
-            op::movi(0x11, 0x00),
-            op::eq(0x10, 0x10, 0x11),
-            op::and(0x20, 0x20, 0x10),
-            op::ret(0x20),
-        ],
-    );
+    predicate_code.extend(vec![
+        op::meq(0x20, 0x10, 0x11, 0x20),
+        op::gtf_args(0x10, 0x00, GTFArgs::BlobWitnessIndex),
+        op::movi(0x11, 0x00),
+        op::eq(0x10, 0x10, 0x11),
+        op::and(0x20, 0x20, 0x10),
+        op::ret(0x20),
+    ]);
 
     let predicate_code = predicate_code.into_iter().collect();
 
@@ -1353,8 +1344,7 @@ fn get__upgrade_specific_transaction_fields__success() {
         op::gtf_args(0x10, 0x00, GTFArgs::UpgradePurpose),
     ];
     predicate_code.extend(state_transition_instructions);
-    predicate_code
-        .extend(vec![op::meq(0x20, 0x10, 0x11, 0x20), op::ret(0x20)]);
+    predicate_code.extend(vec![op::meq(0x20, 0x10, 0x11, 0x20), op::ret(0x20)]);
 
     let predicate_code = predicate_code.into_iter().collect();
 

--- a/fuel-vm/src/tests/validation.rs
+++ b/fuel-vm/src/tests/validation.rs
@@ -136,6 +136,7 @@ fn transaction__execution__works_current_height_expiration() {
 }
 
 /// Malleable fields should not affect validity of the create transaction
+#[allow(deprecated)]
 #[test]
 fn malleable_fields_do_not_affect_validity_of_create() {
     let params = ConsensusParameters::default();


### PR DESCRIPTION
https://github.com/FuelLabs/fuel-vm/issues/812

Add new transactions specific `GTFArgs`, creates new `GTFArgs` to deprecate duplicated one between Script and Create and make them generic for all transactions implementing `ExecutableTransaction`.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
