### PR TITLE
[feature/jmt (2/4) Implementation of functions to manipulate a Jmt

### DIFF
--- a/fuel-merkle/src/jellyfish.rs
+++ b/fuel-merkle/src/jellyfish.rs
@@ -1,6 +1,13 @@
 /// Integration of jmt::JellyfishMerkleTree with the Storage traits.
 pub mod jmt_integration;
 
+/// StorageTrait backed Jellyfish Merkle Tree implementation
+pub mod merkle_tree;
+
+mod error;
+
+pub use error::MerkleTreeError;
+
 // Re-export dependencies from the jmt crate necessary for defining implementations
 // of the Mappable trait required by the JellyfishMerkleTree integration.
 pub use jmt;

--- a/fuel-merkle/src/jellyfish/error.rs
+++ b/fuel-merkle/src/jellyfish/error.rs
@@ -1,0 +1,34 @@
+use crate::common::Bytes32;
+
+#[derive(Debug, derive_more::Display)]
+pub enum MerkleTreeError<StorageError> {
+    #[display(fmt = "{}", _0)]
+    StorageError(StorageError),
+    #[display(
+        fmt = "Error arising from the jmt::TreeReader trait implementation: {}",
+        _0
+    )]
+    TreeReaderError(anyhow::Error),
+    #[display(
+        fmt = "Error arising from the jmt::TreeWriter trait implementation: {}",
+        _0
+    )]
+    TreeWriterError(anyhow::Error),
+    #[display(
+        fmt = "Error arising from the jmt::HasPreimage trait implementation: {}",
+        _0
+    )]
+    HasPreimageError(anyhow::Error),
+    #[display(fmt = "Error propagated from the jmt crate: {}", _0)]
+    JmtError(anyhow::Error),
+    #[display(fmt = "The tree has no version")]
+    NoVersion,
+    #[display(fmt = "Expected root hash: {:?}, Actual root hash: {:?} ", _0, _1)]
+    RootHashMismatch(Bytes32, Bytes32),
+}
+
+impl<StorageError> From<StorageError> for MerkleTreeError<StorageError> {
+    fn from(err: StorageError) -> MerkleTreeError<StorageError> {
+        MerkleTreeError::StorageError(err)
+    }
+}

--- a/fuel-merkle/src/jellyfish/jmt_integration.rs
+++ b/fuel-merkle/src/jellyfish/jmt_integration.rs
@@ -1,15 +1,10 @@
-use core::marker::PhantomData;
-
 use crate::storage::{
     Mappable,
     StorageInspect,
     StorageMutate,
 };
 
