### PR TITLE
Remove unnecessary return values from Storage{Read, Write} methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking
 - [900](https://github.com/FuelLabs/fuel-vm/pull/900): Change the error variant `DuplicateMessageInputId` to `DuplicateInputNonce` which now contains a nonce instead of `MessageId` for performance improvements.
+- [907](https://github.com/FuelLabs/fuel-vm/pull/907): `StorageRead` and `StorageWrite` traits no longer return the number of bytes written. They already required that the whole buffer is used, but now this is reflected in signature and documentation as well.
 
 ### Fixed
 - [895](https://github.com/FuelLabs/fuel-vm/pull/895): Fix elided lifetimes compilation warnings that became errors after the release of rust 1.83.0. 

--- a/fuel-storage/src/impls.rs
+++ b/fuel-storage/src/impls.rs
@@ -273,11 +273,7 @@ where
     T: StorageWrite<Type>,
 {
     #[inline(always)]
-    pub fn write_bytes(
-        &mut self,
-        key: &Type::Key,
-        buf: &[u8],
-    ) -> Result<(), T::Error> {
+    pub fn write_bytes(&mut self, key: &Type::Key, buf: &[u8]) -> Result<(), T::Error> {
         StorageWrite::write_bytes(self.0, key, buf)
     }
 

--- a/fuel-storage/src/impls.rs
+++ b/fuel-storage/src/impls.rs
@@ -99,7 +99,7 @@ impl<T: StorageRead<Type> + StorageSize<Type> + ?Sized, Type: Mappable> StorageR
         key: &<Type as Mappable>::Key,
         offset: usize,
         buf: &mut [u8],
-    ) -> Result<Option<usize>, Self::Error> {
+    ) -> Result<bool, Self::Error> {
         <T as StorageRead<Type>>::read(self, key, offset, buf)
     }
 
@@ -119,7 +119,7 @@ impl<T: StorageRead<Type> + StorageSize<Type> + ?Sized, Type: Mappable> StorageR
         key: &<Type as Mappable>::Key,
         offset: usize,
         buf: &mut [u8],
-    ) -> Result<Option<usize>, Self::Error> {
+    ) -> Result<bool, Self::Error> {
         <T as StorageRead<Type>>::read(self, key, offset, buf)
     }
 
@@ -132,7 +132,7 @@ impl<T: StorageRead<Type> + StorageSize<Type> + ?Sized, Type: Mappable> StorageR
 }
 
 impl<T: StorageWrite<Type> + ?Sized, Type: Mappable> StorageWrite<Type> for &'_ mut T {
-    fn write_bytes(&mut self, key: &Type::Key, buf: &[u8]) -> Result<usize, Self::Error> {
+    fn write_bytes(&mut self, key: &Type::Key, buf: &[u8]) -> Result<(), Self::Error> {
         <T as StorageWrite<Type>>::write_bytes(self, key, buf)
     }
 
@@ -140,7 +140,7 @@ impl<T: StorageWrite<Type> + ?Sized, Type: Mappable> StorageWrite<Type> for &'_ 
         &mut self,
         key: &Type::Key,
         buf: &[u8],
-    ) -> Result<(usize, Option<Vec<u8>>), Self::Error> {
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
         <T as StorageWrite<Type>>::replace_bytes(self, key, buf)
     }
 
@@ -197,7 +197,7 @@ impl<T: StorageRead<Type>, Type: Mappable> StorageRef<'_, T, Type> {
         key: &<Type as Mappable>::Key,
         offset: usize,
         buf: &mut [u8],
-    ) -> Result<Option<usize>, T::Error> {
+    ) -> Result<bool, T::Error> {
         self.0.read(key, offset, buf)
     }
 
@@ -277,7 +277,7 @@ where
         &mut self,
         key: &Type::Key,
         buf: &[u8],
-    ) -> Result<usize, T::Error> {
+    ) -> Result<(), T::Error> {
         StorageWrite::write_bytes(self.0, key, buf)
     }
 
@@ -286,7 +286,7 @@ where
         &mut self,
         key: &Type::Key,
         buf: &[u8],
