### PR TITLE
Bugfix: more receipt generation issues with debugger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - [895](https://github.com/FuelLabs/fuel-vm/pull/895): Fix elided lifetimes compilation warnings that became errors after the release of rust 1.83.0. 
 - [895](https://github.com/FuelLabs/fuel-vm/pull/895): Bump proptest-derive to version `0.5.1` to fix non-local impl errors on the derivation of `proptest_derive::Arbitrary` introduced by rust 1.83.0. 
-- [889](https://github.com/FuelLabs/fuel-vm/pull/889): Debugger breakpoint caused receipts to be produced incorrectly.
+- [889](https://github.com/FuelLabs/fuel-vm/pull/889) and [908](https://github.com/FuelLabs/fuel-vm/pull/908): Debugger breakpoint caused receipts to be produced incorrectly.
 - [903](https://github.com/FuelLabs/fuel-vm/pull/903): Fixed warning being emitted when using packages with Node@22+.
 
 ## [Version 0.59.1]

--- a/fuel-vm/src/interpreter/executors/main.rs
+++ b/fuel-vm/src/interpreter/executors/main.rs
@@ -958,7 +958,7 @@ where
     pub(crate) fn run_program(
         &mut self,
     ) -> Result<ProgramState, InterpreterError<S::DataError>> {
-        let Some(script) = self.transaction().as_script() else {
+        let Some(script) = self.tx.as_script() else {
             unreachable!("Only `Script` transactions can be executed inside of the VM")
         };
         let gas_limit = *script.script_gas_limit();
@@ -1045,7 +1045,11 @@ where
             gas_price,
         )?;
         self.update_transaction_outputs()?;
-        *self.tx.as_script_mut().unwrap().receipts_root_mut() = self.receipts.root();
+
+        let Some(script) = self.tx.as_script_mut() else {
+            unreachable!("This is checked to hold in the beginning of this function");
+        };
+        *script.receipts_root_mut() = self.receipts.root();
 
         Ok(state)
     }

--- a/fuel-vm/src/interpreter/executors/main.rs
+++ b/fuel-vm/src/interpreter/executors/main.rs
@@ -909,6 +909,7 @@ where
                 &base_asset_id,
                 gas_price,
             )?;
+            self.update_transaction_outputs()?;
             ProgramState::Return(1)
         } else if let Some(upgrade) = self.tx.as_upgrade_mut() {
             Self::upgrade_inner(
@@ -920,6 +921,7 @@ where
                 &base_asset_id,
                 gas_price,
             )?;
+            self.update_transaction_outputs()?;
             ProgramState::Return(1)
         } else if let Some(upload) = self.tx.as_upload_mut() {
             Self::upload_inner(
@@ -931,6 +933,7 @@ where
                 &base_asset_id,
                 gas_price,
             )?;
+            self.update_transaction_outputs()?;
             ProgramState::Return(1)
         } else if let Some(blob) = self.tx.as_blob_mut() {
             Self::blob_inner(
@@ -942,13 +945,12 @@ where
                 &base_asset_id,
                 gas_price,
             )?;
+            self.update_transaction_outputs()?;
             ProgramState::Return(1)
         } else {
-            // `Interpreter` supports only `Create` and `Script` transactions. It is not
-            // `Create` -> it is `Script`.
+            // This must be a `Script`.
             self.run_program()?
         };
-        self.update_transaction_outputs()?;
 
         Ok(state)
     }
@@ -1042,15 +1044,10 @@ where
             &self.balances,
             gas_price,
         )?;
+        self.update_transaction_outputs()?;
+        *self.tx.as_script_mut().unwrap().receipts_root_mut() = self.receipts.root();
 
         Ok(state)
-    }
-
-    /// Update tx fields after execution
-    pub(crate) fn post_execute(&mut self) {
-        if let Some(script) = self.tx.as_script_mut() {
-            *script.receipts_root_mut() = self.receipts.root();
-        }
     }
 }
 
