### PR TITLE
Ignore RUSTSEC-2024-0436

### DIFF
--- a/.cargo/audit.yml
+++ b/.cargo/audit.yml
@@ -1,0 +1,4 @@
+[advisories]
+ignore = [
+    "RUSTSEC-2024-0436", # https://github.com/FuelLabs/fuel-vm/issues/924
+]


### PR DESCRIPTION
Closes #924.

We can safely ignore this advisory. The `paste` crate is feature complete, has no runtime code, and thus is extremely unlikely to have exploitable security bugs.