### PR TITLE
feat: Allow empty values in sparse merkle trees

### DIFF
--- a/.changes/breaking/938.md
+++ b/.changes/breaking/938.md
@@ -1,0 +1,1 @@
+Rename `update` method to `insert` on sparse merkle tree, and allow inserting empty values.

--- a/fuel-merkle/src/sparse/in_memory.rs
+++ b/fuel-merkle/src/sparse/in_memory.rs
@@ -189,7 +189,7 @@ impl MerkleTree {
     }
 
     pub fn update(&mut self, key: MerkleTreeKey, data: &[u8]) {
-        let _ = self.tree.update(key, data);
+        let _ = self.tree.insert(key, data);
     }
 
     pub fn delete(&mut self, key: MerkleTreeKey) {

--- a/fuel-merkle/src/sparse/merkle_tree.rs
+++ b/fuel-merkle/src/sparse/merkle_tree.rs
@@ -280,7 +280,6 @@ where
             .collect::<alloc::collections::BTreeMap<Bytes32, D>>();
         let mut branches = sorted
             .iter()
-            .filter(|(_, value)| !value.as_ref().is_empty())
             .map(|(key, data)| Node::create_leaf(key, data))
             .map(Into::<Branch>::into)
             .collect::<Vec<_>>();
@@ -410,13 +409,6 @@ where
         key: MerkleTreeKey,
         data: &[u8],
     ) -> Result<(), MerkleTreeError<StorageError>> {
-        if data.is_empty() {
-            // If the data is empty, this signifies a delete operation for the
-            // given key.
-            self.delete(key)?;
-            return Ok(())
-        }
-
         let leaf_node = Node::create_leaf(key.as_ref(), data);
         self.storage
             .insert(leaf_node.hash(), &leaf_node.as_ref().into())?;
@@ -967,7 +959,7 @@ mod test {
     }
 
     #[test]
-    fn test_update_with_empty_data_does_not_change_root() {
+    fn test_insert_empty_data_changes_root() {
         let mut storage = StorageMap::<TestTable>::new();
         let mut tree = MerkleTree::new(&mut storage);
 
@@ -975,12 +967,12 @@ mod test {
 
         let root = tree.root();
         let expected_root =
-            "0000000000000000000000000000000000000000000000000000000000000000";
+            "3529664b414de6285270f7ebda7a43e20ae0ff6191c07d876b86282eb8ce93ce";
         assert_eq!(hex::encode(root), expected_root);
     }
 
     #[test]
-    fn test_update_with_empty_data_performs_delete() {
+    fn test_update_with_empty_data_changes_root() {
         let mut storage = StorageMap::<TestTable>::new();
         let mut tree = MerkleTree::new(&mut storage);
 
@@ -989,7 +981,7 @@ mod test {
 
         let root = tree.root();
         let expected_root =
-            "0000000000000000000000000000000000000000000000000000000000000000";
+            "3529664b414de6285270f7ebda7a43e20ae0ff6191c07d876b86282eb8ce93ce";
         assert_eq!(hex::encode(root), expected_root);
     }
 

--- a/fuel-merkle/src/sparse/merkle_tree.rs
+++ b/fuel-merkle/src/sparse/merkle_tree.rs
@@ -404,7 +404,7 @@ where
         Ok(tree)
     }
 
-    pub fn update(
+    pub fn insert(
         &mut self,
         key: MerkleTreeKey,
         data: &[u8],
@@ -774,7 +774,7 @@ mod test {
         let mut storage = StorageMap::<TestTable>::new();
         let mut tree = MerkleTree::new(&mut storage);
 
-        tree.update(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
 
         let root = tree.root();
         let expected_root =
@@ -787,8 +787,8 @@ mod test {
         let mut storage = StorageMap::<TestTable>::new();
         let mut tree = MerkleTree::new(&mut storage);
 
-        tree.update(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
-        tree.update(key(b"\x00\x00\x00\x01"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x01"), b"DATA").unwrap();
 
         let root = tree.root();
         let expected_root =
@@ -801,9 +801,9 @@ mod test {
         let mut storage = StorageMap::<TestTable>::new();
         let mut tree = MerkleTree::new(&mut storage);
 
-        tree.update(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
-        tree.update(key(b"\x00\x00\x00\x01"), b"DATA").unwrap();
-        tree.update(key(b"\x00\x00\x00\x02"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x01"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x02"), b"DATA").unwrap();
 
         let root = tree.root();
         let expected_root =
@@ -816,11 +816,11 @@ mod test {
         let mut storage = StorageMap::<TestTable>::new();
         let mut tree = MerkleTree::new(&mut storage);
 
-        tree.update(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
-        tree.update(key(b"\x00\x00\x00\x01"), b"DATA").unwrap();
-        tree.update(key(b"\x00\x00\x00\x02"), b"DATA").unwrap();
-        tree.update(key(b"\x00\x00\x00\x03"), b"DATA").unwrap();
-        tree.update(key(b"\x00\x00\x00\x04"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x01"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x02"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x03"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x04"), b"DATA").unwrap();
 
         let root = tree.root();
         let expected_root =
@@ -835,7 +835,7 @@ mod test {
 
         for i in 0_u32..10 {
             let key = key(i.to_be_bytes());
-            tree.update(key, b"DATA").unwrap();
+            tree.insert(key, b"DATA").unwrap();
         }
 
         let root = tree.root();
@@ -851,7 +851,7 @@ mod test {
 
         for i in 0_u32..100 {
             let key = key(i.to_be_bytes());
-            tree.update(key, b"DATA").unwrap();
+            tree.insert(key, b"DATA").unwrap();
         }
 
         let root = tree.root();
@@ -865,8 +865,8 @@ mod test {
         let mut storage = StorageMap::<TestTable>::new();
         let mut tree = MerkleTree::new(&mut storage);
 
-        tree.update(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
-        tree.update(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
 
         let root = tree.root();
         let expected_root =
@@ -879,8 +879,8 @@ mod test {
         let mut storage = StorageMap::<TestTable>::new();
         let mut tree = MerkleTree::new(&mut storage);
 
-        tree.update(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
-        tree.update(key(b"\x00\x00\x00\x00"), b"CHANGE").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x00"), b"CHANGE").unwrap();
 
         let root = tree.root();
         let expected_root =
@@ -895,19 +895,19 @@ mod test {
 
         for i in 0_u32..10 {
             let key = key(i.to_be_bytes());
-            tree.update(key, b"DATA").unwrap();
+            tree.insert(key, b"DATA").unwrap();
         }
 
         let root_hash_before = tree.root();
 
         for i in 3_u32..7 {
             let key = key(i.to_be_bytes());
-            tree.update(key, b"DATA_2").unwrap();
+            tree.insert(key, b"DATA_2").unwrap();
         }
 
         for i in 3_u32..7 {
             let key = key(i.to_be_bytes());
-            tree.update(key, b"DATA").unwrap();
+            tree.insert(key, b"DATA").unwrap();
         }
 
         let root_hash_after = tree.root();
@@ -922,17 +922,17 @@ mod test {
 
         for i in 0_u32..5 {
             let key = key(i.to_be_bytes());
-            tree.update(key, b"DATA").unwrap();
+            tree.insert(key, b"DATA").unwrap();
         }
 
         for i in 10_u32..15 {
             let key = key(i.to_be_bytes());
-            tree.update(key, b"DATA").unwrap();
+            tree.insert(key, b"DATA").unwrap();
         }
 
         for i in 20_u32..25 {
             let key = key(i.to_be_bytes());
-            tree.update(key, b"DATA").unwrap();
+            tree.insert(key, b"DATA").unwrap();
         }
 
         let root = tree.root();
@@ -946,11 +946,11 @@ mod test {
         let mut storage = StorageMap::<TestTable>::new();
         let mut tree = MerkleTree::new(&mut storage);
 
-        tree.update(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
-        tree.update(key(b"\x00\x00\x00\x02"), b"DATA").unwrap();
-        tree.update(key(b"\x00\x00\x00\x04"), b"DATA").unwrap();
-        tree.update(key(b"\x00\x00\x00\x06"), b"DATA").unwrap();
-        tree.update(key(b"\x00\x00\x00\x08"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x02"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x04"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x06"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x08"), b"DATA").unwrap();
 
         let root = tree.root();
         let expected_root =
@@ -963,7 +963,7 @@ mod test {
         let mut storage = StorageMap::<TestTable>::new();
         let mut tree = MerkleTree::new(&mut storage);
 
-        tree.update(key(b"\x00\x00\x00\x00"), b"").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x00"), b"").unwrap();
 
         let root = tree.root();
         let expected_root =
@@ -976,8 +976,8 @@ mod test {
         let mut storage = StorageMap::<TestTable>::new();
         let mut tree = MerkleTree::new(&mut storage);
 
-        tree.update(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
-        tree.update(key(b"\x00\x00\x00\x00"), b"").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x00"), b"").unwrap();
 
         let root = tree.root();
         let expected_root =
@@ -990,7 +990,7 @@ mod test {
         let mut storage = StorageMap::<TestTable>::new();
         let mut tree = MerkleTree::new(&mut storage);
 
-        tree.update(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
         tree.delete(key(b"\x00\x00\x00\x00")).unwrap();
 
         let root = tree.root();
@@ -1004,8 +1004,8 @@ mod test {
         let mut storage = StorageMap::<TestTable>::new();
         let mut tree = MerkleTree::new(&mut storage);
 
-        tree.update(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
-        tree.update(key(b"\x00\x00\x00\x01"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x01"), b"DATA").unwrap();
         tree.delete(key(b"\x00\x00\x00\x01")).unwrap();
 
         let root = tree.root();
@@ -1021,7 +1021,7 @@ mod test {
 
         for i in 0_u32..10 {
             let key = key(i.to_be_bytes());
-            tree.update(key, b"DATA").unwrap();
+            tree.insert(key, b"DATA").unwrap();
         }
 
         for i in 5_u32..10 {
@@ -1040,11 +1040,11 @@ mod test {
         let mut storage = StorageMap::<TestTable>::new();
         let mut tree = MerkleTree::new(&mut storage);
 
-        tree.update(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
-        tree.update(key(b"\x00\x00\x00\x01"), b"DATA").unwrap();
-        tree.update(key(b"\x00\x00\x00\x02"), b"DATA").unwrap();
-        tree.update(key(b"\x00\x00\x00\x03"), b"DATA").unwrap();
-        tree.update(key(b"\x00\x00\x00\x04"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x01"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x02"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x03"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x04"), b"DATA").unwrap();
         tree.delete(key(b"\x00\x00\x04\x00")).unwrap();
 
         let root = tree.root();
@@ -1060,7 +1060,7 @@ mod test {
 
         for i in 0_u32..10 {
             let key = key(i.to_be_bytes());
-            tree.update(key, b"DATA").unwrap();
+            tree.insert(key, b"DATA").unwrap();
         }
 
         for i in 5_u32..15 {
@@ -1070,7 +1070,7 @@ mod test {
 
         for i in 10_u32..20 {
             let key = key(i.to_be_bytes());
-            tree.update(key, b"DATA").unwrap();
+            tree.insert(key, b"DATA").unwrap();
         }
 
         for i in 15_u32..25 {
@@ -1080,7 +1080,7 @@ mod test {
 
         for i in 20_u32..30 {
             let key = key(i.to_be_bytes());
-            tree.update(key, b"DATA").unwrap();
+            tree.insert(key, b"DATA").unwrap();
         }
 
         for i in 25_u32..35 {
@@ -1102,18 +1102,18 @@ mod test {
 
         for i in 0_u32..tenth_index {
             let key = key(i.to_be_bytes());
-            tree.update(key, b"DATA").unwrap();
+            tree.insert(key, b"DATA").unwrap();
         }
         let size_before_tenth = tree.storage().len();
         let tenth_key = key(tenth_index.to_be_bytes());
 
         // Given
-        tree.update(tenth_key, b"DATA").unwrap();
+        tree.insert(tenth_key, b"DATA").unwrap();
         let size_after_tenth = tree.storage().len();
         assert_ne!(size_after_tenth, size_before_tenth);
 
         // When
-        tree.update(tenth_key, b"ANOTHER_DATA").unwrap();
+        tree.insert(tenth_key, b"ANOTHER_DATA").unwrap();
 
         // Then
         assert_eq!(tree.storage().len(), size_after_tenth);
@@ -1127,18 +1127,18 @@ mod test {
 
         for i in 0_u32..tenth_index {
             let key = key(i.to_be_bytes());
-            tree.update(key, b"DATA").unwrap();
+            tree.insert(key, b"DATA").unwrap();
         }
         let size_before_tenth = tree.storage().len();
         let tenth_key = key(tenth_index.to_be_bytes());
 
         // Given
-        tree.update(tenth_key, b"DATA").unwrap();
+        tree.insert(tenth_key, b"DATA").unwrap();
         let size_after_tenth = tree.storage().len();
         assert_ne!(size_after_tenth, size_before_tenth);
 
         // When
-        tree.update(tenth_key, b"DATA").unwrap();
+        tree.insert(tenth_key, b"DATA").unwrap();
 
         // Then
         assert_eq!(tree.storage().len(), size_after_tenth);
@@ -1152,13 +1152,13 @@ mod test {
 
         for i in 0_u32..tenth_index {
             let key = key(i.to_be_bytes());
-            tree.update(key, b"DATA").unwrap();
+            tree.insert(key, b"DATA").unwrap();
         }
         let size_before_tenth = tree.storage().len();
         let tenth_key = key(tenth_index.to_be_bytes());
 
         // Given
-        tree.update(tenth_key, b"DATA").unwrap();
+        tree.insert(tenth_key, b"DATA").unwrap();
         let size_after_tenth = tree.storage().len();
         assert_ne!(size_after_tenth, size_before_tenth);
 
@@ -1176,7 +1176,7 @@ mod test {
 
         for i in 0_u32..10 {
             let key = key(i.to_be_bytes());
-            tree.update(key, b"DATA").unwrap();
+            tree.insert(key, b"DATA").unwrap();
         }
 
         for i in 0_u32..5 {
@@ -1204,8 +1204,8 @@ mod test {
         let leaf_2_data = b"DATA_2";
         let leaf_2 = Node::create_leaf(&leaf_2_key.0, leaf_2_data);
 
-        tree.update(leaf_2_key, leaf_2_data).unwrap();
-        tree.update(leaf_1_key, leaf_1_data).unwrap();
+        tree.insert(leaf_2_key, leaf_2_data).unwrap();
+        tree.insert(leaf_1_key, leaf_1_data).unwrap();
         assert_eq!(
             tree.storage
                 .get(leaf_2.hash())
@@ -1235,11 +1235,11 @@ mod test {
         let (mut storage_to_load, root_to_load) = {
             let mut storage = StorageMap::<TestTable>::new();
             let mut tree = MerkleTree::new(&mut storage);
-            tree.update(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
-            tree.update(key(b"\x00\x00\x00\x01"), b"DATA").unwrap();
-            tree.update(key(b"\x00\x00\x00\x02"), b"DATA").unwrap();
-            tree.update(key(b"\x00\x00\x00\x03"), b"DATA").unwrap();
-            tree.update(key(b"\x00\x00\x00\x04"), b"DATA").unwrap();
+            tree.insert(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
+            tree.insert(key(b"\x00\x00\x00\x01"), b"DATA").unwrap();
+            tree.insert(key(b"\x00\x00\x00\x02"), b"DATA").unwrap();
+            tree.insert(key(b"\x00\x00\x00\x03"), b"DATA").unwrap();
+            tree.insert(key(b"\x00\x00\x00\x04"), b"DATA").unwrap();
             let root = tree.root();
             (storage, root)
         };
@@ -1250,16 +1250,16 @@ mod test {
         let expected_root = {
             let mut storage = StorageMap::<TestTable>::new();
             let mut tree = MerkleTree::new(&mut storage);
-            tree.update(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
-            tree.update(key(b"\x00\x00\x00\x01"), b"DATA").unwrap();
-            tree.update(key(b"\x00\x00\x00\x02"), b"DATA").unwrap();
-            tree.update(key(b"\x00\x00\x00\x03"), b"DATA").unwrap();
-            tree.update(key(b"\x00\x00\x00\x04"), b"DATA").unwrap();
-            tree.update(key(b"\x00\x00\x00\x05"), b"DATA").unwrap();
-            tree.update(key(b"\x00\x00\x00\x06"), b"DATA").unwrap();
-            tree.update(key(b"\x00\x00\x00\x07"), b"DATA").unwrap();
-            tree.update(key(b"\x00\x00\x00\x08"), b"DATA").unwrap();
-            tree.update(key(b"\x00\x00\x00\x09"), b"DATA").unwrap();
+            tree.insert(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
+            tree.insert(key(b"\x00\x00\x00\x01"), b"DATA").unwrap();
+            tree.insert(key(b"\x00\x00\x00\x02"), b"DATA").unwrap();
+            tree.insert(key(b"\x00\x00\x00\x03"), b"DATA").unwrap();
+            tree.insert(key(b"\x00\x00\x00\x04"), b"DATA").unwrap();
+            tree.insert(key(b"\x00\x00\x00\x05"), b"DATA").unwrap();
+            tree.insert(key(b"\x00\x00\x00\x06"), b"DATA").unwrap();
+            tree.insert(key(b"\x00\x00\x00\x07"), b"DATA").unwrap();
+            tree.insert(key(b"\x00\x00\x00\x08"), b"DATA").unwrap();
+            tree.insert(key(b"\x00\x00\x00\x09"), b"DATA").unwrap();
             tree.root()
         };
 
@@ -1270,11 +1270,11 @@ mod test {
             // root matches the expected root. This verifies that the loaded tree has
             // successfully wrapped the given storage backing and assumed the correct
             // state so that future updates can be made seamlessly.
-            tree.update(key(b"\x00\x00\x00\x05"), b"DATA").unwrap();
-            tree.update(key(b"\x00\x00\x00\x06"), b"DATA").unwrap();
-            tree.update(key(b"\x00\x00\x00\x07"), b"DATA").unwrap();
-            tree.update(key(b"\x00\x00\x00\x08"), b"DATA").unwrap();
-            tree.update(key(b"\x00\x00\x00\x09"), b"DATA").unwrap();
+            tree.insert(key(b"\x00\x00\x00\x05"), b"DATA").unwrap();
+            tree.insert(key(b"\x00\x00\x00\x06"), b"DATA").unwrap();
+            tree.insert(key(b"\x00\x00\x00\x07"), b"DATA").unwrap();
+            tree.insert(key(b"\x00\x00\x00\x08"), b"DATA").unwrap();
+            tree.insert(key(b"\x00\x00\x00\x09"), b"DATA").unwrap();
             tree.root()
         };
 
@@ -1296,11 +1296,11 @@ mod test {
 
         {
             let mut tree = MerkleTree::new(&mut storage);
-            tree.update(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
-            tree.update(key(b"\x00\x00\x00\x01"), b"DATA").unwrap();
-            tree.update(key(b"\x00\x00\x00\x02"), b"DATA").unwrap();
-            tree.update(key(b"\x00\x00\x00\x03"), b"DATA").unwrap();
-            tree.update(key(b"\x00\x00\x00\x04"), b"DATA").unwrap();
+            tree.insert(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
+            tree.insert(key(b"\x00\x00\x00\x01"), b"DATA").unwrap();
+            tree.insert(key(b"\x00\x00\x00\x02"), b"DATA").unwrap();
+            tree.insert(key(b"\x00\x00\x00\x03"), b"DATA").unwrap();
+            tree.insert(key(b"\x00\x00\x00\x04"), b"DATA").unwrap();
         }
 
         let root = &sum(b"\xff\xff\xff\xff");
@@ -1316,11 +1316,11 @@ mod test {
         let mut storage = StorageMap::<TestTable>::new();
 
         let mut tree = MerkleTree::new(&mut storage);
-        tree.update(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
-        tree.update(key(b"\x00\x00\x00\x01"), b"DATA").unwrap();
-        tree.update(key(b"\x00\x00\x00\x02"), b"DATA").unwrap();
-        tree.update(key(b"\x00\x00\x00\x03"), b"DATA").unwrap();
-        tree.update(key(b"\x00\x00\x00\x04"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x00"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x01"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x02"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x03"), b"DATA").unwrap();
+        tree.insert(key(b"\x00\x00\x00\x04"), b"DATA").unwrap();
         let root = tree.root();
 
         // Overwrite the root key-value with an invalid primitive to create a
@@ -1349,7 +1349,7 @@ mod test {
             let mut tree = MerkleTree::new(&mut storage);
             let input = data.clone();
             for (key, value) in input.into_iter() {
-                tree.update(key, &value).unwrap();
+                tree.insert(key, &value).unwrap();
             }
             tree.root()
         };
@@ -1379,7 +1379,7 @@ mod test {
             let mut tree = MerkleTree::new(&mut storage);
             let input = data.clone();
             for (key, value) in input.into_iter() {
-                tree.update(key, &value).unwrap();
+                tree.insert(key, &value).unwrap();
             }
             tree.root()
         };
@@ -1409,7 +1409,7 @@ mod test {
             let mut tree = MerkleTree::new(&mut storage);
             let input = data.clone();
             for (key, value) in input.into_iter() {
-                tree.update(key, &value).unwrap();
+                tree.insert(key, &value).unwrap();
             }
             tree.root()
         };
@@ -1445,7 +1445,7 @@ mod test {
             let mut tree = MerkleTree::new(&mut storage);
             let input = data;
             for (key, value) in input.into_iter() {
-                tree.update(key, &value).unwrap();
+                tree.insert(key, &value).unwrap();
             }
             tree.root()
         };
@@ -1481,7 +1481,7 @@ mod test {
             let mut tree = MerkleTree::new(&mut storage);
             let input = data.clone();
             for (key, value) in input.into_iter() {
-                tree.update(key, &value).unwrap();
+                tree.insert(key, &value).unwrap();
             }
             tree.root()
         };
@@ -1516,25 +1516,25 @@ mod test {
 
         let k0 = [0u8; 32];
         let v0 = sum(b"DATA");
-        tree.update(MerkleTreeKey::new_without_hash(k0), &v0)
+        tree.insert(MerkleTreeKey::new_without_hash(k0), &v0)
             .expect("Expected successful update");
 
         let mut k1 = [0u8; 32];
         k1[0] = 0b01000000;
         let v1 = sum(b"DATA");
-        tree.update(MerkleTreeKey::new_without_hash(k1), &v1)
+        tree.insert(MerkleTreeKey::new_without_hash(k1), &v1)
             .expect("Expected successful update");
 
         let mut k2 = [0u8; 32];
         k2[0] = 0b01100000;
         let v2 = sum(b"DATA");
-        tree.update(MerkleTreeKey::new_without_hash(k2), &v2)
+        tree.insert(MerkleTreeKey::new_without_hash(k2), &v2)
             .expect("Expected successful update");
 
         let mut k3 = [0u8; 32];
         k3[0] = 0b01001000;
         let v3 = sum(b"DATA");
-        tree.update(MerkleTreeKey::new_without_hash(k3), &v3)
+        tree.insert(MerkleTreeKey::new_without_hash(k3), &v3)
             .expect("Expected successful update");
 
         let l0 = Node::create_leaf(&k0, v0);
@@ -1630,25 +1630,25 @@ mod test {
 
         let k0 = [0u8; 32];
         let v0 = sum(b"DATA");
-        tree.update(MerkleTreeKey::new_without_hash(k0), &v0)
+        tree.insert(MerkleTreeKey::new_without_hash(k0), &v0)
             .expect("Expected successful update");
 
         let mut k1 = [0u8; 32];
         k1[0] = 0b01000000;
         let v1 = sum(b"DATA");
-        tree.update(MerkleTreeKey::new_without_hash(k1), &v1)
+        tree.insert(MerkleTreeKey::new_without_hash(k1), &v1)
             .expect("Expected successful update");
 
         let mut k2 = [0u8; 32];
         k2[0] = 0b01100000;
         let v2 = sum(b"DATA");
-        tree.update(MerkleTreeKey::new_without_hash(k2), &v2)
+        tree.insert(MerkleTreeKey::new_without_hash(k2), &v2)
             .expect("Expected successful update");
 
         let mut k3 = [0u8; 32];
         k3[0] = 0b01001000;
         let v3 = sum(b"DATA");
-        tree.update(MerkleTreeKey::new_without_hash(k3), &v3)
+        tree.insert(MerkleTreeKey::new_without_hash(k3), &v3)
             .expect("Expected successful update");
 
         // When
@@ -1679,25 +1679,25 @@ mod test {
 
         let k0 = [0u8; 32];
         let v0 = sum(b"DATA");
-        tree.update(MerkleTreeKey::new_without_hash(k0), &v0)
+        tree.insert(MerkleTreeKey::new_without_hash(k0), &v0)
             .expect("Expected successful update");
 
         let mut k1 = [0u8; 32];
         k1[0] = 0b01000000;
         let v1 = sum(b"DATA");
-        tree.update(MerkleTreeKey::new_without_hash(k1), &v1)
+        tree.insert(MerkleTreeKey::new_without_hash(k1), &v1)
             .expect("Expected successful update");
 
         let mut k2 = [0u8; 32];
         k2[0] = 0b01100000;
         let v2 = sum(b"DATA");
-        tree.update(MerkleTreeKey::new_without_hash(k2), &v2)
+        tree.insert(MerkleTreeKey::new_without_hash(k2), &v2)
             .expect("Expected successful update");
 
         let mut k3 = [0u8; 32];
         k3[0] = 0b01001000;
         let v3 = sum(b"DATA");
-        tree.update(MerkleTreeKey::new_without_hash(k3), &v3)
+        tree.insert(MerkleTreeKey::new_without_hash(k3), &v3)
             .expect("Expected successful update");
 
         // When

--- a/fuel-merkle/src/sparse/proof.rs
+++ b/fuel-merkle/src/sparse/proof.rs
@@ -210,25 +210,25 @@ mod test {
 
         let k0 = [0u8; 32].into();
         let v0 = b"DATA_0";
-        tree.update(k0, v0).expect("Expected successful update");
+        tree.insert(k0, v0).expect("Expected successful update");
 
         let mut k1 = [0u8; 32];
         k1[0] = 0b01000000;
         let k1 = k1.into();
         let v1 = b"DATA_1";
-        tree.update(k1, v1).expect("Expected successful update");
+        tree.insert(k1, v1).expect("Expected successful update");
 
         let mut k2 = [0u8; 32];
         k2[0] = 0b01100000;
         let k2 = k2.into();
         let v2 = b"DATA_2";
-        tree.update(k2, v2).expect("Expected successful update");
+        tree.insert(k2, v2).expect("Expected successful update");
 
         let mut k3 = [0u8; 32];
         k3[0] = 0b01001000;
         let k3 = k3.into();
         let v3 = b"DATA_3";
-        tree.update(k3, v3).expect("Expected successful update");
+        tree.insert(k3, v3).expect("Expected successful update");
 
         let root = tree.root();
 
@@ -309,25 +309,25 @@ mod test {
 
         let k0 = [0u8; 32].into();
         let v0 = b"DATA_0";
-        tree.update(k0, v0).expect("Expected successful update");
+        tree.insert(k0, v0).expect("Expected successful update");
 
         let mut k1 = [0u8; 32];
         k1[0] = 0b01000000;
         let k1 = k1.into();
         let v1 = b"DATA_1";
-        tree.update(k1, v1).expect("Expected successful update");
+        tree.insert(k1, v1).expect("Expected successful update");
 
         let mut k2 = [0u8; 32];
         k2[0] = 0b01100000;
         let k2 = k2.into();
         let v2 = b"DATA_2";
-        tree.update(k2, v2).expect("Expected successful update");
+        tree.insert(k2, v2).expect("Expected successful update");
 
         let mut k3 = [0u8; 32];
         k3[0] = 0b01001000;
         let k3 = k3.into();
         let v3 = b"DATA_3";
-        tree.update(k3, v3).expect("Expected successful update");
+        tree.insert(k3, v3).expect("Expected successful update");
 
         let root = tree.root();
 
@@ -407,25 +407,25 @@ mod test {
 
         let k0 = [0u8; 32].into();
         let v0 = b"DATA_0";
-        tree.update(k0, v0).expect("Expected successful update");
+        tree.insert(k0, v0).expect("Expected successful update");
 
         let mut k1 = [0u8; 32];
         k1[0] = 0b01000000;
         let k1 = k1.into();
         let v1 = b"DATA_1";
-        tree.update(k1, v1).expect("Expected successful update");
+        tree.insert(k1, v1).expect("Expected successful update");
 
         let mut k2 = [0u8; 32];
         k2[0] = 0b01100000;
         let k2 = k2.into();
         let v2 = b"DATA_2";
-        tree.update(k2, v2).expect("Expected successful update");
+        tree.insert(k2, v2).expect("Expected successful update");
 
         let mut k3 = [0u8; 32];
         k3[0] = 0b01001000;
         let k3 = k3.into();
         let v3 = b"DATA_3";
-        tree.update(k3, v3).expect("Expected successful update");
+        tree.insert(k3, v3).expect("Expected successful update");
 
         let root = tree.root();
 
@@ -463,25 +463,25 @@ mod test {
 
         let k0 = [0u8; 32];
         let v0 = b"DATA_0";
-        tree.update(k0.into(), v0)
+        tree.insert(k0.into(), v0)
             .expect("Expected successful update");
 
         let mut k1 = [0u8; 32];
         k1[0] = 0b01000000;
         let v1 = b"DATA_1";
-        tree.update(k1.into(), v1)
+        tree.insert(k1.into(), v1)
             .expect("Expected successful update");
 
         let mut k2 = [0u8; 32];
         k2[0] = 0b01100000;
         let v2 = b"DATA_2";
-        tree.update(k2.into(), v2)
+        tree.insert(k2.into(), v2)
             .expect("Expected successful update");
 
         let mut k3 = [0u8; 32];
         k3[0] = 0b01001000;
         let v3 = b"DATA_3";
-        tree.update(k3.into(), v3)
+        tree.insert(k3.into(), v3)
             .expect("Expected successful update");
 
         let root = tree.root();
@@ -520,25 +520,25 @@ mod test {
 
         let k0 = [0u8; 32].into();
         let v0 = b"DATA_0";
-        tree.update(k0, v0).expect("Expected successful update");
+        tree.insert(k0, v0).expect("Expected successful update");
 
         let mut k1 = [0u8; 32];
         k1[0] = 0b01000000;
         let k1 = k1.into();
         let v1 = b"DATA_1";
-        tree.update(k1, v1).expect("Expected successful update");
+        tree.insert(k1, v1).expect("Expected successful update");
 
         let mut k2 = [0u8; 32];
         k2[0] = 0b01100000;
         let k2 = k2.into();
         let v2 = b"DATA_2";
-        tree.update(k2, v2).expect("Expected successful update");
+        tree.insert(k2, v2).expect("Expected successful update");
 
         let mut k3 = [0u8; 32];
         k3[0] = 0b01001000;
         let k3 = k3.into();
         let v3 = b"DATA_3";
-        tree.update(k3, v3).expect("Expected successful update");
+        tree.insert(k3, v3).expect("Expected successful update");
 
         let root = tree.root();
 
@@ -578,19 +578,19 @@ mod test {
         k0[0] = 0b01000000;
         let k0 = k0.into();
         let v0 = b"DATA_0";
-        tree.update(k0, v0).expect("Expected successful update");
+        tree.insert(k0, v0).expect("Expected successful update");
 
         let mut k1 = [0u8; 32];
         k1[0] = 0b01100000;
         let k1 = k1.into();
         let v1 = b"DATA_1";
-        tree.update(k1, v1).expect("Expected successful update");
+        tree.insert(k1, v1).expect("Expected successful update");
 
         let mut k2 = [0u8; 32];
         k2[0] = 0b01001000;
         let k2 = k2.into();
         let v2 = b"DATA_2";
-        tree.update(k2, v2).expect("Expected successful update");
+        tree.insert(k2, v2).expect("Expected successful update");
 
         let root = tree.root();
 
@@ -658,12 +658,12 @@ mod test_random {
 
         let key = random_bytes32(&mut rng).into();
         let value = random_bytes32(&mut rng);
-        tree.update(key, &value).unwrap();
+        tree.insert(key, &value).unwrap();
 
         for _ in 0..1_000 {
             let key = random_bytes32(&mut rng).into();
             let value = random_bytes32(&mut rng);
-            tree.update(key, &value).unwrap();
+            tree.insert(key, &value).unwrap();
         }
 
         let root = tree.root();
@@ -689,12 +689,12 @@ mod test_random {
 
         let key = random_bytes32(&mut rng).into();
         let value = random_bytes32(&mut rng);
-        tree.update(key, &value).unwrap();
+        tree.insert(key, &value).unwrap();
 
         for _ in 0..1_000 {
             let key = random_bytes32(&mut rng).into();
             let value = random_bytes32(&mut rng);
-            tree.update(key, &value).unwrap();
+            tree.insert(key, &value).unwrap();
         }
 
         let root = tree.root();
@@ -720,16 +720,16 @@ mod test_random {
 
         let key_1 = random_bytes32(&mut rng).into();
         let value_1 = random_bytes32(&mut rng);
-        tree.update(key_1, &value_1).unwrap();
+        tree.insert(key_1, &value_1).unwrap();
 
         let key_2 = random_bytes32(&mut rng).into();
         let value_2 = random_bytes32(&mut rng);
-        tree.update(key_2, &value_2).unwrap();
+        tree.insert(key_2, &value_2).unwrap();
 
         for _ in 0..1_000 {
             let key = random_bytes32(&mut rng).into();
             let value = random_bytes32(&mut rng);
-            tree.update(key, &value).unwrap();
+            tree.insert(key, &value).unwrap();
         }
 
         let root = tree.root();
@@ -758,7 +758,7 @@ mod test_random {
         for _ in 0..1_000 {
             let key = random_bytes32(&mut rng);
             let value = random_bytes32(&mut rng);
-            tree.update(key.into(), &value).unwrap();
+            tree.insert(key.into(), &value).unwrap();
         }
 
         let root = tree.root();

--- a/fuel-merkle/tests-data/fixtures/Test Update With Empty Data Changes Root.yaml
+++ b/fuel-merkle/tests-data/fixtures/Test Update With Empty Data Changes Root.yaml
@@ -1,7 +1,7 @@
 expected_root:
   encoding: hex
-  value: "0000000000000000000000000000000000000000000000000000000000000000"
-name: Test Update With Empty Data Performs Delete
+  value: "3529664b414de6285270f7ebda7a43e20ae0ff6191c07d876b86282eb8ce93ce"
+name: Test Update With Empty Data Changes Root
 steps:
 - action: update
   data:

--- a/fuel-merkle/tests-data/fixtures/Test Update With Empty Data.yaml
+++ b/fuel-merkle/tests-data/fixtures/Test Update With Empty Data.yaml
@@ -1,6 +1,6 @@
 expected_root:
   encoding: hex
-  value: "0000000000000000000000000000000000000000000000000000000000000000"
+  value: "3529664b414de6285270f7ebda7a43e20ae0ff6191c07d876b86282eb8ce93ce"
 name: Test Update With Empty Data
 steps:
 - action: update


### PR DESCRIPTION
closes #937 

This PR removes the problematic check for empty values in the SMT `update` function (and the equivalent filtering in `from_set`). This makes SMTs able to commit to empty values, which we need for the proof system for the `ProcessedTransactions` table.

Additionally, to better reflect the behavior I renamed the `update` method to `insert`.