### PR TITLE
Add fix serailization/deserialization of Policies in compressed transactions to be backward compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- [910](https://github.com/FuelLabs/fuel-vm/pull/910): Fix serialization/deserialization of `Policies` in compressed transactions to be backward compatible.
+
 ## [Version 0.59.1]
 
 ### Fixed

--- a/fuel-tx/src/transaction/policies.rs
+++ b/fuel-tx/src/transaction/policies.rs
@@ -118,10 +118,6 @@ pub const POLICIES_NUMBER: usize = PoliciesBits::all().bits().count_ones() as us
 
 /// Container for managing policies.
 #[derive(Clone, Copy, Default, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(
-    feature = "da-compression",
-    derive(fuel_compression::Compress, fuel_compression::Decompress)
-)]
 #[cfg_attr(feature = "typescript", wasm_bindgen::prelude::wasm_bindgen)]
 pub struct Policies {
     /// A bitmask that indicates what policies are set.
@@ -532,6 +528,31 @@ impl<'de> serde::Deserialize<'de> for Policies {
                 lifetime: PhantomData,
             },
         )
+    }
+}
+
+#[cfg(feature = "da-compression")]
+impl fuel_compression::Compressible for Policies {
+    type Compressed = Policies;
+}
+
+#[cfg(feature = "da-compression")]
+impl<Ctx> fuel_compression::CompressibleBy<Ctx> for Policies
+where
+    Ctx: fuel_compression::ContextError,
+{
+    async fn compress_with(&self, _: &mut Ctx) -> Result<Self::Compressed, Ctx::Error> {
+        Ok(*self)
+    }
+}
+
+#[cfg(feature = "da-compression")]
+impl<Ctx> fuel_compression::DecompressibleBy<Ctx> for Policies
+where
+    Ctx: fuel_compression::ContextError,
+{
+    async fn decompress_with(c: Self::Compressed, _: &Ctx) -> Result<Self, Ctx::Error> {
+        Ok(c)
     }
 }
 

--- a/version-compatibility/Cargo.toml
+++ b/version-compatibility/Cargo.toml
@@ -8,4 +8,11 @@ publish = false
 [dev-dependencies]
 fuel-tx-0-58-2 = { package = "fuel-tx", version = "0.58.2", features = ["random", "test-helpers"] }
 latest-fuel-tx = { package = "fuel-tx", path = "../fuel-tx", features = ["random", "test-helpers"] }
+fuel-compression-0-58-2 = { package = "fuel-compression", version = "0.58.2" }
+latest-fuel-compression = { package = "fuel-compression", path = "../fuel-compression" }
 postcard = { version = "1.0", features = ["use-std"] }
+tokio = { version = "1.27", features = ["full"] }
+
+[features]
+default = ["da-compression"]
+da-compression = ["fuel-tx-0-58-2/da-compression", "latest-fuel-tx/da-compression"]

--- a/version-compatibility/Cargo.toml
+++ b/version-compatibility/Cargo.toml
@@ -6,10 +6,10 @@ license = "BUSL-1.1"
 publish = false
 
 [dev-dependencies]
-fuel-tx-0-58-2 = { package = "fuel-tx", version = "0.58.2", features = ["random", "test-helpers"] }
-latest-fuel-tx = { package = "fuel-tx", path = "../fuel-tx", features = ["random", "test-helpers"] }
 fuel-compression-0-58-2 = { package = "fuel-compression", version = "0.58.2" }
+fuel-tx-0-58-2 = { package = "fuel-tx", version = "0.58.2", features = ["random", "test-helpers"] }
 latest-fuel-compression = { package = "fuel-compression", path = "../fuel-compression" }
+latest-fuel-tx = { package = "fuel-tx", path = "../fuel-tx", features = ["random", "test-helpers"] }
 postcard = { version = "1.0", features = ["use-std"] }
 tokio = { version = "1.27", features = ["full"] }
 

--- a/version-compatibility/src/fuel_tx.rs
+++ b/version-compatibility/src/fuel_tx.rs
@@ -25,3 +25,178 @@ fn release_0_58_2_can_deserialize_latest() {
     // Then
     let _ = latest_tx.expect("Deserialization failed");
 }
