### PR TITLE
Dry run mode: continue-on-error handling for "contract not in inputs" 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [896](https://github.com/FuelLabs/fuel-vm/pull/896): Expose `leaf_sum` and allow binary `MerkleTree` to be built from existing precomputed leafs.
 - [882](https://github.com/FuelLabs/fuel-vm/pull/882): Add a lot of new `GTFArgs` including generic ones that will replace old tx type specific.
 - [909](https://github.com/FuelLabs/fuel-vm/pull/909): Add the `remove_recovery_id()` to `Signature`.
-- [915](https://github.com/FuelLabs/fuel-vm/pull/915): Added support for `AttemptContinue` verifier, that collects and ignores some errors instead of terminating execution. This is mean to help with gathering tx dependencies.
+- [915](https://github.com/FuelLabs/fuel-vm/pull/915): Added support for `AttemptContinue` verifier, that collects and ignores some errors instead of terminating execution. This is meant to help with gathering tx dependencies.
 
 ### Breaking
 - [900](https://github.com/FuelLabs/fuel-vm/pull/900): Change the error variant `DuplicateMessageInputId` to `DuplicateInputNonce` which now contains a nonce instead of `MessageId` for performance improvements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [896](https://github.com/FuelLabs/fuel-vm/pull/896): Expose `leaf_sum` and allow binary `MerkleTree` to be built from existing precomputed leafs.
 - [882](https://github.com/FuelLabs/fuel-vm/pull/882): Add a lot of new `GTFArgs` including generic ones that will replace old tx type specific.
 - [909](https://github.com/FuelLabs/fuel-vm/pull/909): Add the `remove_recovery_id()` to `Signature`.
+- [915](https://github.com/FuelLabs/fuel-vm/pull/915): Added support for `AttemptContinue` verifier, that collects and ignores some errors instead of terminating execution. This is mean to help with gathering tx dependencies.
 
 ### Breaking
 - [900](https://github.com/FuelLabs/fuel-vm/pull/900): Change the error variant `DuplicateMessageInputId` to `DuplicateInputNonce` which now contains a nonce instead of `MessageId` for performance improvements.

--- a/fuel-vm/src/tests/continue_on_error.rs
+++ b/fuel-vm/src/tests/continue_on_error.rs
@@ -1,0 +1,83 @@
+use fuel_asm::op;
+use fuel_types::canonical::Serialize;
+use rand::Rng;
+
+use alloc::vec;
+
+use crate::{
+    prelude::*,
+    tests::test_helpers::{
+        assert_panics,
+        assert_success,
+    },
+};
+
+/// If we call a contract that exists but is not in inputs,
+/// we catch that, and the execution continues as if the contract was in inputs.
+#[test]
+fn calling_contract_not_in_inputs_will_collect_and_continue() {
+    let mut ctx = TestBuilder::new(2322u64);
+    let base_asset_id = ctx.rng.gen();
+
+    // Given
+    let contract_code = vec![
+        op::movi(0x10, 0x11),
+        op::movi(0x11, 0x2a),
+        op::add(0x12, 0x10, 0x11),
+        op::log(0x10, 0x11, 0x12, 0x00),
+        op::ret(0x20),
+    ];
+    let contract_id = ctx.setup_contract(contract_code, None, None).contract_id;
+
+    let script_code = vec![
+        op::gtf_args(0x10, RegId::ZERO, GTFArgs::ScriptData),
+        op::call(0x10, RegId::ZERO, RegId::ZERO, RegId::CGAS),
+        op::ret(RegId::ONE),
+    ];
+    let script_data = Call::new(contract_id, 0, 0).to_bytes();
+
+    // When
+    let (res, collected_errors) = ctx
+        .start_script(script_code, script_data)
+        .max_fee_limit(10_000)
+        .gas_price(0)
+        .base_asset_id(base_asset_id)
+        .coin_input(base_asset_id, 10_000)
+        .change_output(base_asset_id)
+        .script_gas_limit(10_000)
+        .attempt_execute();
+
+    // Then
+    assert_success(res.receipts());
+    assert_eq!(collected_errors.missing_contract_inputs, vec![contract_id]);
+}
+
+#[test]
+fn calling_nonexistent_contract_panics_normally() {
+    let mut ctx = TestBuilder::new(2322u64);
+    let base_asset_id = ctx.rng.gen();
+
+    // Given
+    let nonexistent_contract_id = ctx.rng.gen();
+    let script_code = vec![
+        op::gtf_args(0x10, RegId::ZERO, GTFArgs::ScriptData),
+        op::call(0x10, RegId::ZERO, RegId::ZERO, RegId::CGAS),
+        op::ret(RegId::ONE),
+    ];
+    let script_data = Call::new(nonexistent_contract_id, 0, 0).to_bytes();
+
+    // When
+    let (res, collected_errors) = ctx
+        .start_script(script_code, script_data)
+        .max_fee_limit(10_000)
+        .gas_price(0)
+        .base_asset_id(base_asset_id)
+        .coin_input(base_asset_id, 10_000)
+        .change_output(base_asset_id)
+        .script_gas_limit(10_000)
+        .attempt_execute();
+
+    // Then
+    assert_panics(res.receipts(), PanicReason::ContractNotFound);
+    assert_eq!(collected_errors.missing_contract_inputs, vec![]);
+}

--- a/fuel-vm/src/tests/mod.rs
+++ b/fuel-vm/src/tests/mod.rs
@@ -14,6 +14,7 @@ mod blob;
 mod blockchain;
 mod cgas;
 mod coins;
+mod continue_on_error;
 mod contract;
 mod crypto;
 mod debugger;

--- a/fuel-vm/src/verification.rs
+++ b/fuel-vm/src/verification.rs
@@ -1,7 +1,12 @@
 //! Stategies for verifying the correctness of the VM execution.
 //! The default strategy, [`Normal`], simply returns an error on failed verification.
+//! Alternative strategy, [`AttemptContinue`], continues execution and collects multiple
+//! errors.
 
-use alloc::collections::BTreeSet;
+use alloc::{
+    collections::BTreeSet,
+    vec::Vec,
+};
 
 use fuel_tx::{
     ContractId,
@@ -59,3 +64,33 @@ where
 }
 
 impl Seal for Normal {}
+
+/// With some subset of errors it's possible to continue execution,
+/// allowing the collection of multiple errors during a single run.
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
+pub struct AttemptContinue {
+    /// Contracts that were called but not in the inputs
+    pub missing_contract_inputs: Vec<ContractId>,
+}
+
+impl Verifier for AttemptContinue
+where
+    Self: Sized,
+{
+    #[allow(private_interfaces)]
+    fn check_contract_in_inputs(
+        &mut self,
+        _panic_context: &mut PanicContext,
+        input_contracts: &BTreeSet<ContractId>,
+        contract_id: &ContractId,
+    ) -> Result<(), PanicOrBug> {
+        if !input_contracts.contains(contract_id) {
+            self.missing_contract_inputs.push(*contract_id);
+        }
+        Ok(())
+    }
+}
+
+impl Seal for AttemptContinue {}


### PR DESCRIPTION
~~Requires #918~~

Work towards #691

Adds a way to continue vm execution after each error instead of terminating immediately. This can be used to collect multiple execution errors at once, which is useful if you don't know in advance what storage, inputs or outputs the tx is going to need access to.

Names are still subject to bikeshedding.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [ ] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here
