### PR TITLE
Pin base64ct to non-MSRV-breaking version

### DIFF
--- a/fuel-crypto/Cargo.toml
+++ b/fuel-crypto/Cargo.toml
@@ -11,6 +11,7 @@ repository = { workspace = true }
 description = "Fuel cryptographic primitives."
 
 [dependencies]
+base64ct = "=1.6" # HACK: transitive dependency breaking MSRV requirement
 coins-bip32 = { version = "0.8", default-features = false, optional = true }
 coins-bip39 = { version = "0.8", default-features = false, features = ["english"], optional = true }
 ecdsa = { version = "0.16", default-features = false }

--- a/fuel-crypto/src/lib.rs
+++ b/fuel-crypto/src/lib.rs
@@ -15,6 +15,9 @@
     clippy::string_slice
 )]
 
+// Unused but needed for version pinning
+use base64ct as _;
+
 // Satisfy unused_crate_dependencies lint for self-dependency enabling test features
 #[cfg(test)]
 use fuel_crypto as _;


### PR DESCRIPTION
See https://github.com/RustCrypto/formats/issues/1684

Fixes CI breakage, for now. More issues like this are to be expected, unless we either pin all versions or update our MSRV to latest edition, which includes rust-version-aware resolver.