### PR TITLE
Include input_index of the predicate that failed verification

### DIFF
--- a/.changes/breaking/934.md
+++ b/.changes/breaking/934.md
@@ -1,0 +1,1 @@
+Add `input_index` of the failed predicate to `CheckError::PredicateVerificationFailed`.

--- a/fuel-vm/src/checked_transaction.rs
+++ b/fuel-vm/src/checked_transaction.rs
@@ -291,7 +291,7 @@ pub enum CheckError {
     PredicateVerificationFailed {
         /// Input index of the failed predicate.
         /// `TransactionExceedsTotalGasAllowance` sets this to `0`.
-        input_index: u16,
+        input_index: usize,
         /// The reason of the failure.
         reason: PredicateVerificationFailed,
     },
@@ -925,16 +925,9 @@ impl From<ValidityError> for CheckError {
 
 impl From<(usize, PredicateVerificationFailed)> for CheckError {
     fn from((input_index, reason): (usize, PredicateVerificationFailed)) -> Self {
-        if let Ok(input_index) = u16::try_from(input_index) {
-            CheckError::PredicateVerificationFailed {
-                input_index,
-                reason,
-            }
-        } else {
-            CheckError::PredicateVerificationFailed {
-                input_index: 0,
-                reason: Bug::new(BugVariant::InputIndexMoreThanU16Max).into(),
-            }
+        CheckError::PredicateVerificationFailed {
+            input_index,
+            reason,
         }
     }
 }

--- a/fuel-vm/src/checked_transaction.rs
+++ b/fuel-vm/src/checked_transaction.rs
@@ -288,13 +288,7 @@ pub enum CheckError {
     /// The transaction doesn't pass validity rules.
     Validity(ValidityError),
     /// The predicate verification failed.
-    PredicateVerificationFailed {
-        /// Input index of the failed predicate.
-        /// `TransactionExceedsTotalGasAllowance` sets this to `0`.
-        input_index: usize,
-        /// The reason of the failure.
-        reason: PredicateVerificationFailed,
-    },
+    PredicateVerificationFailed(PredicateVerificationFailed),
     /// The max fee used during checking was lower than calculated during `Immutable`
     /// conversion
     InsufficientMaxFee {
@@ -923,12 +917,9 @@ impl From<ValidityError> for CheckError {
     }
 }
 
-impl From<(usize, PredicateVerificationFailed)> for CheckError {
-    fn from((input_index, reason): (usize, PredicateVerificationFailed)) -> Self {
-        CheckError::PredicateVerificationFailed {
-            input_index,
-            reason,
-        }
+impl From<PredicateVerificationFailed> for CheckError {
+    fn from(value: PredicateVerificationFailed) -> Self {
+        CheckError::PredicateVerificationFailed(value)
     }
 }
 

--- a/fuel-vm/src/error.rs
+++ b/fuel-vm/src/error.rs
@@ -339,21 +339,6 @@ impl From<Bug> for PredicateVerificationFailed {
     }
 }
 
-// impl From<PanicReason> for PredicateVerificationFailed {
-//     fn from(reason: PanicReason) -> Self {
-//         Self::Panic(reason)
-//     }
-// }
-
-// impl From<PanicOrBug> for PredicateVerificationFailed {
-//     fn from(err: PanicOrBug) -> Self {
-//         match err {
-//             PanicOrBug::Panic(reason) => Self::from(reason),
-//             PanicOrBug::Bug(bug) => Self::Bug(bug),
-//         }
-//     }
-// }
-
 /// Traceable bug variants
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, strum::EnumMessage)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/fuel-vm/src/error.rs
+++ b/fuel-vm/src/error.rs
@@ -249,20 +249,35 @@ impl<StorageError> From<Infallible> for RuntimeError<StorageError> {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PredicateVerificationFailed {
     /// The predicate did not use the amount of gas provided
-    #[display(fmt = "Predicate used less than the required amount of gas")]
-    GasMismatch,
+    #[display(fmt = "Predicate {index} used less than the required amount of gas")]
+    GasMismatch {
+        /// Input index of the predicate
+        index: usize,
+    },
     /// The transaction doesn't contain enough gas to evaluate the predicate
-    #[display(fmt = "Insufficient gas available for single predicate")]
-    OutOfGas,
+    #[display(fmt = "Insufficient gas available for predicate {index}")]
+    OutOfGas {
+        /// Input index of the predicate
+        index: usize,
+    },
     /// The predicate owner does not correspond to the predicate code
-    #[display(fmt = "Predicate owner invalid, doesn't match code root")]
-    InvalidOwner,
+    #[display(fmt = "Predicate {index} owner invalid, doesn't match code root")]
+    InvalidOwner {
+        /// Input index of the predicate
+        index: usize,
+    },
     /// The predicate wasn't successfully evaluated to true
-    #[display(fmt = "Predicate failed to evaluate")]
-    False,
+    #[display(fmt = "Predicate {index} failed to evaluate")]
+    False {
+        /// Input index of the predicate
+        index: usize,
+    },
     /// The predicate gas used was not specified before execution
-    #[display(fmt = "Predicate failed to evaluate")]
-    GasNotSpecified,
+    #[display(fmt = "Predicate {index} failed to evaluate")]
+    GasNotSpecified {
+        /// Input index of the predicate
+        index: usize,
+    },
     /// The transaction's `max_gas` is greater than the global gas limit.
     #[display(fmt = "Transaction exceeds total gas allowance {_0:?}")]
     TransactionExceedsTotalGasAllowance(Word),
@@ -273,33 +288,47 @@ pub enum PredicateVerificationFailed {
     #[display(fmt = "Invalid interpreter state reached unexpectedly")]
     Bug(Bug),
     /// The VM execution resulted in a well-formed panic, caused by an instruction.
-    #[display(fmt = "Execution error: {_0:?}")]
-    PanicInstruction(PanicInstruction),
+    #[display(fmt = "Execution error: {instruction:?} in input predicate {index}")]
+    PanicInstruction {
+        /// Input index of the predicate
+        index: usize,
+        /// Instruction that caused the panic
+        instruction: PanicInstruction,
+    },
     /// The VM execution resulted in a well-formed panic not caused by an instruction.
-    #[display(fmt = "Execution error: {_0:?}")]
-    Panic(PanicReason),
+    #[display(fmt = "Execution error: {reason:?} in input predicate {index}")]
+    Panic {
+        /// Input index of the predicate
+        index: usize,
+        /// Panic reason
+        reason: PanicReason,
+    },
     /// Predicate verification failed since it attempted to access storage
-    #[display(
-        fmt = "Predicate verification failed since it attempted to access storage"
-    )]
-    Storage,
+    #[display(fmt = "Predicate {index} attempted to access storage")]
+    Storage {
+        /// Input index of the predicate
+        index: usize,
+    },
 }
 
-impl From<InterpreterError<predicate::PredicateStorageError>>
-    for PredicateVerificationFailed
-{
-    fn from(error: InterpreterError<predicate::PredicateStorageError>) -> Self {
+impl PredicateVerificationFailed {
+    /// Construct a new `PredicateVerificationFailed` from the given
+    /// `InterpreterError` and the index of the predicate that caused it.
+    pub(crate) fn interpreter_error(
+        index: usize,
+        error: InterpreterError<predicate::PredicateStorageError>,
+    ) -> Self {
         match error {
             error if error.panic_reason() == Some(PanicReason::OutOfGas) => {
-                PredicateVerificationFailed::OutOfGas
+                Self::OutOfGas { index }
             }
-            InterpreterError::Panic(reason) => PredicateVerificationFailed::Panic(reason),
-            InterpreterError::PanicInstruction(result) => {
-                PredicateVerificationFailed::PanicInstruction(result)
+            InterpreterError::Panic(reason) => Self::Panic { index, reason },
+            InterpreterError::PanicInstruction(instruction) => {
+                Self::PanicInstruction { index, instruction }
             }
-            InterpreterError::Bug(bug) => PredicateVerificationFailed::Bug(bug),
-            InterpreterError::Storage(_) => PredicateVerificationFailed::Storage,
-            _ => PredicateVerificationFailed::False,
+            InterpreterError::Bug(bug) => Self::Bug(bug),
+            InterpreterError::Storage(_) => Self::Storage { index },
+            _ => Self::False { index },
         }
     }
 }
@@ -310,20 +339,20 @@ impl From<Bug> for PredicateVerificationFailed {
     }
 }
 
-impl From<PanicReason> for PredicateVerificationFailed {
-    fn from(reason: PanicReason) -> Self {
-        Self::Panic(reason)
-    }
-}
+// impl From<PanicReason> for PredicateVerificationFailed {
+//     fn from(reason: PanicReason) -> Self {
+//         Self::Panic(reason)
+//     }
+// }
 
-impl From<PanicOrBug> for PredicateVerificationFailed {
-    fn from(err: PanicOrBug) -> Self {
-        match err {
-            PanicOrBug::Panic(reason) => Self::from(reason),
-            PanicOrBug::Bug(bug) => Self::Bug(bug),
-        }
-    }
-}
+// impl From<PanicOrBug> for PredicateVerificationFailed {
+//     fn from(err: PanicOrBug) -> Self {
+//         match err {
+//             PanicOrBug::Panic(reason) => Self::from(reason),
+//             PanicOrBug::Bug(bug) => Self::Bug(bug),
+//         }
+//     }
+// }
 
 /// Traceable bug variants
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, strum::EnumMessage)]

--- a/fuel-vm/src/error.rs
+++ b/fuel-vm/src/error.rs
@@ -377,6 +377,10 @@ pub enum BugVariant {
         message = "The witness subsection index is higher than the total number of parts."
     )]
     NextSubsectionIndexIsHigherThanTotalNumberOfParts,
+
+    /// Input index more than u16::MAX was used internally.
+    #[strum(message = "Input index more than u16::MAX was used internally.")]
+    InputIndexMoreThanU16Max,
 }
 
 impl fmt::Display for BugVariant {

--- a/fuel-vm/src/predicate.rs
+++ b/fuel-vm/src/predicate.rs
@@ -297,7 +297,7 @@ mod tests {
                     &storage,
                 );
 
-                assert_eq!(result.map(|_| ()), expected, "failed at input {}", i);
+                assert_eq!(result.map(|_| ()), expected.clone().map_err(|r| (0, r)), "failed at input {}", i);
             }
         }
     }

