### PR TITLE
Return `TxId` when error in checking of transactions

### DIFF
--- a/fuel-tx/src/transaction/metadata.rs
+++ b/fuel-tx/src/transaction/metadata.rs
@@ -11,6 +11,8 @@ use crate::{
     ValidityError,
 };
 
+use super::TxId;
+
 /// Entity support metadata computation to cache results.
 pub trait Cacheable {
     /// The cache is already computed.
@@ -19,7 +21,7 @@ pub trait Cacheable {
     fn is_computed(&self) -> bool;
 
     /// Computes the cache for the entity.
-    fn precompute(&mut self, chain_id: &ChainId) -> Result<(), ValidityError>;
+    fn precompute(&mut self, chain_id: &ChainId) -> Result<(), (TxId, ValidityError)>;
 }
 
 impl Cacheable for super::Transaction {
@@ -34,7 +36,7 @@ impl Cacheable for super::Transaction {
         }
     }
 
-    fn precompute(&mut self, chain_id: &ChainId) -> Result<(), ValidityError> {
+    fn precompute(&mut self, chain_id: &ChainId) -> Result<(), (TxId, ValidityError)> {
         match self {
             Self::Script(tx) => tx.precompute(chain_id),
             Self::Create(tx) => tx.precompute(chain_id),
@@ -62,7 +64,7 @@ pub struct CommonMetadata {
 impl CommonMetadata {
     /// Computes the `Metadata` for the `tx` transaction.
     /// Returns `None` if the transaction is invalid.
-    pub fn compute<Tx>(tx: &Tx, chain_id: &ChainId) -> Result<Self, ValidityError>
+    pub fn compute<Tx>(tx: &Tx, chain_id: &ChainId) -> Result<Self, (TxId, ValidityError)>
     where
         Tx: UniqueIdentifier,
         Tx: field::Inputs,
@@ -86,7 +88,7 @@ impl CommonMetadata {
             let i = offset;
             offset = offset
                 .checked_add(input.size())
-                .ok_or(ValidityError::SerializedInputTooLarge { index })?;
+                .ok_or((id, ValidityError::SerializedInputTooLarge { index }))?;
             inputs_offset_at.push(i);
         }
 
@@ -96,7 +98,7 @@ impl CommonMetadata {
             let i = offset;
             offset = offset
                 .checked_add(output.size())
-                .ok_or(ValidityError::SerializedOutputTooLarge { index })?;
+                .ok_or((id, ValidityError::SerializedOutputTooLarge { index }))?;
             outputs_offset_at.push(i);
         }
 
@@ -106,7 +108,7 @@ impl CommonMetadata {
             let i = offset;
             offset = offset
                 .checked_add(witnesses.size())
-                .ok_or(ValidityError::SerializedWitnessTooLarge { index })?;
+                .ok_or((id, ValidityError::SerializedWitnessTooLarge { index }))?;
             witnesses_offset_at.push(i);
         }
 

--- a/fuel-tx/src/transaction/types/blob.rs
+++ b/fuel-tx/src/transaction/types/blob.rs
@@ -16,6 +16,7 @@ use crate::{
     Input,
     Output,
     TransactionRepr,
+    TxId,
     ValidityError,
 };
 use educe::Educe;
@@ -171,7 +172,7 @@ impl crate::Cacheable for Blob {
         self.metadata.is_some()
     }
 
-    fn precompute(&mut self, chain_id: &ChainId) -> Result<(), ValidityError> {
+    fn precompute(&mut self, chain_id: &ChainId) -> Result<(), (TxId, ValidityError)> {
         self.metadata = None;
         self.metadata = Some(ChargeableMetadata {
             common: CommonMetadata::compute(self, chain_id)?,

--- a/fuel-tx/src/transaction/types/create.rs
+++ b/fuel-tx/src/transaction/types/create.rs
@@ -21,6 +21,7 @@ use crate::{
     PrepareSign,
     StorageSlot,
     TransactionRepr,
+    TxId,
     ValidityError,
 };
 use educe::Educe;
@@ -262,11 +263,14 @@ impl crate::Cacheable for Create {
         self.metadata.is_some()
     }
 
-    fn precompute(&mut self, chain_id: &ChainId) -> Result<(), ValidityError> {
+    fn precompute(&mut self, chain_id: &ChainId) -> Result<(), (TxId, ValidityError)> {
         self.metadata = None;
+        let common_metadata = CommonMetadata::compute(self, chain_id)?;
+        let body_metadata =
+            CreateMetadata::compute(self).map_err(|e| (common_metadata.id, e))?;
         self.metadata = Some(ChargeableMetadata {
-            common: CommonMetadata::compute(self, chain_id)?,
-            body: CreateMetadata::compute(self)?,
+            common: common_metadata,
+            body: body_metadata,
         });
         Ok(())
     }

--- a/fuel-tx/src/transaction/types/mint.rs
+++ b/fuel-tx/src/transaction/types/mint.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     ConsensusParameters,
     TransactionRepr,
+    TxId,
     TxPointer,
     ValidityError,
 };
@@ -126,7 +127,7 @@ impl crate::Cacheable for Mint {
         self.metadata.is_some()
     }
 
-    fn precompute(&mut self, chain_id: &ChainId) -> Result<(), ValidityError> {
+    fn precompute(&mut self, chain_id: &ChainId) -> Result<(), (TxId, ValidityError)> {
         self.metadata = None;
         self.metadata = Some(MintMetadata::compute(self, chain_id));
         Ok(())

--- a/fuel-tx/src/transaction/types/script.rs
+++ b/fuel-tx/src/transaction/types/script.rs
@@ -27,6 +27,7 @@ use crate::{
     GasCosts,
     Output,
     TransactionRepr,
+    TxId,
     ValidityError,
 };
 use educe::Educe;
@@ -210,7 +211,7 @@ impl crate::Cacheable for Script {
         self.metadata.is_some()
     }
 
-    fn precompute(&mut self, chain_id: &ChainId) -> Result<(), ValidityError> {
+    fn precompute(&mut self, chain_id: &ChainId) -> Result<(), (TxId, ValidityError)> {
         self.metadata = None;
         self.metadata = Some(ChargeableMetadata {
             common: CommonMetadata::compute(self, chain_id)?,

--- a/fuel-tx/src/transaction/types/upload.rs
+++ b/fuel-tx/src/transaction/types/upload.rs
@@ -16,6 +16,7 @@ use crate::{
     Input,
     Output,
     TransactionRepr,
+    TxId,
     ValidityError,
 };
 use core::ops::Deref;
@@ -278,7 +279,7 @@ impl crate::Cacheable for Upload {
         self.metadata.is_some()
     }
 
-    fn precompute(&mut self, chain_id: &ChainId) -> Result<(), ValidityError> {
+    fn precompute(&mut self, chain_id: &ChainId) -> Result<(), (TxId, ValidityError)> {
         self.metadata = None;
         self.metadata = Some(ChargeableMetadata {
             common: CommonMetadata::compute(self, chain_id)?,

--- a/fuel-vm/src/checked_transaction/types.rs
+++ b/fuel-vm/src/checked_transaction/types.rs
@@ -76,6 +76,8 @@ pub mod create {
         ConsensusParameters,
         Create,
         FormatValidityChecks,
+        TxId,
+        UniqueIdentifier,
     };
     use fuel_types::{
         AssetId,
@@ -104,16 +106,22 @@ pub mod create {
             mut self,
             block_height: BlockHeight,
             consensus_params: &ConsensusParameters,
-        ) -> Result<Checked<Self>, CheckError> {
+        ) -> Result<Checked<Self>, (TxId, CheckError)> {
             let chain_id = consensus_params.chain_id();
-            self.precompute(&chain_id)?;
-            self.check_without_signatures(block_height, consensus_params)?;
+            self.precompute(&chain_id)
+                .map_err(|(id, e)| (id, e.into()))?;
+            let id = self
+                .cached_id()
+                .expect("The `id` should exist for precomputed transactions");
+            self.check_without_signatures(block_height, consensus_params)
+                .map_err(|e| (id, e.into()))?;
 
             // validate fees and compute free balances
             let AvailableBalances {
                 non_retryable_balances,
                 retryable_balance,
-            } = initial_free_balances(&self, consensus_params.base_asset_id())?;
+            } = initial_free_balances(&self, consensus_params.base_asset_id())
+                .map_err(|e| (id, e.into()))?;
             debug_assert_eq!(
                 retryable_balance, 0,
                 "The `check_without_signatures` should return `TransactionInputContainsMessageData` above"
@@ -146,6 +154,8 @@ pub mod mint {
         ConsensusParameters,
         FormatValidityChecks,
         Mint,
+        TxId,
+        UniqueIdentifier,
     };
     use fuel_types::BlockHeight;
 
@@ -156,10 +166,15 @@ pub mod mint {
             mut self,
             block_height: BlockHeight,
             consensus_params: &ConsensusParameters,
-        ) -> Result<Checked<Self>, CheckError> {
+        ) -> Result<Checked<Self>, (TxId, CheckError)> {
             let chain_id = consensus_params.chain_id();
-            self.precompute(&chain_id)?;
-            self.check_without_signatures(block_height, consensus_params)?;
+            self.precompute(&chain_id)
+                .map_err(|(id, e)| (id, e.into()))?;
+            let id = self
+                .cached_id()
+                .expect("The `id` should exist for precomputed transactions");
+            self.check_without_signatures(block_height, consensus_params)
+                .map_err(|e| (id, e.into()))?;
 
             Ok(Checked::basic(self, ()))
         }
@@ -187,6 +202,8 @@ pub mod script {
         ConsensusParameters,
         FormatValidityChecks,
         Script,
+        TxId,
+        UniqueIdentifier,
     };
     use fuel_types::{
         AssetId,
@@ -217,16 +234,22 @@ pub mod script {
             mut self,
             block_height: BlockHeight,
             consensus_params: &ConsensusParameters,
-        ) -> Result<Checked<Self>, CheckError> {
+        ) -> Result<Checked<Self>, (TxId, CheckError)> {
             let chain_id = consensus_params.chain_id();
-            self.precompute(&chain_id)?;
-            self.check_without_signatures(block_height, consensus_params)?;
+            self.precompute(&chain_id)
+                .map_err(|(id, e)| (id, e.into()))?;
+            let id = self
+                .cached_id()
+                .expect("The `id` should exist for precomputed transactions");
+            self.check_without_signatures(block_height, consensus_params)
+                .map_err(|e| (id, e.into()))?;
 
             // validate fees and compute free balances
             let AvailableBalances {
                 non_retryable_balances,
                 retryable_balance,
-            } = initial_free_balances(&self, consensus_params.base_asset_id())?;
+            } = initial_free_balances(&self, consensus_params.base_asset_id())
+                .map_err(|e| (id, e.into()))?;
 
             let metadata = CheckedMetadata {
                 base_asset_id: *consensus_params.base_asset_id(),
@@ -266,6 +289,8 @@ pub mod upgrade {
         Chargeable,
         ConsensusParameters,
         FormatValidityChecks,
+        TxId,
+        UniqueIdentifier,
         Upgrade,
     };
     use fuel_types::{
@@ -295,16 +320,22 @@ pub mod upgrade {
             mut self,
             block_height: BlockHeight,
             consensus_params: &ConsensusParameters,
-        ) -> Result<Checked<Self>, CheckError> {
+        ) -> Result<Checked<Self>, (TxId, CheckError)> {
             let chain_id = consensus_params.chain_id();
-            self.precompute(&chain_id)?;
-            self.check_without_signatures(block_height, consensus_params)?;
+            self.precompute(&chain_id)
+                .map_err(|(id, e)| (id, e.into()))?;
+            let id = self
+                .cached_id()
+                .expect("The `id` should exist for precomputed transactions");
+            self.check_without_signatures(block_height, consensus_params)
+                .map_err(|e| (id, e.into()))?;
 
             // validate fees and compute free balances
             let AvailableBalances {
                 non_retryable_balances,
                 retryable_balance,
-            } = initial_free_balances(&self, consensus_params.base_asset_id())?;
+            } = initial_free_balances(&self, consensus_params.base_asset_id())
+                .map_err(|e| (id, e.into()))?;
             debug_assert_eq!(
                 retryable_balance, 0,
                 "The `check_without_signatures` should return `TransactionInputContainsMessageData` above"
@@ -344,6 +375,8 @@ pub mod upload {
         Chargeable,
         ConsensusParameters,
         FormatValidityChecks,
+        TxId,
+        UniqueIdentifier,
         Upload,
     };
     use fuel_types::{
@@ -373,16 +406,22 @@ pub mod upload {
             mut self,
             block_height: BlockHeight,
             consensus_params: &ConsensusParameters,
-        ) -> Result<Checked<Self>, CheckError> {
+        ) -> Result<Checked<Self>, (TxId, CheckError)> {
             let chain_id = consensus_params.chain_id();
-            self.precompute(&chain_id)?;
-            self.check_without_signatures(block_height, consensus_params)?;
+            self.precompute(&chain_id)
+                .map_err(|(id, e)| (id, e.into()))?;
+            let id = self
+                .cached_id()
+                .expect("The `id` should exist for precomputed transactions");
+            self.check_without_signatures(block_height, consensus_params)
+                .map_err(|e| (id, e.into()))?;
 
             // validate fees and compute free balances
             let AvailableBalances {
                 non_retryable_balances,
                 retryable_balance,
-            } = initial_free_balances(&self, consensus_params.base_asset_id())?;
+            } = initial_free_balances(&self, consensus_params.base_asset_id())
+                .map_err(|e| (id, e.into()))?;
             debug_assert_eq!(
                 retryable_balance, 0,
                 "The `check_without_signatures` should return `TransactionInputContainsMessageData` above"
@@ -424,6 +463,8 @@ pub mod blob {
         Chargeable,
         ConsensusParameters,
         FormatValidityChecks,
+        TxId,
+        UniqueIdentifier,
     };
     use fuel_types::BlockHeight;
 
@@ -449,16 +490,22 @@ pub mod blob {
             mut self,
             block_height: BlockHeight,
             consensus_params: &ConsensusParameters,
-        ) -> Result<Checked<Self>, CheckError> {
+        ) -> Result<Checked<Self>, (TxId, CheckError)> {
             let chain_id = consensus_params.chain_id();
-            self.precompute(&chain_id)?;
-            self.check_without_signatures(block_height, consensus_params)?;
+            self.precompute(&chain_id)
+                .map_err(|(id, e)| (id, e.into()))?;
+            let id = self
+                .cached_id()
+                .expect("The `id` should exist for precomputed transactions");
+            self.check_without_signatures(block_height, consensus_params)
+                .map_err(|e| (id, e.into()))?;
 
             // validate fees and compute free balances
             let AvailableBalances {
                 non_retryable_balances,
                 retryable_balance,
-            } = initial_free_balances(&self, consensus_params.base_asset_id())?;
+            } = initial_free_balances(&self, consensus_params.base_asset_id())
+                .map_err(|e| (id, e.into()))?;
             debug_assert_eq!(
                 retryable_balance, 0,
                 "The `check_without_signatures` should return `TransactionInputContainsMessageData` above"

--- a/fuel-vm/src/tests/upload.rs
+++ b/fuel-vm/src/tests/upload.rs
@@ -276,14 +276,14 @@ fn check__fails_when_subsection_index_more_than_total_number() {
         vec![],
         vec![],
     )
-    .into_checked_basic(Default::default(), &Default::default());
+    .into_checked_basic(Default::default(), &Default::default())
+    .expect_err("Should fail to generate checked tx")
+    .1;
 
     // Then
     assert_eq!(
         result,
-        Err(CheckError::Validity(
-            ValidityError::TransactionUploadRootVerificationFailed
-        ))
+        CheckError::Validity(ValidityError::TransactionUploadRootVerificationFailed)
     );
 }
 
@@ -303,14 +303,14 @@ fn check__fails_when_total_number_is_zero() {
         vec![],
         vec![],
     )
-    .into_checked_basic(Default::default(), &Default::default());
+    .into_checked_basic(Default::default(), &Default::default())
+    .expect_err("Should fail to generate checked tx")
+    .1;
 
     // Then
     assert_eq!(
         result,
-        Err(CheckError::Validity(
-            ValidityError::TransactionUploadRootVerificationFailed
-        ))
+        CheckError::Validity(ValidityError::TransactionUploadRootVerificationFailed)
     );
 }
 


### PR DESCRIPTION
When we try to turn a `Tx` in a `Checked<Tx>`, errors can happens, but we always start by computing the `TxId` and this can never fails. If something else, fails afterwards it's super useful to have the `TxId` to link the error with the transaction associated.

Currently, in the existing code calling `into_checked()`, if we have an error we are computing the `TxId` ourself again to link it to the `CheckError` which creates a double computation.

## Breaking change

The `TxId` is now returned with the error.

Before : 
```rust
fn into_checked(
        self,
        block_height: BlockHeight,
        consensus_params: &ConsensusParameters,
    ) -> Result<Checked<Self>, CheckError>
```

Now :
```rust
fn into_checked(
        self,
        block_height: BlockHeight,
        consensus_params: &ConsensusParameters,
    ) -> Result<Checked<Self>, (TxId, CheckError)>
```

## Breaking change notes

I didn't placed this behind a feature flag because I think it's always valuable, however if we want to avoid breaking for now and have this information under a special feature I'm ok with this. Inputs from reviewers would be super valuable on that.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
