### PR TITLE
Release v0.60.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.60.0]
+
 ### Added
 - [901](https://github.com/FuelLabs/fuel-vm/pull/901): Add `Display` implementation to `Receipt` enum.
 - [896](https://github.com/FuelLabs/fuel-vm/pull/896): Expose `leaf_sum` and allow binary `MerkleTree` to be built from existing precomputed leafs.
@@ -31,6 +33,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [889](https://github.com/FuelLabs/fuel-vm/pull/889) and [908](https://github.com/FuelLabs/fuel-vm/pull/908): Debugger breakpoint caused receipts to be produced incorrectly.
 - [903](https://github.com/FuelLabs/fuel-vm/pull/903): Fixed warning being emitted when using packages with Node@22+.
 - [912](https://github.com/FuelLabs/fuel-vm/pull/912): Fix serialization/deserialization of `Policies` in compressed transactions to be backward compatible.
+
+## [Version 0.59.2]
+
+### Fixed
+- [910](https://github.com/FuelLabs/fuel-vm/pull/910): Fix serialization/deserialization of `Policies` in compressed transactions to be backward compatible.
 
 ## [Version 0.59.1]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,18 +19,18 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.59.1"
+version = "0.60.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.59.1", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.59.1", path = "fuel-crypto", default-features = false }
-fuel-compression = { version = "0.59.1", path = "fuel-compression", default-features = false }
-fuel-derive = { version = "0.59.1", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.59.1", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.59.1", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.59.1", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.59.1", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.59.1", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.60.0", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.60.0", path = "fuel-crypto", default-features = false }
+fuel-compression = { version = "0.60.0", path = "fuel-compression", default-features = false }
+fuel-derive = { version = "0.60.0", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.60.0", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.60.0", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.60.0", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.60.0", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.60.0", path = "fuel-vm", default-features = false }
 bitflags = "2"
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
## Version v0.60.0

### Added
- [901](https://github.com/FuelLabs/fuel-vm/pull/901): Add `Display` implementation to `Receipt` enum.
- [896](https://github.com/FuelLabs/fuel-vm/pull/896): Expose `leaf_sum` and allow binary `MerkleTree` to be built from existing precomputed leafs.
- [882](https://github.com/FuelLabs/fuel-vm/pull/882): Add a lot of new `GTFArgs` including generic ones that will replace old tx type specific.
- [909](https://github.com/FuelLabs/fuel-vm/pull/909): Add the `remove_recovery_id()` to `Signature`.
- [915](https://github.com/FuelLabs/fuel-vm/pull/915): Added support for `AttemptContinue` verifier, that collects and ignores some errors instead of terminating execution. This is meant to help with gathering tx dependencies.

### Breaking
- [900](https://github.com/FuelLabs/fuel-vm/pull/900): Change the error variant `DuplicateMessageInputId` to `DuplicateInputNonce` which now contains a nonce instead of `MessageId` for performance improvements.
- [907](https://github.com/FuelLabs/fuel-vm/pull/907): `StorageRead` and `StorageWrite` traits no longer return the number of bytes written. They already required that the whole buffer is used, but now this is reflected in signature and documentation as well.
- [914](https://github.com/FuelLabs/fuel-vm/pull/914): The built-in profiler is removed. Use the debugger with single-stepping instead.
- [918](https://github.com/FuelLabs/fuel-vm/pull/918): Interpreter is now generic over the validation error handling. No behavioural changes, but the `Interpreter` has one extra type parameter.
- [920](https://github.com/FuelLabs/fuel-vm/pull/920): `Interpreter::execute` and friends are now generic over predicateness of the context. This forces monomorphization so the predicate branch is optimized away on non-predicate execution.

### Changed
- [904](https://github.com/FuelLabs/fuel-vm/pull/904): Moved the logic of each opcode into its own function. It helps so reduce the size of the `instruction_inner` function, allowing compiler to do better optimizations. The Mira swaps receive performance improvement in 16.5%.

### Fixed
- [917](https://github.com/FuelLabs/fuel-vm/pull/917): Ignore predicate verification during the estimation. 
- [895](https://github.com/FuelLabs/fuel-vm/pull/895): Fix elided lifetimes compilation warnings that became errors after the release of rust 1.83.0. 
- [895](https://github.com/FuelLabs/fuel-vm/pull/895): Bump proptest-derive to version `0.5.1` to fix non-local impl errors on the derivation of `proptest_derive::Arbitrary` introduced by rust 1.83.0. 
- [889](https://github.com/FuelLabs/fuel-vm/pull/889) and [908](https://github.com/FuelLabs/fuel-vm/pull/908): Debugger breakpoint caused receipts to be produced incorrectly.
- [903](https://github.com/FuelLabs/fuel-vm/pull/903): Fixed warning being emitted when using packages with Node@22+.
- [912](https://github.com/FuelLabs/fuel-vm/pull/912): Fix serialization/deserialization of `Policies` in compressed transactions to be backward compatible.


**Full Changelog**: https://github.com/FuelLabs/fuel-vm/compare/v0.59.2...v0.60.0