### PR TITLE
[feature/jmt] Jmt: Integration of Storage traits with crate jmt

### DIFF
--- a/fuel-merkle/Cargo.toml
+++ b/fuel-merkle/Cargo.toml
@@ -11,13 +11,16 @@ repository = { workspace = true }
 description = "Fuel Merkle tree libraries."
 
 [dependencies]
+anyhow = { version = "1.0", default-features = false }
 derive_more = { version = "0.99", default-features = false, features = ["display"] }
 digest = { version = "0.10", default-features = false }
 fuel-storage = { workspace = true, default-features = false }
 hashbrown = "0.13"
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
+jmt = { version = "0.11.0" }
 serde = { version = "1.0", default-features = false, optional = true }
 sha2 = { version = "0.10", default-features = false }
+spin = { version = "0.9.8" }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/fuel-merkle/src/common/storage_map.rs
+++ b/fuel-merkle/src/common/storage_map.rs
@@ -44,6 +44,10 @@ where
     pub fn len(&self) -> usize {
         self.map.len()
     }
+
+    pub(crate) fn inner(&self) -> &HashMap<Type::OwnedKey, Type::OwnedValue> {
+        &self.map
+    }
 }
 
 impl<Type> StorageInspect<Type> for StorageMap<Type>

--- a/fuel-merkle/src/jellyfish.rs
+++ b/fuel-merkle/src/jellyfish.rs
@@ -1,0 +1,6 @@
+/// Integration of jmt::JellyfishMerkleTree with the Storage traits.
+pub mod jmt_integration;
+
+// Re-export dependencies from the jmt crate necessary for defining implementations
+// of the Mappable trait required by the JellyfishMerkleTree integration.
+pub use jmt;

--- a/fuel-merkle/src/jellyfish.rs
+++ b/fuel-merkle/src/jellyfish.rs
@@ -1,5 +1,18 @@
+/// In Memory implementation of a Jellyfish Merkle Tree.
+pub mod in_memory;
+
 /// Integration of jmt::JellyfishMerkleTree with the Storage traits.
 pub mod jmt_integration;
+
+/// StorageTrait backed Jellyfish Merkle Tree implementation
+pub mod merkle_tree;
+
+mod error;
+
+pub use error::MerkleTreeError;
+
+/// Inclusion and exclusion proofs for the Jellyfish Merkle Tree.
+pub mod proof;
 
 // Re-export dependencies from the jmt crate necessary for defining implementations
 // of the Mappable trait required by the JellyfishMerkleTree integration.

--- a/fuel-merkle/src/jellyfish/error.rs
+++ b/fuel-merkle/src/jellyfish/error.rs
@@ -1,0 +1,34 @@
+use crate::common::Bytes32;
+
+#[derive(Debug, derive_more::Display)]
+pub enum MerkleTreeError<StorageError> {
+    #[display(fmt = "{}", _0)]
+    StorageError(StorageError),
+    #[display(
+        fmt = "Error arising from the jmt::TreeReader trait implementation: {}",
+        _0
+    )]
+    TreeReaderError(anyhow::Error),
+    #[display(
+        fmt = "Error arising from the jmt::TreeWriter trait implementation: {}",
+        _0
+    )]
+    TreeWriterError(anyhow::Error),
+    #[display(
+        fmt = "Error arising from the jmt::HasPreimage trait implementation: {}",
+        _0
+    )]
+    HasPreimageError(anyhow::Error),
+    #[display(fmt = "Error propagated from the jmt crate: {}", _0)]
+    JmtError(anyhow::Error),
+    #[display(fmt = "The tree has no version")]
+    NoVersion,
+    #[display(fmt = "Expected root hash: {:?}, Actual root hash: {:?} ", _0, _1)]
+    RootHashMismatch(Bytes32, Bytes32),
+}
+
+impl<StorageError> From<StorageError> for MerkleTreeError<StorageError> {
+    fn from(err: StorageError) -> MerkleTreeError<StorageError> {
+        MerkleTreeError::StorageError(err)
+    }
+}

