### PR TITLE
Remove elided lifetimes in associated constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## Fixed
+- [895](https://github.com/FuelLabs/fuel-vm/pull/895): Fix elided lifetimes compilation warnings that became errors after the release of rust 1.83.0. 
+- [895](https://github.com/FuelLabs/fuel-vm/pull/895): Bump proptest-derive to version `0.5.1` to fix non-local impl errors on the derivation of `proptest_derive::Arbitrary` introduced by rust 1.83.0. 
+
 ## [Version 0.59.1]
 
 ### Fixed

--- a/fuel-merkle/Cargo.toml
+++ b/fuel-merkle/Cargo.toml
@@ -25,7 +25,7 @@ datatest-stable = "0.2"
 fuel-merkle-test-helpers = { path = "test-helpers" }
 hex = "0.4"
 proptest = "1.4"
-proptest-derive = "0.4"
+proptest-derive = "0.5.1"
 rand = "0.8"
 serde_json = "1.0"
 serde_yaml = "0.9"

--- a/fuel-storage/src/impls.rs
+++ b/fuel-storage/src/impls.rs
@@ -15,8 +15,23 @@ use alloc::{
     vec::Vec,
 };
 
-impl<'a, T: StorageInspect<Type> + ?Sized, Type: Mappable> StorageInspect<Type>
-    for &'a T
+impl<T: StorageInspect<Type> + ?Sized, Type: Mappable> StorageInspect<Type> for &'_ T {
+    type Error = T::Error;
+
+    fn get(
+        &self,
+        key: &Type::Key,
+    ) -> Result<Option<Cow<'_, Type::OwnedValue>>, Self::Error> {
+        <T as StorageInspect<Type>>::get(self, key)
+    }
+
+    fn contains_key(&self, key: &Type::Key) -> Result<bool, Self::Error> {
+        <T as StorageInspect<Type>>::contains_key(self, key)
+    }
+}
+
+impl<T: StorageInspect<Type> + ?Sized, Type: Mappable> StorageInspect<Type>
+    for &'_ mut T
 {
     type Error = T::Error;
 
@@ -32,26 +47,7 @@ impl<'a, T: StorageInspect<Type> + ?Sized, Type: Mappable> StorageInspect<Type>
     }
 }
 
-impl<'a, T: StorageInspect<Type> + ?Sized, Type: Mappable> StorageInspect<Type>
-    for &'a mut T
-{
-    type Error = T::Error;
-
-    fn get(
-        &self,
-        key: &Type::Key,
-    ) -> Result<Option<Cow<'_, Type::OwnedValue>>, Self::Error> {
-        <T as StorageInspect<Type>>::get(self, key)
-    }
-
-    fn contains_key(&self, key: &Type::Key) -> Result<bool, Self::Error> {
-        <T as StorageInspect<Type>>::contains_key(self, key)
-    }
-}
-
-impl<'a, T: StorageMutate<Type> + ?Sized, Type: Mappable> StorageMutate<Type>
-    for &'a mut T
-{
+impl<T: StorageMutate<Type> + ?Sized, Type: Mappable> StorageMutate<Type> for &'_ mut T {
     fn insert(
         &mut self,
         key: &Type::Key,
@@ -77,7 +73,7 @@ impl<'a, T: StorageMutate<Type> + ?Sized, Type: Mappable> StorageMutate<Type>
     }
 }
 
-impl<'a, T: StorageSize<Type> + ?Sized, Type: Mappable> StorageSize<Type> for &'a T {
+impl<T: StorageSize<Type> + ?Sized, Type: Mappable> StorageSize<Type> for &'_ T {
     fn size_of_value(
         &self,
         key: &<Type as Mappable>::Key,
@@ -86,7 +82,7 @@ impl<'a, T: StorageSize<Type> + ?Sized, Type: Mappable> StorageSize<Type> for &'
     }
 }
 