+
+#[cfg(feature = "da-compression")]
+mod da_compression {
+    use std::convert::Infallible;
+
+    use fuel_compression_0_58_2::{
+        CompressibleBy as CompressibleBy_0_58_2,
+        RegistryKey as RegistryKey_0_58_2,
+    };
+    use latest_fuel_compression::{
+        CompressibleBy as LatestCompressibleBy,
+        RegistryKey as LatestRegistryKey,
+    };
+
+    use fuel_tx_0_58_2::{
+        input::PredicateCode as PredicateCode_0_58_2,
+        Address as Address_0_58_2,
+        AssetId as AssetId_0_58_2,
+        CompressedUtxoId as CompressedUtxoId_0_58_2,
+        ContractId as ContractId_0_58_2,
+        ScriptCode as ScriptCode_0_58_2,
+        TxPointer as TxPointer_0_58_2,
+        UtxoId as UtxoId_0_58_2,
+    };
+    use latest_fuel_tx::{
+        input::PredicateCode as LatestPredicateCode,
+        Address as LatestAddress,
+        AssetId as LatestAssetId,
+        CompressedUtxoId as LatestCompressedUtxoId,
+        ContractId as LatestContractId,
+        ScriptCode as LatestScriptCode,
+        TxPointer as LatestTxPointer,
+        UtxoId as LatestUtxoId,
+    };
+    struct TestContext;
+
+    impl latest_fuel_compression::ContextError for TestContext {
+        type Error = Infallible;
+    }
+
+    impl fuel_compression_0_58_2::ContextError for TestContext {
+        type Error = Infallible;
+    }
+
+    impl LatestCompressibleBy<TestContext> for LatestUtxoId {
+        async fn compress_with(
+            &self,
+            _ctx: &mut TestContext,
+        ) -> Result<LatestCompressedUtxoId, Infallible> {
+            let key = LatestCompressedUtxoId {
+                tx_pointer: LatestTxPointer::default(),
+                output_index: self.output_index(),
+            };
+            Ok(key)
+        }
+    }
+
+    impl LatestCompressibleBy<TestContext> for LatestAddress {
+        async fn compress_with(
+            &self,
+            _ctx: &mut TestContext,
+        ) -> Result<LatestRegistryKey, Infallible> {
+            Ok(LatestRegistryKey::DEFAULT_VALUE)
+        }
+    }
+
+    impl LatestCompressibleBy<TestContext> for LatestAssetId {
+        async fn compress_with(
+            &self,
+            _ctx: &mut TestContext,
+        ) -> Result<LatestRegistryKey, Infallible> {
+            Ok(LatestRegistryKey::DEFAULT_VALUE)
+        }
+    }
+
+    impl LatestCompressibleBy<TestContext> for LatestContractId {
+        async fn compress_with(
+            &self,
+            _ctx: &mut TestContext,
+        ) -> Result<LatestRegistryKey, Infallible> {
+            Ok(LatestRegistryKey::DEFAULT_VALUE)
+        }
+    }
+
+    impl LatestCompressibleBy<TestContext> for LatestScriptCode {
+        async fn compress_with(
+            &self,
+            _ctx: &mut TestContext,
+        ) -> Result<LatestRegistryKey, Infallible> {
+            Ok(LatestRegistryKey::DEFAULT_VALUE)
+        }
+    }
+
+    impl LatestCompressibleBy<TestContext> for LatestPredicateCode {
+        async fn compress_with(
+            &self,
+            _ctx: &mut TestContext,
+        ) -> Result<LatestRegistryKey, Infallible> {
+            Ok(LatestRegistryKey::DEFAULT_VALUE)
+        }
+    }
+
+    impl CompressibleBy_0_58_2<TestContext> for UtxoId_0_58_2 {
+        async fn compress_with(
+            &self,
+            _ctx: &mut TestContext,
+        ) -> Result<CompressedUtxoId_0_58_2, Infallible> {
+            let key = CompressedUtxoId_0_58_2 {
+                tx_pointer: TxPointer_0_58_2::default(),
+                output_index: self.output_index(),
+            };
+            Ok(key)
+        }
+    }
+
+    impl CompressibleBy_0_58_2<TestContext> for Address_0_58_2 {
+        async fn compress_with(
+            &self,
+            _ctx: &mut TestContext,
+        ) -> Result<RegistryKey_0_58_2, Infallible> {
+            Ok(RegistryKey_0_58_2::DEFAULT_VALUE)
+        }
+    }
+
+    impl CompressibleBy_0_58_2<TestContext> for AssetId_0_58_2 {
+        async fn compress_with(
+            &self,
+            _ctx: &mut TestContext,
+        ) -> Result<RegistryKey_0_58_2, Infallible> {
+            Ok(RegistryKey_0_58_2::DEFAULT_VALUE)
+        }
+    }
+
+    impl CompressibleBy_0_58_2<TestContext> for ContractId_0_58_2 {
+        async fn compress_with(
+            &self,
+            _ctx: &mut TestContext,
+        ) -> Result<RegistryKey_0_58_2, Infallible> {
+            Ok(RegistryKey_0_58_2::DEFAULT_VALUE)
+        }
+    }
+
+    impl CompressibleBy_0_58_2<TestContext> for ScriptCode_0_58_2 {
+        async fn compress_with(
+            &self,
+            _ctx: &mut TestContext,
+        ) -> Result<RegistryKey_0_58_2, Infallible> {
+            Ok(RegistryKey_0_58_2::DEFAULT_VALUE)
+        }
+    }
+
+    impl CompressibleBy_0_58_2<TestContext> for PredicateCode_0_58_2 {
+        async fn compress_with(
+            &self,
+            _ctx: &mut TestContext,
+        ) -> Result<RegistryKey_0_58_2, Infallible> {
+            Ok(RegistryKey_0_58_2::DEFAULT_VALUE)
+        }
+    }
+
+    #[tokio::test]
+    async fn release_0_58_2_can_deserialize_compressed_latest() {
+        // Given
+        let mut context = TestContext;
+        let tx = latest_fuel_tx::Transaction::default_test_tx();
+        let tx = tx.compress_with(&mut context).await.unwrap();
+        let bytes_latest = postcard::to_allocvec(&tx).unwrap();
+
+        let tx_0_58_2 = fuel_tx_0_58_2::Transaction::default_test_tx();
+        let tx_0_58_2 = tx_0_58_2.compress_with(&mut context).await.unwrap();
+        let bytes_0_58_2 = postcard::to_allocvec(&tx_0_58_2).unwrap();
+
+        assert_eq!(bytes_latest, bytes_0_58_2);
+    }
+}


### PR DESCRIPTION
We changed the `compress` `decompress` implementation to not be the default one which would lead to use the default serde implementation for each field. Instead we use a custom implementation that will use the custom serde implementations we have for `Policies`

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here