-    ) -> Result<(usize, Option<Vec<u8>>), T::Error>
+    ) -> Result<Option<Vec<u8>>, T::Error>
     where
         T: StorageSize<Type>,
     {

--- a/fuel-vm/src/interpreter/diff/storage.rs
+++ b/fuel-vm/src/interpreter/diff/storage.rs
@@ -371,7 +371,7 @@ where
         key: &<Type as Mappable>::Key,
         offset: usize,
         buf: &mut [u8],
-    ) -> Result<Option<usize>, Self::Error> {
+    ) -> Result<bool, Self::Error> {
         <S as StorageRead<Type>>::read(&self.0, key, offset, buf)
     }
 
@@ -418,7 +418,7 @@ where
     S: StorageWrite<Type>,
     S: InterpreterStorage,
 {
-    fn write_bytes(&mut self, key: &Type::Key, buf: &[u8]) -> Result<usize, Self::Error> {
+    fn write_bytes(&mut self, key: &Type::Key, buf: &[u8]) -> Result<(), Self::Error> {
         <S as StorageWrite<Type>>::write_bytes(&mut self.0, key, buf)
     }
 
@@ -426,7 +426,7 @@ where
         &mut self,
         key: &Type::Key,
         buf: &[u8],
-    ) -> Result<(usize, Option<Vec<u8>>), Self::Error> {
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
         <S as StorageWrite<Type>>::replace_bytes(&mut self.0, key, buf)
     }
 

--- a/fuel-vm/src/interpreter/flow.rs
+++ b/fuel-vm/src/interpreter/flow.rs
@@ -639,9 +639,10 @@ where
     if !storage
         .storage::<ContractsRawCode>()
         .read(contract, 0, dst)
-        .map_err(RuntimeError::Storage)? {
-            return Err(PanicReason::ContractNotFound.into());
-        }
+        .map_err(RuntimeError::Storage)?
+    {
+        return Err(PanicReason::ContractNotFound.into());
+    }
     Ok(())
 }
 

--- a/fuel-vm/src/interpreter/flow.rs
+++ b/fuel-vm/src/interpreter/flow.rs
@@ -636,14 +636,12 @@ fn read_contract<S>(
 where
     S: StorageSize<ContractsRawCode> + StorageRead<ContractsRawCode> + StorageAsRef,
 {
-    let bytes_read = storage
+    if !storage
         .storage::<ContractsRawCode>()
         .read(contract, 0, dst)
-        .map_err(RuntimeError::Storage)?
-        .ok_or(PanicReason::ContractNotFound)?;
-    if bytes_read != dst.len() {
-        return Err(PanicReason::ContractMismatch.into())
-    }
+        .map_err(RuntimeError::Storage)? {
+            return Err(PanicReason::ContractNotFound.into());
+        }
     Ok(())
 }
 

--- a/fuel-vm/src/storage/interpreter.rs
+++ b/fuel-vm/src/storage/interpreter.rs
@@ -210,12 +210,11 @@ pub trait InterpreterStorage:
         key: &Bytes32,
         value: &[u8],
     ) -> Result<Option<Vec<u8>>, Self::DataError> {
-        let (_, prev) = StorageWrite::<ContractsState>::replace_bytes(
+        StorageWrite::<ContractsState>::replace_bytes(
             self,
             &(contract, key).into(),
             value,
-        )?;
-        Ok(prev)
+        )
     }
 
     /// Fetch a range of values from a key-value mapping in a contract storage.

