### PR TITLE
fix: deprecation message

### DIFF
--- a/.npm/.scripts/template/src/index.js
+++ b/.npm/.scripts/template/src/index.js
@@ -2,7 +2,7 @@ import init from './{{NAME_UNDERSCORED}}.js'
 import wasm from './{{NAME_UNDERSCORED}}_bg.wasm'
 
 export async function initWasm () {
-  return await init(wasm());
+  return await init({ module_or_path: wasm() });
 }
 
 /**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [895](https://github.com/FuelLabs/fuel-vm/pull/895): Fix elided lifetimes compilation warnings that became errors after the release of rust 1.83.0. 
 - [895](https://github.com/FuelLabs/fuel-vm/pull/895): Bump proptest-derive to version `0.5.1` to fix non-local impl errors on the derivation of `proptest_derive::Arbitrary` introduced by rust 1.83.0. 
 - [889](https://github.com/FuelLabs/fuel-vm/pull/889): Debugger breakpoint caused receipts to be produced incorrectly.
+- [903](https://github.com/FuelLabs/fuel-vm/pull/903): Fixed warning being emitted when using packages with Node@22+.
 
 ## [Version 0.59.1]
 


### PR DESCRIPTION
Related to: https://github.com/FuelLabs/fuels-ts/issues/3482

## Summary

Passing the `module_or_path` directly is deprecated, it now expects an object with the `module_or_path` key ([reference](https://github.com/rustwasm/wasm-bindgen/blob/c35cc9369d5e0dc418986f7811a0dd702fb33ef9/crates/cli/tests/reference/targets-1.d.ts#L25-L34)).

### Reproduction

- Using `node@22` on `master`, [build and test](https://github.com/FuelLabs/fuel-vm/blob/a53fc36c58daaa0ca7f6b08b29439799af0d6c6f/.npm/README.md?plain=1#L32-L48) and you'll encounter the following warning:
  > using deprecated parameters for the initialization function; pass a single object instead

- Using `node@22` on `ps/fix/deprecation-warning`, build and test, the error should not be present.

## Checklist
- [X] Breaking changes are clearly marked as such in the PR description and changelog
- [X] New behavior is reflected in tests
- [X] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
- [X] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [X] I have reviewed the code myself
- [X] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

- [ ] [Typescript SDK](https://github.com/FuelLabs/fuels-ts/)