@@ -1073,7 +1070,6 @@ where
         self.verify_ready_tx(&tx)?;
 
         let state_result = self.init_script(tx).and_then(|_| self.run());
-        self.post_execute();
 
         #[cfg(feature = "profile-any")]
         {

--- a/fuel-vm/src/interpreter/internal.rs
+++ b/fuel-vm/src/interpreter/internal.rs
@@ -80,7 +80,7 @@ pub(crate) fn absolute_output_mem_range<Tx: Outputs>(
 }
 
 pub(crate) fn update_memory_output<Tx: ExecutableTransaction>(
-    tx: &mut Tx,
+    tx: &Tx,
     memory: &mut MemoryInstance,
     tx_offset: usize,
     idx: usize,
@@ -89,8 +89,8 @@ pub(crate) fn update_memory_output<Tx: ExecutableTransaction>(
         .ok_or(PanicReason::OutputNotFound)?;
     let mut mem = memory.write_noownerchecks(range.start, range.len())?;
     let output = tx
-        .outputs_mut()
-        .get_mut(idx)
+        .outputs()
+        .get(idx)
         .expect("Invalid output index; checked above");
     output
         .encode(&mut mem)

--- a/fuel-vm/src/interpreter/internal.rs
+++ b/fuel-vm/src/interpreter/internal.rs
@@ -43,7 +43,7 @@ where
 {
     pub(crate) fn update_memory_output(&mut self, idx: usize) -> SimpleResult<()> {
         let tx_offset = self.tx_offset();
-        update_memory_output(&mut self.tx, self.memory.as_mut(), tx_offset, idx)
+        update_memory_output(&self.tx, self.memory.as_mut(), tx_offset, idx)
     }
 }
 

--- a/fuel-vm/src/interpreter/internal/message_tests.rs
+++ b/fuel-vm/src/interpreter/internal/message_tests.rs
@@ -61,7 +61,7 @@ fn test_update_memory_output(tx_offset: usize) -> SimpleResult<MemoryInstance> {
     *tx.policies_mut() = Policies::default();
     *tx.outputs_mut() = vec![Output::default()];
     let mut memory: MemoryInstance = vec![0; MEM_SIZE].try_into().unwrap();
-    update_memory_output(&mut tx, &mut memory, tx_offset, 0).map(|_| memory)
+    update_memory_output(&tx, &mut memory, tx_offset, 0).map(|_| memory)
 }
 
 fn check_memory(result: MemoryInstance, expected: &[(usize, Vec<u8>)]) {

--- a/fuel-vm/src/tests/debugger.rs
+++ b/fuel-vm/src/tests/debugger.rs
@@ -8,6 +8,7 @@ use fuel_asm::{
     RegId,
 };
 use fuel_tx::{
+    field::ReceiptsRoot,
     ConsensusParameters,
     Finalizable,
     GasCosts,
@@ -47,6 +48,7 @@ fn receipts_are_produced_correctly_with_stepping() {
     let mut vm = Interpreter::<_, _, Script>::with_memory_storage();
     vm.transact(tx.clone()).expect("panicked");
     let receipts_without_debugger = vm.receipts().to_vec();
+    let receipts_root_without_debugger = vm.transaction().receipts_root();
 
     let mut vm = Interpreter::<_, _, Script>::with_memory_storage();
     vm.set_single_stepping(true);
@@ -67,6 +69,8 @@ fn receipts_are_produced_correctly_with_stepping() {
         }
     }
     let receipts_with_debugger = vm.receipts();
+    let receipts_root_with_debugger = vm.transaction().receipts_root();
 
     assert_eq!(receipts_without_debugger, receipts_with_debugger);
+    assert_eq!(receipts_root_without_debugger, receipts_root_with_debugger);
 }


### PR DESCRIPTION
While #889 fixed some receipt generation issues it missed regenerating receipts_root after the debugger is done. Also the in-memory outputs were updated too early.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here
