### PR TITLE
Compare nonce instead of message id of inputs to catch duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Breaking
+- [900](https://github.com/FuelLabs/fuel-vm/pull/900): Change the error variant `DuplicateMessageInputId` to `DuplicateInputNonce` which now contains a nonce instead of `MessageId` for performance improvements.
+
 ### Fixed
 - [889](https://github.com/FuelLabs/fuel-vm/pull/889): Debugger breakpoint caused receipts to be produced incorrectly.
 

--- a/fuel-tx/src/tests/valid_cases/input.rs
+++ b/fuel-tx/src/tests/valid_cases/input.rs
@@ -564,7 +564,7 @@ fn transaction_with_duplicate_message_inputs_is_invalid() {
         0,
         generate_bytes(rng),
     );
-    let message_id = message_input.message_id().unwrap();
+    let nonce = message_input.nonce().cloned().unwrap();
     let fee = Input::coin_signed(
         rng.gen(),
         rng.gen(),
@@ -587,7 +587,7 @@ fn transaction_with_duplicate_message_inputs_is_invalid() {
         )
         .expect_err("Expected checkable failure");
 
-    assert_eq!(err, ValidityError::DuplicateMessageInputId { message_id });
+    assert_eq!(err, ValidityError::DuplicateMessageInputId { nonce });
 }
 
 #[test]

--- a/fuel-tx/src/tests/valid_cases/input.rs
+++ b/fuel-tx/src/tests/valid_cases/input.rs
@@ -587,7 +587,7 @@ fn transaction_with_duplicate_message_inputs_is_invalid() {
         )
         .expect_err("Expected checkable failure");
 
-    assert_eq!(err, ValidityError::DuplicateMessageInputId { nonce });
+    assert_eq!(err, ValidityError::DuplicateInputNonce { nonce });
 }
 
 #[test]

--- a/fuel-tx/src/transaction/validity.rs
+++ b/fuel-tx/src/transaction/validity.rs
@@ -434,7 +434,7 @@ where
     // Check for duplicated input nonce
     let duplicated_nonce = tx.inputs().iter().filter_map(Input::nonce);
     if let Some(nonce) = next_duplicate(duplicated_nonce).copied() {
-        return Err(ValidityError::DuplicateMessageInputId { nonce });
+        return Err(ValidityError::DuplicateInputNonce { nonce });
     }
 
     // Validate the inputs without checking signature

--- a/fuel-tx/src/transaction/validity.rs
+++ b/fuel-tx/src/transaction/validity.rs
@@ -431,10 +431,10 @@ where
         return Err(ValidityError::DuplicateInputContractId { contract_id });
     }
 
-    // Check for duplicated input message id
-    let duplicated_message_id = tx.inputs().iter().filter_map(Input::message_id);
-    if let Some(message_id) = next_duplicate(duplicated_message_id) {
-        return Err(ValidityError::DuplicateMessageInputId { message_id });
+    // Check for duplicated input nonce
+    let duplicated_nonce = tx.inputs().iter().filter_map(Input::nonce);
+    if let Some(nonce) = next_duplicate(duplicated_nonce).copied() {
+        return Err(ValidityError::DuplicateMessageInputId { nonce });
     }
 
     // Validate the inputs without checking signature

--- a/fuel-tx/src/transaction/validity/error.rs
+++ b/fuel-tx/src/transaction/validity/error.rs
@@ -49,7 +49,7 @@ pub enum ValidityError {
     DuplicateInputUtxoId {
         utxo_id: UtxoId,
     },
-    DuplicateMessageInputId {
+    DuplicateInputNonce {
         nonce: Nonce,
     },
     DuplicateInputContractId {

--- a/fuel-tx/src/transaction/validity/error.rs
+++ b/fuel-tx/src/transaction/validity/error.rs
@@ -2,7 +2,7 @@ use crate::UtxoId;
 use fuel_types::{
     AssetId,
     ContractId,
-    MessageId,
+    Nonce,
 };
 
 /// The error returned during the checking of the transaction's validity rules.
@@ -50,7 +50,7 @@ pub enum ValidityError {
         utxo_id: UtxoId,
     },
     DuplicateMessageInputId {
-        message_id: MessageId,
+        nonce: Nonce,
     },
     DuplicateInputContractId {
         contract_id: ContractId,


### PR DESCRIPTION
Comparing the `nonce` of two messages inputs if enough to decide if they are duplicated or not. Previously we were computing the `message_id` now we avoid this computation and only compare the `nonce`.

It requires us to change the error variant to include `nonce` instead of `message_id`. Because the type of the content has change it's already breaking and so we can change the name also to match this type.

### Breaking

#### Before 
```rust
enum ValidityError {
  DuplicateMessageInputId {
        message_id: MessageId,
  },
  ...
}
```

#### After
```rust
enum ValidityError {
  DuplicateInputNonce {
        nonce: Nonce,
  },
  ...
}
```

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
