### PR TITLE
Make Interpreter::execute and friends generic over predicate-ness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.79.0
+  RUST_VERSION: 1.81.0
   RUST_VERSION_FMT: nightly-2024-02-07
   RUST_VERSION_COV: nightly-2024-06-05
   GIT_BRANCH: ${{ github.head_ref || github.ref_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [907](https://github.com/FuelLabs/fuel-vm/pull/907): `StorageRead` and `StorageWrite` traits no longer return the number of bytes written. They already required that the whole buffer is used, but now this is reflected in signature and documentation as well.
 - [914](https://github.com/FuelLabs/fuel-vm/pull/914): The built-in profiler is removed. Use the debugger with single-stepping instead.
 - [918](https://github.com/FuelLabs/fuel-vm/pull/918): Interpreter is now generic over the validation error handling. No behavioural changes, but the `Interpreter` has one extra type parameter.
+- [920](https://github.com/FuelLabs/fuel-vm/pull/920): `Interpreter::execute` and friends are now generic over predicateness of the context. This forces monomorphization so the predicate branch is optimized away on non-predicate execution.
 
 ### Changed
 - [904](https://github.com/FuelLabs/fuel-vm/pull/904): Moved the logic of each opcode into its own function. It helps so reduce the size of the `instruction_inner` function, allowing compiler to do better optimizations. The Mira swaps receive performance improvement in 16.5%.

--- a/fuel-vm/benches/execution.rs
+++ b/fuel-vm/benches/execution.rs
@@ -58,7 +58,7 @@ fn execution(c: &mut Criterion) {
     group_execution.bench_function("Infinite `meq` loop", |b| {
         b.iter(|| {
             for _ in 0..1000 {
-                let _ = interpreter.execute().unwrap();
+                let _ = interpreter.execute::<false>().unwrap();
             }
         })
     });
@@ -66,7 +66,7 @@ fn execution(c: &mut Criterion) {
     group_execution.bench_function("Infinite `meq` loop black box", |b| {
         b.iter(|| {
             for _ in 0..1000 {
-                black_box(interpreter.execute()).unwrap();
+                black_box(interpreter.execute::<false>()).unwrap();
             }
         })
     });
@@ -75,7 +75,7 @@ fn execution(c: &mut Criterion) {
         b.iter(|| {
             for _ in 0..1000 {
                 unsafe {
-                    let dummy = interpreter.execute().unwrap();
+                    let dummy = interpreter.execute::<false>().unwrap();
                     std::ptr::read_volatile(&dummy)
                 };
             }
@@ -103,7 +103,7 @@ fn execution(c: &mut Criterion) {
     group_execution.bench_function("Infinite `add` loop", |b| {
         b.iter(|| {
             for _ in 0..1000 {
-                let _ = interpreter.execute().unwrap();
+                let _ = interpreter.execute::<false>().unwrap();
             }
         })
     });
@@ -111,7 +111,7 @@ fn execution(c: &mut Criterion) {
     group_execution.bench_function("Infinite `add` loop black box", |b| {
         b.iter(|| {
             for _ in 0..1000 {
-                black_box(interpreter.execute()).unwrap();
+                black_box(interpreter.execute::<false>()).unwrap();
             }
         })
     });
@@ -120,7 +120,7 @@ fn execution(c: &mut Criterion) {
         b.iter(|| {
             for _ in 0..1000 {
                 unsafe {
-                    let dummy = interpreter.execute().unwrap();
+                    let dummy = interpreter.execute::<false>().unwrap();
                     std::ptr::read_volatile(&dummy)
                 };
             }
@@ -148,7 +148,7 @@ fn execution(c: &mut Criterion) {
     group_execution.bench_function("Infinite `not` loop", |b| {
         b.iter(|| {
             for _ in 0..1000 {
-                let _ = interpreter.execute().unwrap();
+                let _ = interpreter.execute::<false>().unwrap();
             }
         })
     });
@@ -156,7 +156,7 @@ fn execution(c: &mut Criterion) {
     group_execution.bench_function("Infinite `not` loop black box", |b| {
         b.iter(|| {
             for _ in 0..1000 {
-                black_box(interpreter.execute()).unwrap();
+                black_box(interpreter.execute::<false>()).unwrap();
             }
         })
     });
@@ -165,7 +165,7 @@ fn execution(c: &mut Criterion) {
         b.iter(|| {
             for _ in 0..1000 {
                 unsafe {
-                    let dummy = interpreter.execute().unwrap();
+                    let dummy = interpreter.execute::<false>().unwrap();
                     std::ptr::read_volatile(&dummy)
                 };
             }

--- a/fuel-vm/src/interpreter/diff/tests.rs
+++ b/fuel-vm/src/interpreter/diff/tests.rs
@@ -42,7 +42,9 @@ fn reset_vm_state() {
     let desired = Interpreter::<_, _, Script>::with_memory_storage();
     let mut latest = Interpreter::<_, _, Script>::with_memory_storage();
     latest.set_gas(1_000_000);
-    latest.instruction(op::addi(0x10, 0x11, 1)).unwrap();
+    latest
+        .instruction::<_, false>(op::addi(0x10, 0x11, 1))
+        .unwrap();
     let diff: Diff<InitialVmState> = latest.rollback_to(&desired).into();
     assert_ne!(desired, latest);
     latest.reset_vm_state(&diff);
@@ -75,7 +77,9 @@ fn record_and_invert_storage() {
     )
     .unwrap();
     latest.set_gas(1_000_000);
-    latest.instruction(op::addi(0x10, 0x11, 1)).unwrap();
+    latest
+        .instruction::<_, false>(op::addi(0x10, 0x11, 1))
+        .unwrap();
 
     let storage_diff: Diff<InitialVmState> = latest.storage_diff().into();
     let mut diff: Diff<InitialVmState> = latest.rollback_to(&desired).into();
@@ -95,7 +99,7 @@ fn record_and_invert_storage() {
     )
     .unwrap();
     d.set_gas(1_000_000);
-    d.instruction(op::addi(0x10, 0x11, 1)).unwrap();
+    d.instruction::<_, false>(op::addi(0x10, 0x11, 1)).unwrap();
 
     assert_ne!(c, d);
     d.reset_vm_state(&diff);

--- a/fuel-vm/src/interpreter/executors/instruction.rs
+++ b/fuel-vm/src/interpreter/executors/instruction.rs
@@ -61,10 +61,13 @@ where
     }
 
     /// Execute a provided instruction
-    pub fn instruction<R: Into<RawInstruction> + Copy, const PREDICATE: bool>(
+    pub fn instruction<R, const PREDICATE: bool>(
         &mut self,
         raw: R,
-    ) -> Result<ExecuteState, InterpreterError<S::DataError>> {
+    ) -> Result<ExecuteState, InterpreterError<S::DataError>>
+    where
+        R: Into<RawInstruction> + Copy,
+    {
         let raw = raw.into();
         let raw = raw.to_be_bytes();
 

--- a/fuel-vm/src/interpreter/executors/instruction/tests/reserved_registers.rs
+++ b/fuel-vm/src/interpreter/executors/instruction/tests/reserved_registers.rs
@@ -79,7 +79,7 @@ fn cant_write_to_reserved_registers(raw_random_instruction: u32) -> TestResult {
         .expect("failed dynamic checks");
 
     vm.init_script(tx).expect("Failed to init VM");
-    let res = vm.instruction(raw_random_instruction);
+    let res = vm.instruction::<_, false>(raw_random_instruction);
 
     if writes_to_ra(opcode) || writes_to_rb(opcode) {
         // if this opcode writes to $rA or $rB, expect an error since we're attempting to

--- a/fuel-vm/src/interpreter/executors/main.rs
+++ b/fuel-vm/src/interpreter/executors/main.rs
@@ -981,7 +981,7 @@ where
                 // Check whether the instruction will be executed in a call context
                 let in_call = !self.frames.is_empty();
 
-                match self.execute() {
+                match self.execute::<true>() {
                     // Proceeding with the execution normally
                     Ok(ExecuteState::Proceed) => continue,
                     // Debugger events are returned directly to the caller

--- a/fuel-vm/src/interpreter/executors/main.rs
+++ b/fuel-vm/src/interpreter/executors/main.rs
@@ -981,7 +981,7 @@ where
                 // Check whether the instruction will be executed in a call context
                 let in_call = !self.frames.is_empty();
 
-                match self.execute::<true>() {
+                match self.execute::<false>() {
                     // Proceeding with the execution normally
                     Ok(ExecuteState::Proceed) => continue,
                     // Debugger events are returned directly to the caller

--- a/fuel-vm/src/interpreter/executors/predicate.rs
+++ b/fuel-vm/src/interpreter/executors/predicate.rs
@@ -30,7 +30,7 @@ where
         &mut self,
     ) -> Result<ProgramState, PredicateVerificationFailed> {
         loop {
-            match self.execute()? {
+            match self.execute::<false>()? {
                 ExecuteState::Return(r) => {
                     if r == 1 {
                         return Ok(ProgramState::Return(r))

--- a/fuel-vm/src/interpreter/executors/predicate.rs
+++ b/fuel-vm/src/interpreter/executors/predicate.rs
@@ -30,7 +30,7 @@ where
         &mut self,
     ) -> Result<ProgramState, PredicateVerificationFailed> {
         loop {
-            match self.execute::<false>()? {
+            match self.execute::<true>()? {
                 ExecuteState::Return(r) => {
                     if r == 1 {
                         return Ok(ProgramState::Return(r))

--- a/fuel-vm/src/interpreter/internal.rs
+++ b/fuel-vm/src/interpreter/internal.rs
@@ -111,10 +111,6 @@ where
         &self.context
     }
 
-    pub(crate) const fn is_predicate(&self) -> bool {
-        self.context.is_predicate()
-    }
-
     pub(crate) fn internal_contract(&self) -> Result<ContractId, PanicReason> {
         internal_contract(&self.context, self.registers.fp(), self.memory.as_ref())
     }

--- a/fuel-vm/src/interpreter/memory/tests.rs
+++ b/fuel-vm/src/interpreter/memory/tests.rs
@@ -48,45 +48,51 @@ fn memcopy() {
     let alloc = 1024;
 
     // r[0x10] := 1024
-    vm.instruction(op::addi(0x10, RegId::ZERO, alloc)).unwrap();
-    vm.instruction(op::aloc(0x10)).unwrap();
+    vm.instruction::<_, false>(op::addi(0x10, RegId::ZERO, alloc))
+        .unwrap();
+    vm.instruction::<_, false>(op::aloc(0x10)).unwrap();
 
     // r[0x20] := 128
-    vm.instruction(op::addi(0x20, RegId::ZERO, 128)).unwrap();
+    vm.instruction::<_, false>(op::addi(0x20, RegId::ZERO, 128))
+        .unwrap();
 
     for i in 0..alloc {
-        vm.instruction(op::addi(0x21, RegId::ZERO, i)).unwrap();
-        vm.instruction(op::sb(RegId::HP, 0x21, i as Immediate12))
+        vm.instruction::<_, false>(op::addi(0x21, RegId::ZERO, i))
+            .unwrap();
+        vm.instruction::<_, false>(op::sb(RegId::HP, 0x21, i as Immediate12))
             .unwrap();
     }
 
     // r[0x23] := m[$hp, 0x20] == m[$zero, 0x20]
-    vm.instruction(op::meq(0x23, RegId::HP, RegId::ZERO, 0x20))
+    vm.instruction::<_, false>(op::meq(0x23, RegId::HP, RegId::ZERO, 0x20))
         .unwrap();
 
     assert_eq!(0, vm.registers()[0x23]);
 
     // r[0x12] := $hp + r[0x20]
-    vm.instruction(op::add(0x12, RegId::HP, 0x20)).unwrap();
+    vm.instruction::<_, false>(op::add(0x12, RegId::HP, 0x20))
+        .unwrap();
 
     // Test ownership
-    vm.instruction(op::mcp(RegId::HP, 0x12, 0x20)).unwrap();
+    vm.instruction::<_, false>(op::mcp(RegId::HP, 0x12, 0x20))
+        .unwrap();
 
     // r[0x23] := m[0x30, 0x20] == m[0x12, 0x20]
-    vm.instruction(op::meq(0x23, RegId::HP, 0x12, 0x20))
+    vm.instruction::<_, false>(op::meq(0x23, RegId::HP, 0x12, 0x20))
         .unwrap();
 
     assert_eq!(1, vm.registers()[0x23]);
 
     // Assert ownership
-    vm.instruction(op::subi(0x24, RegId::HP, 1)).unwrap(); // TODO: look into this
-    let ownership_violated = vm.instruction(op::mcp(0x24, 0x12, 0x20));
+    vm.instruction::<_, false>(op::subi(0x24, RegId::HP, 1))
+        .unwrap(); // TODO: look into this
+    let ownership_violated = vm.instruction::<_, false>(op::mcp(0x24, 0x12, 0x20));
 
     assert!(ownership_violated.is_err());
 
     // Assert no panic on overlapping
-    vm.instruction(op::subi(0x25, 0x12, 1)).unwrap();
-    let overlapping = vm.instruction(op::mcp(RegId::HP, 0x25, 0x20));
+    vm.instruction::<_, false>(op::subi(0x25, 0x12, 1)).unwrap();
+    let overlapping = vm.instruction::<_, false>(op::mcp(RegId::HP, 0x25, 0x20));
 
     assert!(overlapping.is_err());
 }
@@ -112,11 +118,12 @@ fn stack_alloc_ownership() {
         .unwrap();
     vm.init_script(tx).expect("Failed to init VM");
 
-    vm.instruction(op::move_(0x10, RegId::SP)).unwrap();
-    vm.instruction(op::cfei(2)).unwrap();
+    vm.instruction::<_, false>(op::move_(0x10, RegId::SP))
+        .unwrap();
+    vm.instruction::<_, false>(op::cfei(2)).unwrap();
 
     // Assert allocated stack is writable
-    vm.instruction(op::mcli(0x10, 2)).unwrap();
+    vm.instruction::<_, false>(op::mcli(0x10, 2)).unwrap();
 }
 
 #[test_case(


### PR DESCRIPTION
Force monomorphization of the execute family of functions over predicate vs non-predicate execution. This allows optimizing a branch from the hot VM main loop.

Originally from https://github.com/FuelLabs/fuel-core/pull/2767#issuecomment-2686153439.

Also bumps Rust version in CI to 1.81.0.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [ ] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here