-impl<'a, T: StorageSize<Type> + ?Sized, Type: Mappable> StorageSize<Type> for &'a mut T {
+impl<T: StorageSize<Type> + ?Sized, Type: Mappable> StorageSize<Type> for &'_ mut T {
     fn size_of_value(
         &self,
         key: &<Type as Mappable>::Key,
@@ -95,8 +91,8 @@ impl<'a, T: StorageSize<Type> + ?Sized, Type: Mappable> StorageSize<Type> for &'
     }
 }
 
-impl<'a, T: StorageRead<Type> + StorageSize<Type> + ?Sized, Type: Mappable>
-    StorageRead<Type> for &'a T
+impl<T: StorageRead<Type> + StorageSize<Type> + ?Sized, Type: Mappable> StorageRead<Type>
+    for &'_ T
 {
     fn read(
         &self,
@@ -115,8 +111,8 @@ impl<'a, T: StorageRead<Type> + StorageSize<Type> + ?Sized, Type: Mappable>
     }
 }
 
-impl<'a, T: StorageRead<Type> + StorageSize<Type> + ?Sized, Type: Mappable>
-    StorageRead<Type> for &'a mut T
+impl<T: StorageRead<Type> + StorageSize<Type> + ?Sized, Type: Mappable> StorageRead<Type>
+    for &'_ mut T
 {
     fn read(
         &self,
@@ -135,9 +131,7 @@ impl<'a, T: StorageRead<Type> + StorageSize<Type> + ?Sized, Type: Mappable>
     }
 }
 
-impl<'a, T: StorageWrite<Type> + ?Sized, Type: Mappable> StorageWrite<Type>
-    for &'a mut T
-{
+impl<T: StorageWrite<Type> + ?Sized, Type: Mappable> StorageWrite<Type> for &'_ mut T {
     fn write_bytes(&mut self, key: &Type::Key, buf: &[u8]) -> Result<usize, Self::Error> {
         <T as StorageWrite<Type>>::write_bytes(self, key, buf)
     }
@@ -155,16 +149,16 @@ impl<'a, T: StorageWrite<Type> + ?Sized, Type: Mappable> StorageWrite<Type>
     }
 }
 
-impl<'a, T: MerkleRootStorage<Key, Type> + ?Sized, Key, Type: Mappable>
-    MerkleRootStorage<Key, Type> for &'a T
+impl<T: MerkleRootStorage<Key, Type> + ?Sized, Key, Type: Mappable>
+    MerkleRootStorage<Key, Type> for &'_ T
 {
     fn root(&self, key: &Key) -> Result<MerkleRoot, Self::Error> {
         <T as MerkleRootStorage<Key, Type>>::root(self, key)
     }
 }
 
-impl<'a, T: MerkleRootStorage<Key, Type> + ?Sized, Key, Type: Mappable>
-    MerkleRootStorage<Key, Type> for &'a mut T
+impl<T: MerkleRootStorage<Key, Type> + ?Sized, Key, Type: Mappable>
+    MerkleRootStorage<Key, Type> for &'_ mut T
 {
     fn root(&self, key: &Key) -> Result<MerkleRoot, Self::Error> {
         <T as MerkleRootStorage<Key, Type>>::root(self, key)
@@ -186,7 +180,7 @@ impl<'a, T: StorageInspect<Type>, Type: Mappable> StorageRef<'a, T, Type> {
     }
 }
 
-impl<'a, T, Type: Mappable> StorageRef<'a, T, Type> {
+impl<T, Type: Mappable> StorageRef<'_, T, Type> {
     #[inline(always)]
     pub fn root<Key>(self, key: &Key) -> Result<MerkleRoot, T::Error>
     where
@@ -196,7 +190,7 @@ impl<'a, T, Type: Mappable> StorageRef<'a, T, Type> {
     }
 }
 
-impl<'a, T: StorageRead<Type>, Type: Mappable> StorageRef<'a, T, Type> {
+impl<T: StorageRead<Type>, Type: Mappable> StorageRef<'_, T, Type> {
     #[inline(always)]
     pub fn read(
         &self,
@@ -233,7 +227,7 @@ impl<'a, T: StorageInspect<Type>, Type: Mappable> StorageMut<'a, T, Type> {
     }
 }
 
-impl<'a, T, Type> StorageMut<'a, T, Type>
+impl<T, Type> StorageMut<'_, T, Type>
 where
     T: StorageMutate<Type>,
     Type: Mappable,
@@ -263,7 +257,7 @@ where
     }
 }
 
