### PR TITLE
Add the `remove_recovery_id()` to `Signature`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - [896](https://github.com/FuelLabs/fuel-vm/pull/896): Expose `leaf_sum` and allow binary `MerkleTree` to be built from existing precomputed leafs.
+- [???](https://github.com/FuelLabs/fuel-vm/pull/???): Add the `remove_recovery_id()` to `Signature`.
 
 ### Breaking
 - [900](https://github.com/FuelLabs/fuel-vm/pull/900): Change the error variant `DuplicateMessageInputId` to `DuplicateInputNonce` which now contains a nonce instead of `MessageId` for performance improvements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - [896](https://github.com/FuelLabs/fuel-vm/pull/896): Expose `leaf_sum` and allow binary `MerkleTree` to be built from existing precomputed leafs.
-- [???](https://github.com/FuelLabs/fuel-vm/pull/???): Add the `remove_recovery_id()` to `Signature`.
+- [909](https://github.com/FuelLabs/fuel-vm/pull/909): Add the `remove_recovery_id()` to `Signature`.
 
 ### Breaking
 - [900](https://github.com/FuelLabs/fuel-vm/pull/900): Change the error variant `DuplicateMessageInputId` to `DuplicateInputNonce` which now contains a nonce instead of `MessageId` for performance improvements.

--- a/fuel-crypto/Cargo.toml
+++ b/fuel-crypto/Cargo.toml
@@ -31,6 +31,7 @@ bincode = { workspace = true }
 criterion = { workspace = true }
 fuel-crypto = { path = ".", features = ["random", "test-helpers"] }
 sha2 = "0.10"
+test-case = "3.3"
 
 [features]
 default = ["fuel-types/default", "std"]

--- a/fuel-crypto/src/secp256/signature.rs
+++ b/fuel-crypto/src/secp256/signature.rs
@@ -1,4 +1,7 @@
-use super::backend::k1;
+use super::{
+    backend::k1,
+    signature_format::decode_signature,
+};
 use crate::{
     Error,
     Message,
@@ -42,6 +45,12 @@ impl Signature {
         unsafe {
             &*(bytes.as_ptr() as *const Self)
         }
+    }
+
+    /// Removes the recovery id from the signature.
+    pub fn remove_recovery_id(&self) -> [u8; Self::LEN] {
+        let (signature, _recovery_id) = decode_signature(self.0.into());
+        signature
     }
 
     /// Kept temporarily for backwards compatibility.
@@ -135,5 +144,25 @@ impl Signature {
     /// Verify that a signature matches given public key
     pub fn verify(&self, public_key: &PublicKey, message: &Message) -> Result<(), Error> {
         k1::verify(*self.0, **public_key, message)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Signature;
+    use test_case::test_case;
+
+    #[test_case(0x00 => 0x00)]
+    #[test_case(0x7E => 0x7E)]
+    #[test_case(0x7F => 0x7F)]
+    #[test_case(0x80 => 0x00)]
+    #[test_case(0xFF => 0x7F)]
+    fn removes_recovery_id(s_byte: u8) -> u8 {
+        let mut sig_bytes = [0u8; 64];
+        sig_bytes[32..].fill(s_byte);
+
+        let signature = Signature::from_bytes(sig_bytes);
+        let without_recovery_id = signature.remove_recovery_id();
+        without_recovery_id[32]
     }
 }


### PR DESCRIPTION
This PR adds the `remove_recovery_id()` function to the `Signature`. Recovery ID must be removed from the signature in some use cases and this is done manually in `fuel-core`, for example [here](https://github.com/FuelLabs/fuel-core/blob/master/crates/services/shared-sequencer/src/lib.rs#L258-L260). Therefore, there will be a follow-up PR for the `fuel-core` created.

Closes: https://github.com/FuelLabs/fuel-vm/issues/886

## Checklist
- [X] New behavior is reflected in tests

### Before requesting review
- [X] I have reviewed the code myself