-use alloc::{
-    sync::Arc,
-    vec::Vec,
-};
+use alloc::vec::Vec;
 
 use jmt::storage::{
     HasPreimage,
@@ -20,52 +15,8 @@ use jmt::storage::{
     TreeReader,
     TreeWriter,
 };
-use spin::{
-    RwLock,
-    RwLockReadGuard,
-    RwLockWriteGuard,
-};
 
-#[derive(Debug, Clone)]
-pub struct JellyfishMerkleTreeStorage<
-    NodeTableType,
-    ValueTableType,
-    LatestRootVersionTableType,
-    StorageType,
-    StorageError,
-> {
-    inner: Arc<RwLock<StorageType>>,
-    phantom_table: PhantomData<(
-        NodeTableType,
-        ValueTableType,
-        LatestRootVersionTableType,
-        StorageError,
-    )>,
-}
-
-impl<
-        NodeTableType,
-        ValueTableType,
-        LatestRootVersionTableType,
-        StorageType,
-        StorageError,
-    >
-    JellyfishMerkleTreeStorage<
-        NodeTableType,
-        ValueTableType,
-        LatestRootVersionTableType,
-        StorageType,
-        StorageError,
-    >
-{
-    pub fn storage_read(&self) -> RwLockReadGuard<StorageType> {
-        self.inner.read()
-    }
-
-    pub fn storage_write(&self) -> RwLockWriteGuard<StorageType> {
-        self.inner.write()
-    }
-}
+use super::merkle_tree::JellyfishMerkleTreeStorage;
 
 impl<
         NodeTableType,

--- a/fuel-merkle/src/jellyfish/merkle_tree.rs
+++ b/fuel-merkle/src/jellyfish/merkle_tree.rs
@@ -1,0 +1,344 @@
+use crate::{
+    common::Bytes32,
+    sparse::MerkleTreeKey,
+    storage::{
+        Mappable,
+        StorageInspect,
+        StorageMutate,
+    },
+};
+
+use alloc::sync::Arc;
+use core::marker::PhantomData;
+use spin::{
+    rwlock::RwLock,
+    RwLockReadGuard,
+    RwLockWriteGuard,
+};
+
+use jmt::{
+    storage::{
+        Node as JmtNode,
+        NodeKey as JmtNodeKey,
+        TreeWriter,
+    },
+    JellyfishMerkleTree,
+    Sha256Jmt,
+};
+
+use crate::jellyfish::error::MerkleTreeError;
+
+// Obtained by creating an empty tree.
+pub const EMPTY_ROOT: Bytes32 = [
+    83, 80, 65, 82, 83, 69, 95, 77, 69, 82, 75, 76, 69, 95, 80, 76, 65, 67, 69, 72, 79,
+    76, 68, 69, 82, 95, 72, 65, 83, 72, 95, 95,
+];
+
+#[derive(Debug, Clone)]
+pub struct JellyfishMerkleTreeStorage<
+    NodeTableType,
+    ValueTableType,
+    LatestRootVersionTableType,
+    StorageType,
+    StorageError,
+> {
+    inner: Arc<RwLock<StorageType>>,
+    phantom_table: PhantomData<(
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageError,
+    )>,
+}
+
+impl<
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageType,
+        StorageError,
+    >
+    JellyfishMerkleTreeStorage<
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageType,
+        StorageError,
+    >
+{
+    pub const fn empty_root() -> &'static Bytes32 {
+        &EMPTY_ROOT
+    }
+
+    pub fn storage_read(&self) -> RwLockReadGuard<StorageType> {
+        self.inner.read()
+    }
+
+    pub fn storage_write(&self) -> RwLockWriteGuard<StorageType> {
+        self.inner.write()
+    }
+}
+
+impl<
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageType,
+        StorageError,
+    >
+    JellyfishMerkleTreeStorage<
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageType,
+        StorageError,
+    >
+where
+    LatestRootVersionTableType: Mappable<Key = (), Value = u64, OwnedValue = u64>,
+    StorageType: StorageInspect<LatestRootVersionTableType, Error = StorageError>,
+{
+    fn get_latest_root_version(
+        &self,
+    ) -> Result<Option<u64>, MerkleTreeError<StorageType::Error>> {
+        let storage = self.storage_read();
+        let version = <StorageType as StorageInspect<LatestRootVersionTableType>>::get(
+            &*storage,
+            &(),
+        )?
+        .map(|v| *v);
+
+        Ok(version)
+    }
+}
+
+impl<
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageType,
+        StorageError,
+    >
+    JellyfishMerkleTreeStorage<
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageType,
+        StorageError,
+    >
+where
+    NodeTableType: Mappable<Key = JmtNodeKey, Value = JmtNode, OwnedValue = JmtNode>,
+    ValueTableType: Mappable<
+        Key = jmt::KeyHash,
+        Value = (jmt::Version, jmt::OwnedValue),
+        OwnedValue = (jmt::Version, jmt::OwnedValue),
+    >,
+    StorageType: StorageInspect<NodeTableType, Error = StorageError>
+        + StorageInspect<ValueTableType, Error = StorageError>,
+{
+    // Requires TreeReader + HasPreimage
+    // TreeReader requires StorageInspect<NodeTableType> and
+    // StorageInspect<ValueTableType> HasPreimage requires
+    // StorageInspect<ValueTableType>
+    fn as_jmt<'a>(&'a self) -> Sha256Jmt<'a, Self> {
+        JellyfishMerkleTree::new(&self)
+    }
+}
+
+impl<
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageType,
+        StorageError,
+    >
+    JellyfishMerkleTreeStorage<
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageType,
+        StorageError,
+    >
+where
+    NodeTableType: Mappable<Key = JmtNodeKey, Value = JmtNode, OwnedValue = JmtNode>,
+    ValueTableType: Mappable<
+        Key = jmt::KeyHash,
+        Value = (jmt::Version, jmt::OwnedValue),
+        OwnedValue = (jmt::Version, jmt::OwnedValue),
+    >,
+    LatestRootVersionTableType: Mappable<Key = (), Value = u64, OwnedValue = u64>,
+    StorageType: StorageInspect<NodeTableType, Error = StorageError>
+        + StorageInspect<ValueTableType, Error = StorageError>
+        + StorageInspect<LatestRootVersionTableType, Error = StorageError>,
+{
+    // get_latest_root_version() requires StorageInspect<LatestRootVersionTableType>
+    // as_jmt() requires TreeReader, which requires StorageInspect<NodeTableType> and
+    // StorageInspect<ValueTableType>. Therefore this function requires
+    // StorageInspect<LatestRootVersionTableType>, StorageInspect<NodeTableType>, and
+    // StorageInspect<ValueTableType>.
+    pub fn root(&self) -> Result<Bytes32, MerkleTreeError<StorageError>> {
+        // We need to know the version of the root node.
+        let version = self
+            .get_latest_root_version()?
+            .ok_or(MerkleTreeError::NoVersion)?;
+
+        self.as_jmt()
+            .get_root_hash(version)
+            .map_err(MerkleTreeError::JmtError)
+            .map(|root_hash| root_hash.0)
+    }
+
+    pub fn load(
+        storage: StorageType,
+        root: &Bytes32,
+    ) -> Result<Self, MerkleTreeError<StorageError>> {
+        let inner = Arc::new(RwLock::new(storage));
+        let merkle_tree = Self {
+            inner,
+            phantom_table: PhantomData,
+        };
+        // If the storage is not initialized, this function will fail.
+        // TODO: This should be tested.
+        let root_from_storage = merkle_tree.root()?;
+        //
+        if *root == root_from_storage {
+            Ok(merkle_tree)
+        } else {
+            Err(MerkleTreeError::RootHashMismatch(*root, root_from_storage))
+        }
+    }
+}
+
+impl<
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageType,
+        StorageError,
+    >
+    JellyfishMerkleTreeStorage<
+        NodeTableType,
+        ValueTableType,
+        LatestRootVersionTableType,
+        StorageType,
+        StorageError,
+    >
+where
+    NodeTableType: Mappable<Key = JmtNodeKey, Value = JmtNode, OwnedValue = JmtNode>,
+    ValueTableType: Mappable<
+        Key = jmt::KeyHash,
+        Value = (jmt::Version, jmt::OwnedValue),
+        OwnedValue = (jmt::Version, jmt::OwnedValue),
+    >,
+    LatestRootVersionTableType: Mappable<Key = (), Value = u64, OwnedValue = u64>,
+    StorageType: StorageMutate<NodeTableType, Error = StorageError>
+        + StorageMutate<ValueTableType, Error = StorageError>
+        + StorageMutate<LatestRootVersionTableType, Error = StorageError>,
+{
+    // Because we insert and remove a node, we need to have StorageType:
+    // StorageMutate<NodeTableType> + StorageMutate<ValueTableType> +
+    // StorageMutate<LatestRootVersionTableType>
+    pub fn new(storage: StorageType) -> Result<Self, MerkleTreeError<StorageError>> {
+        let inner = Arc::new(RwLock::new(storage));
+        // Set the initial version of the tree to 0
+        <StorageType as StorageMutate<LatestRootVersionTableType>>::insert(
+            &mut *inner.write(),
+            &(),
+            &0,
+        )?;
+        let mut tree = Self {
+            inner,
+            phantom_table: PhantomData,
+        };
+        // Inclusion and Exclusion proof require that the root is set, hence we add it
+        // here. Jmt does not make the constructor for `NibblePath` accessible, so
+        // we add and remove a node instead.
+        // TODO: Find a way to set the root without adding and deleting a node
+        let mock_key = MerkleTreeKey::new(Bytes32::default());
+        let mock_value = vec![0u8];
+        tree.update(mock_key, &mock_value)?;
+        tree.delete(mock_key)?;
+
+        Ok(tree)
+    }
+
+    pub fn from_set<B, I, D>(
+        storage: StorageType,
+        set: I,
+    ) -> Result<Self, MerkleTreeError<StorageError>>
+    where
+        I: Iterator<Item = (B, D)>,
+        B: Into<Bytes32>,
+        D: AsRef<[u8]>,
+    {
+        let tree = Self::new(storage)?;
+        let jmt = tree.as_jmt();
+        // We assume that we are constructing a new Merkle Tree.
+        // We start from version 2 to be consistent with the version obtained
+        // when returning a new tree.
+        // TODO: Change Self::new so that the initial version of a new tree is 0.
+        let version = 2;
+        let update_batch = set.map(|(key, data)| {
+            let key_hash = jmt::KeyHash(key.into());
+            // Sad, but jmt requires an owned value
+            // TODO: We should consider forking jmt to allow for borrowed values
+            let value = data.as_ref().to_vec();
+            (key_hash, Some(value))
+        });
+        // This writes the values into the tree cache. This function returns the tree
+        // updates that must be written into storage
+        let (_root_hash, updates) = jmt
+            .put_value_set(update_batch, version)
+            .map_err(MerkleTreeError::JmtError)?;
+        // TODO: Should we check the stale node indexes as well?
+        let node_updates = updates.node_batch;
+        <Self as TreeWriter>::write_node_batch(&tree, &node_updates)
+            .map_err(MerkleTreeError::TreeWriterError)?;
+
+        Ok(tree)
+    }
+
+    // TODO: We should have a corresponding function to batch udpates and increment the
+    // version only once
+    pub fn update(
+        &mut self,
+        key: MerkleTreeKey,
+        data: &[u8],
+    ) -> Result<(), MerkleTreeError<StorageError>> {
+        let key_hash = jmt::KeyHash(*key);
+        // If data.is_empty() we remove the value from the jmt
+        let value = if data.is_empty() {
+            None
+        } else {
+            Some(data.to_vec())
+        };
+        // TODO : We could update version once per block, but here we
+        // update version for each update operation.
+        let version = self
+            .get_latest_root_version()?
+            .ok_or(MerkleTreeError::NoVersion)?
+            .saturating_add(1);
+        let update_batch = [(key_hash, value); 1];
+        let (_root_hash, updates) = self
+            .as_jmt()
+            .put_value_set(update_batch, version)
+            .map_err(MerkleTreeError::JmtError)?;
+        // TODO: Figure out what to do with stale node indexes
+        let node_updates = updates.node_batch;
+        <Self as TreeWriter>::write_node_batch(&self, &node_updates)
+            .map_err(MerkleTreeError::TreeWriterError)?;
+        let stale_nodes = updates.stale_node_index_batch;
+        let mut storage_write_guard = self.storage_write();
+        for stale_node_index in stale_nodes {
+            let node_key = stale_node_index.node_key;
+            StorageMutate::<NodeTableType>::remove(&mut *storage_write_guard, &node_key)?;
+        }
+        return Ok(())
+    }
+
+    pub fn delete(
+        &mut self,
+        key: MerkleTreeKey,
+    ) -> Result<(), MerkleTreeError<StorageError>> {
+        self.update(key, &[])
+    }
+}


### PR DESCRIPTION
This PR builds upon #891 to provide the basic functions to manipulate a jmt: 

- [ ] create a new Jmt backed by a generic storage, 
- [ ] load a Jmt from existing storage
- [ ] return the tree root
- [ ] create a Jmt from a set of key-value pairs
- [ ] update and delete a key-value pair in a Jmt

Tests are provided in the last PR of this feature.

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