-impl<'a, T, Type: Mappable> StorageMut<'a, T, Type> {
+impl<T, Type: Mappable> StorageMut<'_, T, Type> {
     #[inline(always)]
     pub fn root<Key>(self, key: &Key) -> Result<MerkleRoot, T::Error>
     where
@@ -273,7 +267,7 @@ impl<'a, T, Type: Mappable> StorageMut<'a, T, Type> {
     }
 }
 
-impl<'a, T, Type> StorageMut<'a, T, Type>
+impl<T, Type> StorageMut<'_, T, Type>
 where
     Type: Mappable,
     T: StorageWrite<Type>,

--- a/fuel-tx/src/transaction.rs
+++ b/fuel-tx/src/transaction.rs
@@ -984,13 +984,13 @@ pub mod field {
         pub(crate) storage_slots: &'a mut Vec<StorageSlot>,
     }
 
-    impl<'a> AsMut<Vec<StorageSlot>> for StorageSlotRef<'a> {
+    impl AsMut<Vec<StorageSlot>> for StorageSlotRef<'_> {
         fn as_mut(&mut self) -> &mut Vec<StorageSlot> {
             self.storage_slots
         }
     }
 
-    impl<'a> Deref for StorageSlotRef<'a> {
+    impl Deref for StorageSlotRef<'_> {
         type Target = [StorageSlot];
 
         fn deref(&self) -> &Self::Target {
@@ -998,14 +998,14 @@ pub mod field {
         }
     }
 
-    impl<'a> DerefMut for StorageSlotRef<'a> {
+    impl DerefMut for StorageSlotRef<'_> {
         fn deref_mut(&mut self) -> &mut Self::Target {
             self.storage_slots.deref_mut()
         }
     }
 
     /// Ensure the storage slots are sorted after being set
-    impl<'a> Drop for StorageSlotRef<'a> {
+    impl Drop for StorageSlotRef<'_> {
         fn drop(&mut self) {
             self.storage_slots.sort()
         }

--- a/fuel-tx/src/transaction/policies.rs
+++ b/fuel-tx/src/transaction/policies.rs
@@ -316,7 +316,7 @@ impl<'de> serde::Deserialize<'de> for Policies {
             Ignore,
         }
         struct FieldVisitor;
-        impl<'de> serde::de::Visitor<'de> for FieldVisitor {
+        impl serde::de::Visitor<'_> for FieldVisitor {
             type Value = Field;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/fuel-types/src/canonical.rs
+++ b/fuel-types/src/canonical.rs
@@ -481,7 +481,7 @@ impl Output for Vec<u8> {
     }
 }
 
-impl<'a> Output for &'a mut [u8] {
+impl Output for &'_ mut [u8] {
     fn write(&mut self, from: &[u8]) -> Result<(), Error> {
         if from.len() > self.len() {
             return Err(Error::BufferIsTooShort)
@@ -498,7 +498,7 @@ impl<'a> Output for &'a mut [u8] {
     }
 }
 
-impl<'a> Input for &'a [u8] {
+impl Input for &'_ [u8] {
     fn remaining(&mut self) -> usize {
         self.len()
     }

--- a/fuel-vm/src/constraints/reg_key.rs
+++ b/fuel-vm/src/constraints/reg_key.rs
@@ -109,14 +109,14 @@ impl<'a, const INDEX: u8> From<RegMut<'a, INDEX>> for Reg<'a, INDEX> {
     }
 }
 
-impl<'r, const INDEX: u8> RegMut<'r, INDEX> {
+impl<const INDEX: u8> RegMut<'_, INDEX> {
     /// Re-borrow the register as an immutable reference.
     pub fn as_ref(&self) -> Reg<INDEX> {
         Reg(self.0)
     }
 }
 
-impl<'r, const INDEX: u8> RegMut<'r, INDEX> {
+impl<const INDEX: u8> RegMut<'_, INDEX> {
     /// Re-borrow the register as a mutable reference.
     pub fn as_mut(&mut self) -> RegMut<INDEX> {
         RegMut(self.0)
@@ -271,7 +271,7 @@ pub(crate) fn copy_registers(
     out
 }
 
-impl<'r> ProgramRegisters<'r> {
+impl ProgramRegisters<'_> {
     /// Get two mutable references to program registers.
     /// Note they cannot be the same register.
     pub fn get_mut_two(
@@ -425,7 +425,7 @@ pub(crate) enum ProgramRegistersSegment {
     High,
 }
 
-impl<'r> ProgramRegisters<'r> {
+impl ProgramRegisters<'_> {
     /// Returns the registers corresponding to the segment, always 24 elements.
     pub(crate) fn segment(&self, segment: ProgramRegistersSegment) -> &[Word] {
         match segment {

--- a/fuel-vm/src/interpreter/blockchain.rs
+++ b/fuel-vm/src/interpreter/blockchain.rs
@@ -573,7 +573,7 @@ struct LoadContractCodeCtx<'vm, S> {
     is: Reg<'vm, IS>,
 }
 
-impl<'vm, S> LoadContractCodeCtx<'vm, S>
+impl<S> LoadContractCodeCtx<'_, S>
 where
     S: InterpreterStorage,
 {
@@ -874,7 +874,7 @@ struct BurnCtx<'vm, S> {
     is: Reg<'vm, IS>,
 }
 
-impl<'vm, S> BurnCtx<'vm, S>
+impl<S> BurnCtx<'_, S>
 where
     S: ContractsAssetsStorage,
 {
@@ -914,7 +914,7 @@ struct MintCtx<'vm, S> {
     is: Reg<'vm, IS>,
 }
 
-impl<'vm, S> MintCtx<'vm, S>
+impl<S> MintCtx<'_, S>
 where
     S: ContractsAssetsStorage,
 {
@@ -969,7 +969,7 @@ struct CodeCopyCtx<'vm, S> {
     is: Reg<'vm, IS>,
 }
 
-impl<'vm, S> CodeCopyCtx<'vm, S>
+impl<S> CodeCopyCtx<'_, S>
 where
     S: InterpreterStorage,
 {
@@ -1081,7 +1081,7 @@ struct CodeRootCtx<'vm, S> {
     is: Reg<'vm, IS>,
 }
 
-impl<'vm, S> CodeRootCtx<'vm, S> {
+impl<S> CodeRootCtx<'_, S> {
     pub(crate) fn code_root(mut self, a: Word, b: Word) -> IoResult<(), S::DataError>
     where
         S: InterpreterStorage,
@@ -1133,7 +1133,7 @@ struct CodeSizeCtx<'vm, S> {
     is: Reg<'vm, IS>,
 }
 
-impl<'vm, S> CodeSizeCtx<'vm, S> {
+impl<S> CodeSizeCtx<'_, S> {
     pub(crate) fn code_size(
         mut self,
         result: &mut Word,

--- a/fuel-vm/src/interpreter/contract.rs
+++ b/fuel-vm/src/interpreter/contract.rs
@@ -185,7 +185,7 @@ struct ContractBalanceCtx<'vm, S> {
     input_contracts: InputContracts<'vm>,
 }
 
-impl<'vm, S> ContractBalanceCtx<'vm, S> {
+impl<S> ContractBalanceCtx<'_, S> {
     pub(crate) fn contract_balance(
         mut self,
         result: &mut Word,
@@ -225,7 +225,7 @@ struct TransferCtx<'vm, S, Tx> {
     pc: RegMut<'vm, PC>,
 }
 
-impl<'vm, S, Tx> TransferCtx<'vm, S, Tx> {
+impl<S, Tx> TransferCtx<'_, S, Tx> {
     /// In Fuel specs:
     /// Transfer $rB coins with asset ID at $rC to contract with ID at $rA.
     /// $rA -> recipient_contract_id_offset

--- a/fuel-vm/src/interpreter/executors/main.rs
+++ b/fuel-vm/src/interpreter/executors/main.rs
@@ -126,7 +126,7 @@ enum PredicateRunKind<'a, Tx> {
     Estimating(&'a mut Tx),
 }
 
-impl<'a, Tx> PredicateRunKind<'a, Tx> {
+impl<Tx> PredicateRunKind<'_, Tx> {
     fn tx(&self) -> &Tx {
         match self {
             PredicateRunKind::Verifying(tx) => tx,

--- a/fuel-vm/src/interpreter/flow.rs
+++ b/fuel-vm/src/interpreter/flow.rs
@@ -437,7 +437,7 @@ struct PrepareCallUnusedRegisters<'a> {
     retl: Reg<'a, RETL>,
 }
 
-impl<'a> PrepareCallRegisters<'a> {
+impl PrepareCallRegisters<'_> {
     fn copy_registers(&self) -> [Word; VM_REGISTER_COUNT] {
         copy_registers(&self.into(), &self.program_registers)
     }
@@ -459,7 +459,7 @@ struct PrepareCallCtx<'vm, S> {
     profiler: &'vm mut Profiler,
 }
 
-impl<'vm, S> PrepareCallCtx<'vm, S>
+impl<S> PrepareCallCtx<'_, S>
 where
     S: InterpreterStorage,
 {

--- a/fuel-vm/src/interpreter/gas.rs
+++ b/fuel-vm/src/interpreter/gas.rs
@@ -157,7 +157,7 @@ pub(crate) struct ProfileGas<'a> {
     pub profiler: &'a mut Profiler,
 }
 
-impl<'a> ProfileGas<'a> {
+impl ProfileGas<'_> {
     #[allow(unused_variables)]
     pub(crate) fn profile(&mut self, cgas: Reg<CGAS>, gas: Word) {
         #[cfg(feature = "profile-coverage")]

--- a/fuel-vm/src/interpreter/receipts.rs
+++ b/fuel-vm/src/interpreter/receipts.rs
@@ -153,7 +153,7 @@ impl<'a> ReceiptsCtxMut<'a> {
     }
 }
 
-impl<'a> Drop for ReceiptsCtxMut<'a> {
+impl Drop for ReceiptsCtxMut<'_> {
     fn drop(&mut self) {
         // The receipts may have been modified; recalculate the root
         self.receipts_ctx.recalculate_root()

--- a/fuel-vm/src/profiler.rs
+++ b/fuel-vm/src/profiler.rs
@@ -38,7 +38,7 @@ impl serde::Serialize for InstructionLocation {
 struct InstructionLocationVisitor;
 
 #[cfg(feature = "serde")]
-impl<'de> serde::de::Visitor<'de> for InstructionLocationVisitor {
+impl serde::de::Visitor<'_> for InstructionLocationVisitor {
     type Value = InstructionLocation;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/fuel-vm/src/state.rs
+++ b/fuel-vm/src/state.rs
@@ -203,7 +203,7 @@ impl<'a, Tx> From<&'a StateTransition<Tx>> for StateTransitionRef<'a, Tx> {
     }
 }
 
-impl<'a, Tx: Clone> From<StateTransitionRef<'a, Tx>> for StateTransition<Tx> {
+impl<Tx: Clone> From<StateTransitionRef<'_, Tx>> for StateTransition<Tx> {
     fn from(t: StateTransitionRef<Tx>) -> StateTransition<Tx> {
         StateTransition {
             state: *t.state(),


### PR DESCRIPTION

![lifetimes_everywhere](https://github.com/user-attachments/assets/4bbb678d-5cbf-47d5-9667-494a807336a3)

Compilation is currently failing locally due to a warning that lifetimes could be elided having be  promoted to an error. 
See https://github.com/rust-lang/rust/pull/124211/

Compilation is also failing because the derivation of `proptest_derive::Arbitrary` is affected by a reworks of non-local impls 
in rust 1.83.0 (see https://github.com/rust-lang/rust/pull/127117 for the rust side, and https://github.com/proptest-rs/proptest/issues/447 for the proptest issue, https://github.com/proptest-rs/proptest/pull/531/files contains a fix). 
The problem disappears by bumping proptest_derive to the latest version. 



## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