--- a/fuel-vm/src/storage/predicate.rs
+++ b/fuel-vm/src/storage/predicate.rs
@@ -139,12 +139,7 @@ impl StorageSize<BlobData> for EmptyStorage {
 }
 
 impl StorageRead<BlobData> for EmptyStorage {
-    fn read(
-        &self,
-        _: &BlobId,
-        _: usize,
-        _: &mut [u8],
-    ) -> Result<bool, Self::Error> {
+    fn read(&self, _: &BlobId, _: usize, _: &mut [u8]) -> Result<bool, Self::Error> {
         Err(Self::Error::UnsupportedStorageOperation)
     }
 

--- a/fuel-vm/src/storage/predicate.rs
+++ b/fuel-vm/src/storage/predicate.rs
@@ -144,7 +144,7 @@ impl StorageRead<BlobData> for EmptyStorage {
         _: &BlobId,
         _: usize,
         _: &mut [u8],
-    ) -> Result<Option<usize>, Self::Error> {
+    ) -> Result<bool, Self::Error> {
         Err(Self::Error::UnsupportedStorageOperation)
     }
 
@@ -248,7 +248,7 @@ impl<D> StorageRead<ContractsRawCode> for PredicateStorage<D> {
         _key: &<ContractsRawCode as Mappable>::Key,
         _offset: usize,
         _buf: &mut [u8],
-    ) -> Result<Option<usize>, Self::Error> {
+    ) -> Result<bool, Self::Error> {
         Err(Self::Error::UnsupportedStorageOperation)
     }
 
@@ -265,7 +265,7 @@ impl<D> StorageWrite<ContractsRawCode> for PredicateStorage<D> {
         &mut self,
         _key: &<ContractsRawCode as Mappable>::Key,
         _buf: &[u8],
-    ) -> Result<usize, Self::Error> {
+    ) -> Result<(), Self::Error> {
         Err(Self::Error::UnsupportedStorageOperation)
     }
 
@@ -273,7 +273,7 @@ impl<D> StorageWrite<ContractsRawCode> for PredicateStorage<D> {
         &mut self,
         _key: &<ContractsRawCode as Mappable>::Key,
         _buf: &[u8],
-    ) -> Result<(usize, Option<Vec<u8>>), Self::Error> {
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
         Err(Self::Error::UnsupportedStorageOperation)
     }
 
@@ -300,7 +300,7 @@ impl<D> StorageRead<ContractsState> for PredicateStorage<D> {
         _key: &<ContractsState as Mappable>::Key,
         _offset: usize,
         _buf: &mut [u8],
-    ) -> Result<Option<usize>, Self::Error> {
+    ) -> Result<bool, Self::Error> {
         Err(Self::Error::UnsupportedStorageOperation)
     }
 
@@ -317,7 +317,7 @@ impl<D> StorageWrite<ContractsState> for PredicateStorage<D> {
         &mut self,
         _key: &<ContractsState as Mappable>::Key,
         _buf: &[u8],
-    ) -> Result<usize, Self::Error> {
+    ) -> Result<(), Self::Error> {
         Err(Self::Error::UnsupportedStorageOperation)
     }
 
@@ -325,7 +325,7 @@ impl<D> StorageWrite<ContractsState> for PredicateStorage<D> {
         &mut self,
         _key: &<ContractsState as Mappable>::Key,
         _buf: &[u8],
-    ) -> Result<(usize, Option<Vec<u8>>), Self::Error> {
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
         Err(Self::Error::UnsupportedStorageOperation)
     }
 
@@ -359,7 +359,7 @@ where
         key: &<BlobData as Mappable>::Key,
         offset: usize,
         buf: &mut [u8],
-    ) -> Result<Option<usize>, Self::Error> {
+    ) -> Result<bool, Self::Error> {
         StorageRead::<BlobData>::read(&self.storage, key, offset, buf)
             .map_err(|e| Self::Error::StorageError(D::storage_error_to_string(e)))
     }
@@ -381,7 +381,7 @@ where
         &mut self,
         _key: &<BlobData as Mappable>::Key,
         _buf: &[u8],
-    ) -> Result<usize, Self::Error> {
+    ) -> Result<(), Self::Error> {
         Err(Self::Error::UnsupportedStorageOperation)
     }
 
@@ -389,7 +389,7 @@ where
         &mut self,
         _key: &<BlobData as Mappable>::Key,
         _buf: &[u8],
-    ) -> Result<(usize, Option<Vec<u8>>), Self::Error> {
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
         Err(Self::Error::UnsupportedStorageOperation)
     }
 


### PR DESCRIPTION
When reviewing this fix https://github.com/FuelLabs/fuel-core/pull/2673, it became apparent that the return values from StorageRead and StorageWrite traits are not useful and quite misleading. We require the target buffer to be filled completely, which means the caller already knows the number of bytes written after successful invocation.

The PR removes the return values indicating number of bytes written. It's a breaking change, but the fix on caller side is simple and likely affects fuel-core and execution-tracing only.


## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here