--- a/fuel-merkle/src/jellyfish/in_memory.rs
+++ b/fuel-merkle/src/jellyfish/in_memory.rs
@@ -1,0 +1,481 @@
+use core::convert::Infallible;
+
+use fuel_storage::{
+    StorageAsMut as _,
+    StorageAsRef,
+    StorageInspect,
+    StorageMutate,
+};
+
+use crate::jellyfish::merkle_tree::JellyfishMerkleTreeStorage;
+
+use jmt::storage::{
+    NibblePath,
+    Node as JmtNode,
+    NodeKey as JmtNodeKey,
+};
+
+use crate::{
+    common::{
+        Bytes32,
+        StorageMap,
+    },
+    sparse::MerkleTreeKey,
+    storage::Mappable,
+};
+
+use alloc::borrow::Cow;
+
+use super::MerkleTreeError;
+
+/// The table of the JellyFish Merkle Tree's nodes.
+#[derive(Debug, Clone)]
+pub struct NodesTable;
+
+impl Mappable for NodesTable {
+    type Key = Self::OwnedKey;
+    type OwnedKey = JmtNodeKey;
+    type OwnedValue = JmtNode;
+    type Value = Self::OwnedValue;
+}
+/// The table of the Binary Merkle Tree's values.
+#[derive(Debug, Clone)]
+pub struct ValuesTable;
+
+impl Mappable for ValuesTable {
+    type Key = Self::OwnedKey;
+    type OwnedKey = jmt::KeyHash;
+    type OwnedValue = (jmt::Version, jmt::OwnedValue);
+    type Value = Self::OwnedValue;
+}
+
+#[derive(Debug, Clone)]
+
+/// Auxiliary table that stores the latest version of the tree.
+pub struct LatestRootVersionTable;
+
+impl Mappable for LatestRootVersionTable {
+    type Key = Self::OwnedKey;
+    type OwnedKey = ();
+    type OwnedValue = jmt::Version;
+    type Value = Self::OwnedValue;
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct Storage {
+    pub nodes: StorageMap<NodesTable>,
+    pub values: StorageMap<ValuesTable>,
+    pub latest_root_version: Option<<LatestRootVersionTable as Mappable>::OwnedValue>,
+}
+
+impl StorageInspect<NodesTable> for Storage {
+    type Error = Infallible;
+
+    fn get(
+        &self,
+        key: &<NodesTable as Mappable>::Key,
+    ) -> Result<Option<Cow<<NodesTable as Mappable>::OwnedValue>>, Self::Error> {
+        self.nodes.storage::<NodesTable>().get(key)
+    }
+
+    fn contains_key(
+        &self,
+        key: &<NodesTable as Mappable>::Key,
+    ) -> Result<bool, Self::Error> {
+        self.nodes.storage::<NodesTable>().contains_key(key)
+    }
+}
+
+impl StorageInspect<ValuesTable> for Storage {
+    type Error = Infallible;
+
+    fn get(
+        &self,
+        key: &<ValuesTable as Mappable>::Key,
+    ) -> Result<Option<Cow<<ValuesTable as Mappable>::OwnedValue>>, Self::Error> {
+        self.values.storage::<ValuesTable>().get(key)
+    }
+
+    fn contains_key(
+        &self,
+        key: &<ValuesTable as Mappable>::Key,
+    ) -> Result<bool, Self::Error> {
+        self.values.storage::<ValuesTable>().contains_key(key)
+    }
+}
+
+impl StorageInspect<LatestRootVersionTable> for Storage {
+    type Error = Infallible;
+
+    fn get(
+        &self,
+        _key: &<LatestRootVersionTable as Mappable>::Key,
+    ) -> Result<Option<Cow<<LatestRootVersionTable as Mappable>::OwnedValue>>, Self::Error>
+    {
+        let latest_root_version = &self.latest_root_version;
+        if let Some(latest_root_version) = latest_root_version {
+            Ok(Some(Cow::Borrowed(latest_root_version)))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn contains_key(
+        &self,
+        _key: &<LatestRootVersionTable as Mappable>::Key,
+    ) -> Result<bool, Self::Error> {
+        Ok(self.latest_root_version.is_some())
+    }
+}
+
+impl StorageMutate<NodesTable> for Storage {
+    fn replace(
+        &mut self,
+        key: &<NodesTable as Mappable>::Key,
+        value: &<NodesTable as Mappable>::Value,
+    ) -> Result<Option<<NodesTable as Mappable>::OwnedValue>, Self::Error> {
+        self.nodes.storage_as_mut().replace(key, value)
+    }
+
+    fn take(
+        &mut self,
+        key: &<NodesTable as Mappable>::Key,
+    ) -> Result<Option<<NodesTable as Mappable>::OwnedValue>, Self::Error> {
+        self.nodes.storage_as_mut().take(key)
+    }
+}
+
+impl StorageMutate<ValuesTable> for Storage {
+    fn replace(
+        &mut self,
+        key: &<ValuesTable as Mappable>::Key,
+        value: &<ValuesTable as Mappable>::Value,
+    ) -> Result<Option<<ValuesTable as Mappable>::OwnedValue>, Self::Error> {
+        self.values.storage_as_mut().replace(key, value)
+    }
+
+    fn take(
+        &mut self,
+        key: &<ValuesTable as Mappable>::Key,
+    ) -> Result<Option<<ValuesTable as Mappable>::OwnedValue>, Self::Error> {
+        self.values.storage_as_mut().take(key)
+    }
+}
+
+impl StorageMutate<LatestRootVersionTable> for Storage {
+    fn replace(
+        &mut self,
+        _key: &<LatestRootVersionTable as Mappable>::Key,
+        value: &<LatestRootVersionTable as Mappable>::Value,
+    ) -> Result<Option<<LatestRootVersionTable as Mappable>::OwnedValue>, Self::Error>
+    {
+        let old_value = self.latest_root_version.take();
+        self.latest_root_version = Some(value.clone());
+        Ok(old_value)
+    }
+
+    fn take(
+        &mut self,
+        _key: &<LatestRootVersionTable as Mappable>::Key,
+    ) -> Result<Option<<LatestRootVersionTable as Mappable>::OwnedValue>, Self::Error>
+    {
+        Ok(self.latest_root_version.take())
+    }
+}
+
+#[derive(Clone)]
+pub struct MerkleTree {
+    storage: JellyfishMerkleTreeStorage<
+        NodesTable,
+        ValuesTable,
+        LatestRootVersionTable,
+        Storage,
+        Infallible,
+    >,
+}
+
+impl MerkleTree {
+    pub fn new() -> Result<Self, MerkleTreeError<Infallible>> {
+        let storage = Storage::default();
+        Ok(Self {
+            storage: JellyfishMerkleTreeStorage::new(storage)?,
+        })
+    }
+
+    /// Build a sparse Merkle tree from a set of key-value pairs. This is
+    /// equivalent to creating an empty sparse Merkle tree and sequentially
+    /// calling [update](Self::update) for each key-value pair. This constructor
+    /// is more performant than calling individual sequential updates and is the
+    /// preferred approach when the key-values are known upfront. Leaves can be
+    /// appended to the returned tree using `update` to further accumulate leaf
+    /// data.
+    pub fn from_set<I, D>(set: I) -> Self
+    where
+        I: Iterator<Item = (MerkleTreeKey, D)>,
+        D: AsRef<[u8]>,
+    {
+        let storage = Storage::default();
+        let storage = JellyfishMerkleTreeStorage::from_set(storage, set)
+            .expect("`Storage` can't return error");
+        Self { storage }
+    }
+
+    /// Calculate the sparse Merkle root from a set of key-value pairs. This is
+    /// similar to constructing a new tree from a set of key-value pairs using
+    /// [from_set](Self::from_set), except this method returns only the root; it
+    /// does not write to storage nor return a sparse Merkle tree instance. It
+    /// is equivalent to calling `from_set(..)`, followed by `root()`, but does
+    /// not incur the overhead of storage writes. This can be helpful when we
+    /// know all the key-values in the set upfront and we will not need to
+    /// update the set in the future.
+    pub fn root_from_set<I, D>(set: I) -> Result<Bytes32, MerkleTreeError<Infallible>>
+    where
+        I: Iterator<Item = (MerkleTreeKey, D)>,
+        D: AsRef<[u8]>,
+    {
+        let tree = Self::from_set(set);
+        tree.root()
+    }
+
+    pub fn nodes_from_set<I, D>(
+        set: I,
+    ) -> Result<(Bytes32, Vec<(NibblePath, JmtNode)>), MerkleTreeError<Infallible>>
+    where
+        I: Iterator<Item = (MerkleTreeKey, D)>,
+        D: AsRef<[u8]>,
+    {
+        let tree = Self::from_set(set);
+        let root = tree.root()?;
+        let storage_read_guard = tree.storage.storage_read();
+        let nodes = storage_read_guard
+            .nodes
+            .inner()
+            .iter()
+            .map(|(k, v)| (k.nibble_path().clone(), v.clone()))
+            .collect();
+        Ok((root, nodes))
+    }
+
+    pub fn update(&mut self, key: MerkleTreeKey, data: &[u8]) {
+        let _ = self.storage.update(key, data);
+    }
+
+    pub fn delete(&mut self, key: MerkleTreeKey) {
+        let _ = self.storage.delete(key);
+    }
+
+    pub fn root(&self) -> Result<Bytes32, MerkleTreeError<Infallible>> {
+        self.storage.root()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        jellyfish::{
+            merkle_tree::EMPTY_ROOT,
+            proof::{
+                InclusionProof,
+                MerkleProof,
+            },
+        },
+        sparse::MerkleTreeKey,
+    };
+    use jmt::storage::LeafNode as JmtLeafNode;
+    use sha2::Sha256;
+
+    use super::*;
+
+    #[test]
+    fn root_returns_the_empty_root_for_0_leaves() {
+        let tree = MerkleTree::new().unwrap();
+
+        let root = tree.root().unwrap();
+        assert_eq!(root, EMPTY_ROOT);
+    }
+
+    #[test]
+    fn adding_key_value_pair_works() {
+        let mut tree = MerkleTree::new().unwrap();
+        let initial_storage_version =
+            tree.storage.storage_read().latest_root_version.unwrap();
+        let raw_key = b"key";
+        let merkle_tree_key = MerkleTreeKey::new(raw_key);
+        let data = b"data";
+        tree.update(merkle_tree_key, data);
+        let storage = tree.storage.storage_read();
+        let nodes = storage.nodes.inner();
+        let values = storage.values.inner();
+        // The version has been updated:
+        assert_eq!(
+            storage.latest_root_version.unwrap(),
+            initial_storage_version + 1
+        );
+        // The root has been updated:
+        assert_ne!(tree.root().unwrap(), EMPTY_ROOT);
+        // There is exactly one value in the tree
+        assert_eq!(values.len(), 1);
+        let leaves = nodes
+            .iter()
+            .filter_map(|(_node_key, node)| match node {
+                JmtNode::Leaf(leaf_node) => Some(leaf_node),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(leaves.len(), 1);
+        let leaf_node = leaves[0];
+        // The only node is a leaf
+
+        let value = values.iter().next().unwrap();
+        let (value_key_hash, (_version, preimage)) = value;
+        // The key_hash of the leaf node is the same as the key_hash of the value
+        assert_eq!(value_key_hash, &leaf_node.key_hash());
+        let preimage_value_hash = jmt::ValueHash::with::<Sha256>(preimage);
+        let expected_leaf_node =
+            JmtLeafNode::new(value_key_hash.clone(), preimage_value_hash);
+        assert_eq!(leaf_node, &expected_leaf_node);
+    }
+
+    #[test]
+    fn adding_and_removing_key_value_pair_gives_the_empty_root() {
+        let mut tree = MerkleTree::new().unwrap();
+        let raw_key = b"key";
+        let merkle_tree_key = MerkleTreeKey::new(raw_key);
+        let data = b"data";
+        tree.update(merkle_tree_key, data);
+        tree.delete(merkle_tree_key);
+        let first_root = tree.root().unwrap();
+        assert_eq!(first_root, EMPTY_ROOT);
+        tree.update(merkle_tree_key, data);
+        tree.delete(merkle_tree_key);
+        let second_root = tree.root().unwrap();
+        assert_eq!(second_root, EMPTY_ROOT);
+    }
+
+    #[test]
+    fn updating_key_with_same_value_does_not_change_root() {
+        let mut tree = MerkleTree::new().unwrap();
+        let raw_key = b"key";
+        let merkle_tree_key = MerkleTreeKey::new(raw_key);
+        let data = b"data";
+        tree.update(merkle_tree_key, data);
+        let first_root = tree.root().unwrap();
+        tree.update(merkle_tree_key, data);
+        let second_root = tree.root().unwrap();
+        assert_eq!(first_root, second_root);
+    }
+
+    #[test]
+    fn updating_same_key_changes_root() {
+        let mut tree = MerkleTree::new().unwrap();
+        let raw_key = b"key";
+        let merkle_tree_key = MerkleTreeKey::new(raw_key);
+        let data1 = b"data1";
+        let data2 = b"data2";
+        tree.update(merkle_tree_key, data1);
+        let first_root = tree.root().unwrap();
+        tree.update(merkle_tree_key, data2);
+        let second_root = tree.root().unwrap();
+        assert_ne!(first_root, second_root);
+    }
+
+    #[test]
+    fn verify_exclusion_proof_for_empty_tree_succeeds() {
+        let tree = MerkleTree::new().unwrap();
+        let raw_key = b"key";
+        let merkle_tree_key = MerkleTreeKey::new(raw_key);
+        let proof = tree.storage.generate_proof(&merkle_tree_key).unwrap();
+        assert!(proof.is_exclusion_proof());
+        assert!(proof.verify(EMPTY_ROOT));
+    }
+
+    #[test]
+    fn verify_inclusion_proof_succeeds() {
+        let mut tree = MerkleTree::new().unwrap();
+        let raw_key = b"key";
+        let merkle_tree_key = MerkleTreeKey::new(raw_key);
+        let data = b"data";
+        tree.update(merkle_tree_key, data);
+        let root = tree.root().unwrap();
+        let proof = tree.storage.generate_proof(&merkle_tree_key).unwrap();
+        assert!(proof.is_inclusion_proof());
+        assert!(proof.verify(root));
+    }
+
+    #[test]
+    fn verify_inclusion_on_empty_tree_fails() {
+        let mut tree = MerkleTree::new().unwrap();
+        let raw_key = b"key";
+        let merkle_tree_key = MerkleTreeKey::new(raw_key);
+        let data = b"data";
+        tree.update(merkle_tree_key, data);
+        let proof = tree.storage.generate_proof(&merkle_tree_key).unwrap();
+        assert!(proof.is_inclusion_proof());
+
+        let empty_tree = MerkleTree::new().unwrap();
+        let empty_root = empty_tree.root().unwrap();
+        assert!(!proof.verify(empty_root));
+    }
+
+    #[test]
+    fn verify_wrong_value_for_key_fails() {
+        let mut tree = MerkleTree::new().unwrap();
+        let raw_key = b"key";
+        let merkle_tree_key = MerkleTreeKey::new(raw_key);
+        let data = b"data";
+        tree.update(merkle_tree_key, data);
+        let root = tree.root().unwrap();
+        let proof = tree.storage.generate_proof(&merkle_tree_key).unwrap();
+        assert!(proof.is_inclusion_proof());
+        let tampered_proof = match proof {
+            MerkleProof::Inclusion(inclusion_proof) => {
+                MerkleProof::Inclusion(InclusionProof {
+                    value: b"Wrong value".to_vec(),
+                    ..inclusion_proof
+                })
+            }
+            MerkleProof::Exclusion(_exclusion_proof) => {
+                panic!("It's an inclusion proof")
+            }
+        };
+        assert!(!tampered_proof.verify(root));
+    }
+
+    #[test]
+    fn verify_multiple_updates() {
+        let num_updates = 1000;
+        let mut tree = MerkleTree::new().unwrap();
+        let updates: Vec<_> = (0..num_updates)
+            .map(|i| {
+                let raw_key = format!("key{}", i);
+                let raw_key = raw_key.as_bytes();
+                let merkle_tree_key = MerkleTreeKey::new(raw_key);
+
+                let data = format!("data{}", i);
+                (merkle_tree_key, data)
+            })
+            .collect();
+        for (key, value) in updates.iter() {
+            tree.update(*key, value.as_bytes());
+        }
+        let root = tree.root().unwrap();
+        for (key, _value) in updates {
+            let proof = tree.storage.generate_proof(&key).unwrap();
+            assert!(proof.is_inclusion_proof());
+            assert!(proof.verify(root));
+        }
+        // Generate proof for several non-existing nodes
+        let non_existing_keys: Vec<_> = (0..num_updates)
+            .map(|i| {
+                let raw_key = format!("non-existing-key{}", i);
+                let raw_key = raw_key.as_bytes();
+                MerkleTreeKey::new(raw_key)
+            })
+            .collect();
+        for key in non_existing_keys {
+            let proof = tree.storage.generate_proof(&key).unwrap();
+            assert!(proof.is_exclusion_proof());
+            assert!(proof.verify(root));
+        }
+    }
+}

--- a/fuel-merkle/src/jellyfish/jmt_integration.rs
+++ b/fuel-merkle/src/jellyfish/jmt_integration.rs
@@ -1,15 +1,10 @@
-use core::marker::PhantomData;
-
 use crate::storage::{
     Mappable,
     StorageInspect,
     StorageMutate,
 };
 
-use alloc::{
-    sync::Arc,
-    vec::Vec,
-};
+use alloc::vec::Vec;
 
 use jmt::storage::{
     HasPreimage,
@@ -20,52 +15,8 @@ use jmt::storage::{
     TreeReader,
     TreeWriter,
 };
-use spin::{
-    RwLock,
-    RwLockReadGuard,
-    RwLockWriteGuard,
-};
 
-#[derive(Debug, Clone)]
-pub struct JellyfishMerkleTreeStorage<
-    NodeTableType,
-    ValueTableType,
-    LatestRootVersionTableType,
-    StorageType,
-    StorageError,
-> {
-    inner: Arc<RwLock<StorageType>>,
-    phantom_table: PhantomData<(
-        NodeTableType,
-        ValueTableType,
-        LatestRootVersionTableType,
-        StorageError,
-    )>,
-}
-
-impl<
-        NodeTableType,
-        ValueTableType,
-        LatestRootVersionTableType,
-        StorageType,
-        StorageError,
-    >
-    JellyfishMerkleTreeStorage<
-        NodeTableType,
-        ValueTableType,
-        LatestRootVersionTableType,
-        StorageType,
-        StorageError,
-    >
-{
-    pub fn storage_read(&self) -> RwLockReadGuard<StorageType> {
-        self.inner.read()
-    }
-
-    pub fn storage_write(&self) -> RwLockWriteGuard<StorageType> {
-        self.inner.write()
-    }
-}
+use super::merkle_tree::JellyfishMerkleTreeStorage;
 
 impl<
         NodeTableType,

--- a/fuel-merkle/src/jellyfish/jmt_integration.rs
+++ b/fuel-merkle/src/jellyfish/jmt_integration.rs
@@ -1,0 +1,245 @@
+use core::marker::PhantomData;
+
+use crate::storage::{
+    Mappable,
+    StorageInspect,
+    StorageMutate,
+};
+
+use alloc::{
+    sync::Arc,
+    vec::Vec,
+};
+
+use jmt::storage::{
+    HasPreimage,
+    LeafNode as JmtLeafNode,
+    Node as JmtNode,
+    NodeBatch as JmtNodeBatch,
+    NodeKey as JmtNodeKey,
+    TreeReader,
+    TreeWriter,
+};
+use spin::{
+    RwLock,
+    RwLockReadGuard,
+    RwLockWriteGuard,
+};
+
+#[derive(Debug, Clone)]
+pub struct JellyfishMerkleTreeStorage<
+    NodeTableType,
+    ValueTableType,
+    LatestRootVersionTableType,
+    StorageType,
+    StorageError,
+> {
+    inner: Arc<RwLock<StorageType>>,
+    phantom_table: PhantomData<(
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageError,
+    )>,
+}
+
+impl<
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageType,
+        StorageError,
+    >
+    JellyfishMerkleTreeStorage<
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageType,
+        StorageError,
+    >
+{
+    pub fn storage_read(&self) -> RwLockReadGuard<StorageType> {
+        self.inner.read()
+    }
+
+    pub fn storage_write(&self) -> RwLockWriteGuard<StorageType> {
+        self.inner.write()
+    }
+}
+
+impl<
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageType,
+        StorageError,
+    > TreeWriter
+    for JellyfishMerkleTreeStorage<
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageType,
+        StorageError,
+    >
+where
+    NodeTableType: Mappable<Key = JmtNodeKey, Value = JmtNode, OwnedValue = JmtNode>,
+    ValueTableType: Mappable<
+        Key = jmt::KeyHash,
+        Value = (jmt::Version, jmt::OwnedValue),
+        OwnedValue = (jmt::Version, jmt::OwnedValue),
+    >,
+    LatestRootVersionTableType: Mappable<Key = (), Value = u64, OwnedValue = u64>,
+    StorageType: StorageMutate<NodeTableType, Error = StorageError>
+        + StorageMutate<ValueTableType, Error = StorageError>
+        + StorageMutate<LatestRootVersionTableType, Error = StorageError>,
+{
+    fn write_node_batch(&self, node_batch: &JmtNodeBatch) -> anyhow::Result<()> {
+        for (key, node) in node_batch.nodes() {
+            // TODO: Do we really need locks here?
+            let mut storage = self.storage_write();
+            <StorageType as StorageMutate<NodeTableType>>::insert(
+                &mut *storage,
+                key,
+                node,
+            )
+            .map_err(|_err| anyhow::anyhow!("Node table write Storage Error"))?;
+            if key.nibble_path().is_empty() {
+                // If the nibble path is empty, we are updating the root node.
+                // We must also update the latest root version
+                let newer_version = <StorageType as StorageInspect<
+                    LatestRootVersionTableType,
+                >>::get(&*storage, &())
+                .map_err(|_e| anyhow::anyhow!("Latest root version read storage error"))?
+                .map(|v| *v)
+                .filter(|v| *v >= key.version());
+                // To check: it should never be the case that this check fails
+                if newer_version.is_none() {
+                    StorageMutate::<LatestRootVersionTableType>::insert(
+                        &mut *storage,
+                        &(),
+                        &key.version(),
+                    )
+                    .map_err(|_e| {
+                        anyhow::anyhow!("Latest root version write storage error")
+                    })?;
+                }
+            }
+
+            for ((version, key_hash), value) in node_batch.values() {
+                match value {
+                    None => {
+                        let _old = <StorageType as StorageMutate<ValueTableType>>::take(
+                            &mut *storage,
+                            key_hash,
+                        )
+                        .map_err(|_e| anyhow::anyhow!("Version Storage Error"))?;
+                    }
+                    Some(value) => {
+                        let _old =
+                            <StorageType as StorageMutate<ValueTableType>>::replace(
+                                &mut *storage,
+                                key_hash,
+                                &(*version, value.clone()),
+                            )
+                            .map_err(|_e| anyhow::anyhow!("Version Storage Error"))?;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageType,
+        StorageError,
+    > TreeReader
+    for JellyfishMerkleTreeStorage<
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageType,
+        StorageError,
+    >
+where
+    NodeTableType: Mappable<Key = JmtNodeKey, Value = JmtNode, OwnedValue = JmtNode>,
+    ValueTableType: Mappable<
+        Key = jmt::KeyHash,
+        Value = (jmt::Version, jmt::OwnedValue),
+        OwnedValue = (jmt::Version, jmt::OwnedValue),
+    >,
+    StorageType: StorageInspect<NodeTableType, Error = StorageError>
+        + StorageInspect<ValueTableType, Error = StorageError>,
+{
+    fn get_node_option(&self, node_key: &JmtNodeKey) -> anyhow::Result<Option<JmtNode>> {
+        let storage = self.storage_read();
+        let get_result =
+            <StorageType as StorageInspect<NodeTableType>>::get(&*storage, node_key)
+                .map_err(|_e| anyhow::anyhow!("Storage Error"))?;
+        let node = get_result.map(|node| node.into_owned());
+
+        Ok(node)
+    }
+
+    fn get_value_option(
+        &self,
+        max_version: jmt::Version,
+        key_hash: jmt::KeyHash,
+    ) -> anyhow::Result<Option<jmt::OwnedValue>> {
+        let storage = self.storage_read();
+        let Some(value) =
+            <StorageType as StorageInspect<ValueTableType>>::get(&*storage, &key_hash)
+                .map_err(|_e| anyhow::anyhow!("Version Storage Error"))?
+                .filter(|v| v.0 <= max_version)
+                .map(|v| v.into_owned().1)
+        else {
+            return Ok(None)
+        };
+        // Retrieve current version of key
+
+        return Ok(Some(value))
+    }
+
+    fn get_rightmost_leaf(&self) -> anyhow::Result<Option<(JmtNodeKey, JmtLeafNode)>> {
+        unimplemented!(
+            "Righmost leaf is used only when restoring the tree, which we do not support"
+        )
+    }
+}
+
+impl<
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageType,
+        StorageError,
+    > HasPreimage
+    for JellyfishMerkleTreeStorage<
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageType,
+        StorageError,
+    >
+where
+    ValueTableType: Mappable<
+        Key = jmt::KeyHash,
+        Value = (jmt::Version, jmt::OwnedValue),
+        OwnedValue = (jmt::Version, jmt::OwnedValue),
+    >,
+    StorageType: StorageInspect<ValueTableType, Error = StorageError>,
+{
+    fn preimage(&self, key_hash: jmt::KeyHash) -> anyhow::Result<Option<Vec<u8>>> {
+        let storage = self.storage_read();
+        let preimage =
+            <StorageType as StorageInspect<ValueTableType>>::get(&*storage, &key_hash)
+                .map_err(|_e| anyhow::anyhow!("Preimage storage error"))?
+                .map(|v| v.into_owned().1);
+
+        Ok(preimage)
+    }
+}

--- a/fuel-merkle/src/jellyfish/merkle_tree.rs
+++ b/fuel-merkle/src/jellyfish/merkle_tree.rs
@@ -1,0 +1,377 @@
+use crate::{
+    common::Bytes32,
+    sparse::MerkleTreeKey,
+    storage::{
+        Mappable,
+        StorageInspect,
+        StorageMutate,
+    },
+};
+
+use alloc::sync::Arc;
+use core::marker::PhantomData;
+use spin::{
+    rwlock::RwLock,
+    RwLockReadGuard,
+    RwLockWriteGuard,
+};
+
+use jmt::{
+    storage::{
+        Node as JmtNode,
+        NodeKey as JmtNodeKey,
+        TreeWriter,
+    },
+    JellyfishMerkleTree,
+    Sha256Jmt,
+};
+
+use crate::jellyfish::proof::{
+    ExclusionProof,
+    InclusionProof,
+    MerkleProof,
+};
+
+use crate::jellyfish::error::MerkleTreeError;
+
+// Obtained by creating an empty tree.
+pub const EMPTY_ROOT: Bytes32 = [
+    83, 80, 65, 82, 83, 69, 95, 77, 69, 82, 75, 76, 69, 95, 80, 76, 65, 67, 69, 72, 79,
+    76, 68, 69, 82, 95, 72, 65, 83, 72, 95, 95,
+];
+
+#[derive(Debug, Clone)]
+pub struct JellyfishMerkleTreeStorage<
+    NodeTableType,
+    ValueTableType,
+    LatestRootVersionTableType,
+    StorageType,
+    StorageError,
+> {
+    inner: Arc<RwLock<StorageType>>,
+    phantom_table: PhantomData<(
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageError,
+    )>,
+}
+
+impl<
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageType,
+        StorageError,
+    >
+    JellyfishMerkleTreeStorage<
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageType,
+        StorageError,
+    >
+{
+    pub const fn empty_root() -> &'static Bytes32 {
+        &EMPTY_ROOT
+    }
+
+    pub fn storage_read(&self) -> RwLockReadGuard<StorageType> {
+        self.inner.read()
+    }
+
+    pub fn storage_write(&self) -> RwLockWriteGuard<StorageType> {
+        self.inner.write()
+    }
+}
+
+impl<
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageType,
+        StorageError,
+    >
+    JellyfishMerkleTreeStorage<
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageType,
+        StorageError,
+    >
+where
+    LatestRootVersionTableType: Mappable<Key = (), Value = u64, OwnedValue = u64>,
+    StorageType: StorageInspect<LatestRootVersionTableType, Error = StorageError>,
+{
+    fn get_latest_root_version(
+        &self,
+    ) -> Result<Option<u64>, MerkleTreeError<StorageType::Error>> {
+        let storage = self.storage_read();
+        let version = <StorageType as StorageInspect<LatestRootVersionTableType>>::get(
+            &*storage,
+            &(),
+        )?
+        .map(|v| *v);
+
+        Ok(version)
+    }
+}
+
+impl<
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageType,
+        StorageError,
+    >
+    JellyfishMerkleTreeStorage<
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageType,
+        StorageError,
+    >
+where
+    NodeTableType: Mappable<Key = JmtNodeKey, Value = JmtNode, OwnedValue = JmtNode>,
+    ValueTableType: Mappable<
+        Key = jmt::KeyHash,
+        Value = (jmt::Version, jmt::OwnedValue),
+        OwnedValue = (jmt::Version, jmt::OwnedValue),
+    >,
+    StorageType: StorageInspect<NodeTableType, Error = StorageError>
+        + StorageInspect<ValueTableType, Error = StorageError>,
+{
+    // Requires TreeReader + HasPreimage
+    // TreeReader requires StorageInspect<NodeTableType> and
+    // StorageInspect<ValueTableType> HasPreimage requires
+    // StorageInspect<ValueTableType>
+    fn as_jmt<'a>(&'a self) -> Sha256Jmt<'a, Self> {
+        JellyfishMerkleTree::new(&self)
+    }
+}
+
+impl<
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageType,
+        StorageError,
+    >
+    JellyfishMerkleTreeStorage<
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageType,
+        StorageError,
+    >
+where
+    NodeTableType: Mappable<Key = JmtNodeKey, Value = JmtNode, OwnedValue = JmtNode>,
+    ValueTableType: Mappable<
+        Key = jmt::KeyHash,
+        Value = (jmt::Version, jmt::OwnedValue),
+        OwnedValue = (jmt::Version, jmt::OwnedValue),
+    >,
+    LatestRootVersionTableType: Mappable<Key = (), Value = u64, OwnedValue = u64>,
+    StorageType: StorageInspect<NodeTableType, Error = StorageError>
+        + StorageInspect<ValueTableType, Error = StorageError>
+        + StorageInspect<LatestRootVersionTableType, Error = StorageError>,
+{
+    // get_latest_root_version() requires StorageInspect<LatestRootVersionTableType>
+    // as_jmt() requires TreeReader, which requires StorageInspect<NodeTableType> and
+    // StorageInspect<ValueTableType>. Therefore this function requires
+    // StorageInspect<LatestRootVersionTableType>, StorageInspect<NodeTableType>, and
+    // StorageInspect<ValueTableType>.
+    pub fn root(&self) -> Result<Bytes32, MerkleTreeError<StorageError>> {
+        // We need to know the version of the root node.
+        let version = self
+            .get_latest_root_version()?
+            .ok_or(MerkleTreeError::NoVersion)?;
+
+        self.as_jmt()
+            .get_root_hash(version)
+            .map_err(MerkleTreeError::JmtError)
+            .map(|root_hash| root_hash.0)
+    }
+
+    pub fn load(
+        storage: StorageType,
+        root: &Bytes32,
+    ) -> Result<Self, MerkleTreeError<StorageError>> {
+        let inner = Arc::new(RwLock::new(storage));
+        let merkle_tree = Self {
+            inner,
+            phantom_table: PhantomData,
+        };
+        // If the storage is not initialized, this function will fail.
+        // TODO: This should be tested.
+        let root_from_storage = merkle_tree.root()?;
+        //
+        if *root == root_from_storage {
+            Ok(merkle_tree)
+        } else {
+            Err(MerkleTreeError::RootHashMismatch(*root, root_from_storage))
+        }
+    }
+
+    pub fn generate_proof(
+        &self,
+        key: &MerkleTreeKey,
+    ) -> Result<MerkleProof, MerkleTreeError<StorageError>> {
+        let jmt = self.as_jmt();
+        let key_hash = jmt::KeyHash(**key);
+        let version = self
+            .get_latest_root_version()
+            .unwrap_or_default()
+            .unwrap_or_default();
+        let (value_vec, proof) = jmt
+            .get_with_proof(key_hash, version)
+            .map_err(MerkleTreeError::JmtError)?;
+        let proof = match value_vec {
+            Some(value) => MerkleProof::Inclusion(InclusionProof {
+                proof,
+                key: key_hash,
+                value,
+            }),
+            None => MerkleProof::Exclusion(ExclusionProof {
+                proof,
+                key: key_hash,
+            }),
+        };
+        Ok(proof)
+    }
+}
+
+impl<
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageType,
+        StorageError,
+    >
+    JellyfishMerkleTreeStorage<
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageType,
+        StorageError,
+    >
+where
+    NodeTableType: Mappable<Key = JmtNodeKey, Value = JmtNode, OwnedValue = JmtNode>,
+    ValueTableType: Mappable<
+        Key = jmt::KeyHash,
+        Value = (jmt::Version, jmt::OwnedValue),
+        OwnedValue = (jmt::Version, jmt::OwnedValue),
+    >,
+    LatestRootVersionTableType: Mappable<Key = (), Value = u64, OwnedValue = u64>,
+    StorageType: StorageMutate<NodeTableType, Error = StorageError>
+        + StorageMutate<ValueTableType, Error = StorageError>
+        + StorageMutate<LatestRootVersionTableType, Error = StorageError>,
+{
+    // Because we insert and remove a node, we need to have StorageType:
+    // StorageMutate<NodeTableType> + StorageMutate<ValueTableType> +
+    // StorageMutate<LatestRootVersionTableType>
+    pub fn new(storage: StorageType) -> Result<Self, MerkleTreeError<StorageError>> {
+        let inner = Arc::new(RwLock::new(storage));
+        // Set the initial version of the tree to 0
+        <StorageType as StorageMutate<LatestRootVersionTableType>>::insert(
+            &mut *inner.write(),
+            &(),
+            &0,
+        )?;
+        let mut tree = Self {
+            inner,
+            phantom_table: PhantomData,
+        };
+        // Inclusion and Exclusion proof require that the root is set, hence we add it
+        // here. Jmt does not make the constructor for `NibblePath` accessible, so
+        // we add and remove a node instead.
+        // TODO: Find a way to set the root without adding and deleting a node
+        let mock_key = MerkleTreeKey::new(Bytes32::default());
+        let mock_value = vec![0u8];
+        tree.update(mock_key, &mock_value)?;
+        tree.delete(mock_key)?;
+
+        Ok(tree)
+    }
+
+    pub fn from_set<B, I, D>(
+        storage: StorageType,
+        set: I,
+    ) -> Result<Self, MerkleTreeError<StorageError>>
+    where
+        I: Iterator<Item = (B, D)>,
+        B: Into<Bytes32>,
+        D: AsRef<[u8]>,
+    {
+        let tree = Self::new(storage)?;
+        let jmt = tree.as_jmt();
+        // We assume that we are constructing a new Merkle Tree.
+        // We start from version 2 to be consistent with the version obtained
+        // when returning a new tree.
+        // TODO: Change Self::new so that the initial version of a new tree is 0.
+        let version = 2;
+        let update_batch = set.map(|(key, data)| {
+            let key_hash = jmt::KeyHash(key.into());
+            // Sad, but jmt requires an owned value
+            // TODO: We should consider forking jmt to allow for borrowed values
+            let value = data.as_ref().to_vec();
+            (key_hash, Some(value))
+        });
+        // This writes the values into the tree cache. This function returns the tree
+        // updates that must be written into storage
+        let (_root_hash, updates) = jmt
+            .put_value_set(update_batch, version)
+            .map_err(MerkleTreeError::JmtError)?;
+        // TODO: Should we check the stale node indexes as well?
+        let node_updates = updates.node_batch;
+        <Self as TreeWriter>::write_node_batch(&tree, &node_updates)
+            .map_err(MerkleTreeError::TreeWriterError)?;
+
+        Ok(tree)
+    }
+
+    // TODO: We should have a corresponding function to batch udpates and increment the
+    // version only once
+    pub fn update(
+        &mut self,
+        key: MerkleTreeKey,
+        data: &[u8],
+    ) -> Result<(), MerkleTreeError<StorageError>> {
+        let key_hash = jmt::KeyHash(*key);
+        // If data.is_empty() we remove the value from the jmt
+        let value = if data.is_empty() {
+            None
+        } else {
+            Some(data.to_vec())
+        };
+        // TODO : We could update version once per block, but here we
+        // update version for each update operation.
+        let version = self
+            .get_latest_root_version()?
+            .ok_or(MerkleTreeError::NoVersion)?
+            .saturating_add(1);
+        let update_batch = [(key_hash, value); 1];
+        let (_root_hash, updates) = self
+            .as_jmt()
+            .put_value_set(update_batch, version)
+            .map_err(MerkleTreeError::JmtError)?;
+        // TODO: Figure out what to do with stale node indexes
+        let node_updates = updates.node_batch;
+        <Self as TreeWriter>::write_node_batch(&self, &node_updates)
+            .map_err(MerkleTreeError::TreeWriterError)?;
+        let stale_nodes = updates.stale_node_index_batch;
+        let mut storage_write_guard = self.storage_write();
+        for stale_node_index in stale_nodes {
+            let node_key = stale_node_index.node_key;
+            StorageMutate::<NodeTableType>::remove(&mut *storage_write_guard, &node_key)?;
+        }
+        return Ok(())
+    }
+
+    pub fn delete(
+        &mut self,
+        key: MerkleTreeKey,
+    ) -> Result<(), MerkleTreeError<StorageError>> {
+        self.update(key, &[])
+    }
+}

--- a/fuel-merkle/src/jellyfish/proof.rs
+++ b/fuel-merkle/src/jellyfish/proof.rs
@@ -1,0 +1,56 @@
+use jmt::proof::SparseMerkleProof;
+
+use crate::common::Bytes32;
+
+// Give crate access to fields for testing tampering with proofs
+pub struct InclusionProof {
+    pub(crate) proof: SparseMerkleProof<sha2::Sha256>,
+    pub(crate) key: jmt::KeyHash,
+    pub(crate) value: jmt::OwnedValue,
+}
+
+pub struct ExclusionProof {
+    pub(crate) proof: SparseMerkleProof<sha2::Sha256>,
+    pub(crate) key: jmt::KeyHash,
+}
+
+pub enum MerkleProof {
+    Inclusion(InclusionProof),
+    Exclusion(ExclusionProof),
+}
+
+impl MerkleProof {
+    pub fn verify(&self, root_hash: Bytes32) -> bool {
+        match self {
+            MerkleProof::Inclusion(inclusion_proof) => {
+                let root_hash = jmt::RootHash(root_hash);
+                let key = inclusion_proof.key;
+                let value = &inclusion_proof.value;
+                let proof = &inclusion_proof.proof;
+
+                proof.verify_existence(root_hash, key, value).is_ok()
+            }
+            MerkleProof::Exclusion(exclusion_proof) => {
+                let root_hash = jmt::RootHash(root_hash);
+                let key = exclusion_proof.key;
+                let proof = &exclusion_proof.proof;
+
+                proof.verify_nonexistence(root_hash, key).is_ok()
+            }
+        }
+    }
+
+    pub fn is_inclusion_proof(&self) -> bool {
+        match self {
+            MerkleProof::Inclusion(_) => true,
+            MerkleProof::Exclusion(_) => false,
+        }
+    }
+
+    pub fn is_exclusion_proof(&self) -> bool {
+        match self {
+            MerkleProof::Inclusion(_) => false,
+            MerkleProof::Exclusion(_) => true,
+        }
+    }
+}

--- a/fuel-merkle/src/lib.rs
+++ b/fuel-merkle/src/lib.rs
@@ -14,6 +14,7 @@ extern crate alloc;
 
 pub mod binary;
 pub mod common;
+pub mod jellyfish;
 pub mod sparse;
 pub mod storage;
 


### PR DESCRIPTION
In order to integrate Jellyfish Merkle Trees from the jmt crate, we must implement three traits from that crate: 
- [x] TreeReader - used to read and cache updates to the tree in memory
- [x] TreeWriter - used to flush updates from the tree cache into the underlying storage backend
- [x] HasPreimage - used for proof generation and verification. 

This PR connects the storage traits on the fuel-vm side with jmt crate as follows: 
- [x] It defines a data structure parametric in several types that require an implementation of Mappable each, 
- [x] It implements the three storage traits above for mappable 

Tests are provided in the last PR of the feature branch.

[Short description of the changes.]

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