--- a/fuel-vm/src/predicate.rs
+++ b/fuel-vm/src/predicate.rs
@@ -297,7 +297,12 @@ mod tests {
                     &storage,
                 );
 
-                assert_eq!(result.map(|_| ()), expected.clone().map_err(|r| (0, r)), "failed at input {}", i);
+                assert_eq!(
+                    result.map(|_| ()),
+                    expected.clone().map_err(|r| (0, r)),
+                    "failed at input {}",
+                    i
+                );
             }
         }
     }

--- a/fuel-vm/src/predicate.rs
+++ b/fuel-vm/src/predicate.rs
@@ -297,12 +297,7 @@ mod tests {
                     &storage,
                 );
 
-                assert_eq!(
-                    result.map(|_| ()),
-                    expected.clone().map_err(|r| (0, r)),
-                    "failed at input {}",
-                    i
-                );
+                assert_eq!(result.map(|_| ()), expected, "failed at input {}", i);
             }
         }
     }
@@ -407,37 +402,40 @@ mod tests {
                     op::ret(0x01),
                 ],
                 INCORRECT_GAS,
-                Err(PredicateVerificationFailed::GasMismatch),
+                Err(PredicateVerificationFailed::GasMismatch { index: 0 }),
             ),
             (
                 // Returning an invalid value
                 vec![op::ret(0x0)],
                 CORRECT_GAS,
-                Err(PredicateVerificationFailed::Panic(
-                    PanicReason::PredicateReturnedNonOne,
-                )),
+                Err(PredicateVerificationFailed::Panic {
+                    index: 0,
+                    reason: PanicReason::PredicateReturnedNonOne,
+                }),
             ),
             (
                 // Using a contract instruction
                 vec![op::time(0x20, 0x1), op::ret(0x1)],
                 CORRECT_GAS,
-                Err(PredicateVerificationFailed::PanicInstruction(
-                    PanicInstruction::error(
+                Err(PredicateVerificationFailed::PanicInstruction {
+                    index: 0,
+                    instruction: PanicInstruction::error(
                         PanicReason::ContractInstructionNotAllowed,
                         op::time(0x20, 0x1).into(),
                     ),
-                )),
+                }),
             ),
             (
                 // Using a contract instruction
                 vec![op::ldc(ONE, ONE, ONE, 0)],
                 CORRECT_GAS,
-                Err(PredicateVerificationFailed::PanicInstruction(
-                    PanicInstruction::error(
+                Err(PredicateVerificationFailed::PanicInstruction {
+                    index: 0,
+                    instruction: PanicInstruction::error(
                         PanicReason::ContractInstructionNotAllowed,
                         op::ldc(ONE, ONE, ONE, 0).into(),
                     ),
-                )),
+                }),
             ),
             (
                 // Use `LDC` with mode `1` to load the blob into the predicate.
@@ -462,9 +460,10 @@ mod tests {
                     op::jmp(0x12),
                 ],
                 CORRECT_GAS,
-                Err(PredicateVerificationFailed::Panic(
-                    PanicReason::PredicateReturnedNonOne,
-                )),
+                Err(PredicateVerificationFailed::Panic {
+                    index: 0,
+                    reason: PanicReason::PredicateReturnedNonOne,
+                }),
             ),
             (
                 // Use `LDC` with mode `2` to load the part of the predicate from the
@@ -500,9 +499,10 @@ mod tests {
                     op::jmp(0x12),
                 ],
                 CORRECT_GAS,
-                Err(PredicateVerificationFailed::Panic(
-                    PanicReason::PredicateReturnedNonOne,
-                )),
+                Err(PredicateVerificationFailed::Panic {
+                    index: 0,
+                    reason: PanicReason::PredicateReturnedNonOne,
+                }),
             ),
         ];
 

--- a/fuel-vm/src/tests/predicate.rs
+++ b/fuel-vm/src/tests/predicate.rs
@@ -47,11 +47,11 @@ pub struct TokioWithRayon;
 
 #[async_trait::async_trait]
 impl ParallelExecutor for TokioWithRayon {
-    type Task = AsyncRayonHandle<Result<(Word, usize), PredicateVerificationFailed>>;
+    type Task = AsyncRayonHandle<(usize, Result<Word, PredicateVerificationFailed>)>;
 
     fn create_task<F>(func: F) -> Self::Task
     where
-        F: FnOnce() -> Result<(Word, usize), PredicateVerificationFailed>
+        F: FnOnce() -> (usize, Result<Word, PredicateVerificationFailed>)
             + Send
             + 'static,
     {
@@ -60,7 +60,7 @@ impl ParallelExecutor for TokioWithRayon {
 
     async fn execute_tasks(
         futures: Vec<Self::Task>,
-    ) -> Vec<Result<(Word, usize), PredicateVerificationFailed>> {
+    ) -> Vec<(usize, Result<Word, PredicateVerificationFailed>)> {
         futures::future::join_all(futures).await
     }
 }
@@ -676,7 +676,10 @@ async fn gas_used_by_predicates_more_than_limit() {
 
         assert!(matches!(
             tx_with_predicate.unwrap_err(),
-            CheckError::PredicateVerificationFailed(_)
+            CheckError::PredicateVerificationFailed {
+                input_index: 1,
+                reason: _
+            }
         ));
     }
 
@@ -686,7 +689,10 @@ async fn gas_used_by_predicates_more_than_limit() {
 
     assert!(matches!(
         tx_with_predicate.unwrap_err(),
-        CheckError::PredicateVerificationFailed(_)
+            CheckError::PredicateVerificationFailed {
+                input_index: 1,
+                reason: _
+            }
     ));
 }
 

--- a/fuel-vm/src/tests/predicate.rs
+++ b/fuel-vm/src/tests/predicate.rs
@@ -676,10 +676,7 @@ async fn gas_used_by_predicates_more_than_limit() {
 
         assert!(matches!(
             tx_with_predicate.unwrap_err(),
-            CheckError::PredicateVerificationFailed {
-                input_index: 1,
-                reason: _
-            }
+            CheckError::PredicateVerificationFailed(_)
         ));
     }
 
@@ -689,10 +686,7 @@ async fn gas_used_by_predicates_more_than_limit() {
 
     assert!(matches!(
         tx_with_predicate.unwrap_err(),
-        CheckError::PredicateVerificationFailed {
-            input_index: 1,
-            reason: _
-        }
+        CheckError::PredicateVerificationFailed(_)
     ));
 }
 

--- a/fuel-vm/src/tests/predicate.rs
+++ b/fuel-vm/src/tests/predicate.rs
@@ -689,10 +689,10 @@ async fn gas_used_by_predicates_more_than_limit() {
 
     assert!(matches!(
         tx_with_predicate.unwrap_err(),
-            CheckError::PredicateVerificationFailed {
-                input_index: 1,
-                reason: _
-            }
+        CheckError::PredicateVerificationFailed {
+            input_index: 1,
+            reason: _
+        }
     ));
 }
 


### PR DESCRIPTION
@luizstacio posted on slack:
> It would be good to have the input index of the predicate that failed on this error: Invalid transaction data: `PredicateVerificationFailed(Panic(PredicateReturnedNonOne))`  Right now, with many predicates on a single TX, it is difficult for me to say which one is returning false.

The PR adds `input_index` field to `PredicateVerificationFailed` variants that need use it.

This breaks serde deserialization of old `PredicateVerificationFailed` into the new type, but I don't think we depend on that anywhere. Maybe @xgreenx knows about this one?

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
