### PR TITLE
fix(memory_instance): zero out heap memory when reallocating after reset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
           targets: "wasm32-unknown-unknown"
 
       - name: Installing required crates
-        run: cargo install wasm-bindgen-cli wasm-opt
+        run: cargo install wasm-bindgen-cli wasm-opt --locked
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- [941](https://github.com/FuelLabs/fuel-vm/pull/941): Fix heap memory reallocation after reset.
+
 ## [Version 0.59.2]
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ fuel-vm = { version = "0.59.2", path = "fuel-vm", default-features = false }
 bitflags = "2"
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"
+base64ct = "=1.6.0"
 
 [profile.web-release] # For minimal wasm binaries, use this profile
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ fuel-vm = { version = "0.59.2", path = "fuel-vm", default-features = false }
 bitflags = "2"
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"
-base64ct = "=1.6.0"
 
 [profile.web-release] # For minimal wasm binaries, use this profile
 inherits = "release"

--- a/fuel-crypto/Cargo.toml
+++ b/fuel-crypto/Cargo.toml
@@ -11,11 +11,13 @@ repository = { workspace = true }
 description = "Fuel cryptographic primitives."
 
 [dependencies]
+base64ct = { version = "=1.6.0" }
 coins-bip32 = { version = "0.8", default-features = false, optional = true }
 coins-bip39 = { version = "0.8", default-features = false, features = ["english"], optional = true }
 ecdsa = { version = "0.16", default-features = false }
 ed25519-dalek = { version = "2.0.0", default-features = false }
 fuel-types = { workspace = true, default-features = false }
+half = { version = "=2.4.1", default-features = false }
 k256 = { version = "0.13", default-features = false, features = ["digest", "ecdsa"] }
 lazy_static = { version = "1.4", optional = true }
 p256 = { version = "0.13", default-features = false, features = ["digest", "ecdsa"] }

--- a/fuel-crypto/src/lib.rs
+++ b/fuel-crypto/src/lib.rs
@@ -19,6 +19,9 @@
 #[cfg(test)]
 use fuel_crypto as _;
 
+use base64ct as _;
+use half as _;
+
 /// Required export for using mnemonic keygen on [`SecretKey::new_from_mnemonic`]
 #[cfg(feature = "std")]
 #[doc(no_inline)]

--- a/fuel-vm/src/interpreter/memory.rs
+++ b/fuel-vm/src/interpreter/memory.rs
@@ -205,7 +205,7 @@ impl MemoryInstance {
             // So, either we need to clear the memory before copying,
             // or after we copied dirty parts.
             // Clearing before looks like more readable solution.
-            let end = self.hp - self.heap_offset();
+            let end = self.hp.saturating_sub(self.heap_offset());
             self.heap[..end].fill(0);
 
             // To reduce frequent reallocations, allocate at least 256 bytes at once.

--- a/fuel-vm/src/interpreter/memory.rs
+++ b/fuel-vm/src/interpreter/memory.rs
@@ -51,6 +51,7 @@ mod tests;
 #[cfg(test)]
 mod impl_tests;
 
+#[allow(non_snake_case)]
 #[cfg(test)]
 mod allocation_tests;
 
@@ -187,6 +188,26 @@ impl MemoryInstance {
             self.heap[start..end].fill(0);
         } else {
             // Reallocation is needed.
+
+            // Need to clear dirty memory before expanding it. An example:
+            // Heap vector: [dirty, dirty, dirty, 0, 0, 0]
+            //                                   /|\
+            //                                    |
+            //                                   HP
+            //
+            // If we copy from [0, old_len), it means we copy the dirty memory as well.
+            // Ending up with:
+            // Heap vector: [0, 0, dirty, dirty, dirty, 0, 0, 0]
+            //              /|\
+            //               |
+            //              HP
+            //
+            // So, either we need to clear the memory before copying,
+            // or after we copied dirty parts.
+            // Clearing before looks like more readable solution.
+            let end = self.hp - self.heap_offset();
+            self.heap[..end].fill(0);
+
             // To reduce frequent reallocations, allocate at least 256 bytes at once.
             // After that, double the allocation every time.
             let cap = new_len.next_power_of_two().clamp(256, MEM_SIZE);

--- a/fuel-vm/src/interpreter/memory/allocation_tests.rs
+++ b/fuel-vm/src/interpreter/memory/allocation_tests.rs
@@ -298,7 +298,7 @@ macro_rules! generate_memory_instance_grow_by_heap_test {
 
                 memory_instance.grow_heap_by(sp, RegMut::new(&mut hp), SIZE.try_into().unwrap())?;
                 memory_instance.write_bytes_noownerchecks(
-                    memory_instance.heap_offset().to_addr().unwrap(),
+                    memory_instance.hp,
                     [1u8; SIZE],
                 )?;
 
@@ -335,5 +335,8 @@ macro_rules! generate_memory_instance_grow_by_heap_tests {
 }
 
 generate_memory_instance_grow_by_heap_tests!(
-    256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288
+    0, 1, 16, 32, 64, 128,
+    256, 512, 1024, 2048,
+    4096, 8192, 16384,
+    32768, 65536, 131072
 );

--- a/fuel-vm/src/interpreter/memory/allocation_tests.rs
+++ b/fuel-vm/src/interpreter/memory/allocation_tests.rs
@@ -285,37 +285,55 @@ fn test_store_word(has_ownership: bool, a: Word, b: Word, c: Imm12) -> SimpleRes
     Ok(())
 }
 
-#[test]
-fn memory_instance__grow_heap_by_after_reset__does_not_retain_dirty_memory(
-) -> SimpleResult<()> {
-    // given: a pre-initialized memory instance with 1024 bytes of heap memory
-    let mut memory_instance = MemoryInstance::new();
-    let sp = Reg::new(&10);
-    let mut hp = VM_MAX_RAM;
-    const SIZE: usize = 1024;
+macro_rules! generate_memory_instance_grow_by_heap_test {
+    ($size:expr) => {
+        paste::paste! {
+            #[test]
+            fn [<memory_instance__grow_heap_by_after_reset__does_not_retain_dirty_memory_size_ $size>]() -> SimpleResult<()> {
+                // given: a pre-initialized memory instance with $size bytes of heap memory
+                let mut memory_instance = MemoryInstance::new();
+                let sp = Reg::new(&10);
+                let mut hp = VM_MAX_RAM;
+                const SIZE: usize = $size;
 
-    memory_instance.grow_heap_by(sp, RegMut::new(&mut hp), SIZE.try_into().unwrap())?;
-    memory_instance.write_bytes_noownerchecks(
-        memory_instance.heap_offset().to_addr().unwrap(),
-        [1u8; SIZE],
-    )?;
+                memory_instance.grow_heap_by(sp, RegMut::new(&mut hp), SIZE.try_into().unwrap())?;
+                memory_instance.write_bytes_noownerchecks(
+                    memory_instance.heap_offset().to_addr().unwrap(),
+                    [1u8; SIZE],
+                )?;
 
-    // when: we reset and grow the heap again, triggering the reallocation
-    // after we grow the heap again, it should not have any memory left over from before
-    // the reset
-    memory_instance.reset();
-    let mut hp = VM_MAX_RAM;
-    const NEW_SIZE: usize = SIZE * 3;
-    memory_instance.grow_heap_by(
-        sp,
-        RegMut::new(&mut hp),
-        NEW_SIZE.try_into().unwrap(),
-    )?;
-    let heap = memory_instance.heap_raw();
-    let heap_len = heap.len();
+                // when: we reset and grow the heap again, triggering the reallocation
+                // after we grow the heap again, it should not have any memory left over from before
+                // the reset
+                memory_instance.reset();
+                let mut hp = VM_MAX_RAM;
+                const NEW_SIZE: usize = SIZE * 3;
+                memory_instance.grow_heap_by(
+                    sp,
+                    RegMut::new(&mut hp),
+                    NEW_SIZE.try_into().unwrap(),
+                )?;
+                let heap = memory_instance.heap_raw();
+                let heap_len = heap.len();
 
-    // then: we check that the heap is all zeroed out
-    assert_eq!(heap, vec![0u8; heap_len]);
+                // then: we check that the heap is all zeroed out
+                assert_eq!(heap, vec![0u8; heap_len]);
 
-    Ok(())
+                Ok(())
+            }
+        }
+    };
 }
+
+// Generate tests with different sizes
+macro_rules! generate_memory_instance_grow_by_heap_tests {
+    ($($size:expr),*) => {
+        $(
+            generate_memory_instance_grow_by_heap_test!($size);
+        )*
+    };
+}
+
+generate_memory_instance_grow_by_heap_tests!(
+    256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288
+);

--- a/fuel-vm/src/interpreter/memory/allocation_tests.rs
+++ b/fuel-vm/src/interpreter/memory/allocation_tests.rs
@@ -284,3 +284,38 @@ fn test_store_word(has_ownership: bool, a: Word, b: Word, c: Imm12) -> SimpleRes
 
     Ok(())
 }
+
+#[test]
+fn memory_instance__grow_heap_by_after_reset__does_not_retain_dirty_memory(
+) -> SimpleResult<()> {
+    // given: a pre-initialized memory instance with 1024 bytes of heap memory
+    let mut memory_instance = MemoryInstance::new();
+    let sp = Reg::new(&10);
+    let mut hp = VM_MAX_RAM;
+    const SIZE: usize = 1024;
+
+    memory_instance.grow_heap_by(sp, RegMut::new(&mut hp), SIZE.try_into().unwrap())?;
+    memory_instance.write_bytes_noownerchecks(
+        memory_instance.heap_offset().to_addr().unwrap(),
+        [1u8; SIZE],
+    )?;
+
+    // when: we reset and grow the heap again, triggering the reallocation
+    // after we grow the heap again, it should not have any memory left over from before
+    // the reset
+    memory_instance.reset();
+    let mut hp = VM_MAX_RAM;
+    const NEW_SIZE: usize = SIZE * 3;
+    memory_instance.grow_heap_by(
+        sp,
+        RegMut::new(&mut hp),
+        NEW_SIZE.try_into().unwrap(),
+    )?;
+    let heap = memory_instance.heap_raw();
+    let heap_len = heap.len();
+
+    // then: we check that the heap is all zeroed out
+    assert_eq!(heap, vec![0u8; heap_len]);
+
+    Ok(())
+}

--- a/fuel-vm/src/interpreter/memory/allocation_tests.rs
+++ b/fuel-vm/src/interpreter/memory/allocation_tests.rs
@@ -285,7 +285,7 @@ fn test_store_word(has_ownership: bool, a: Word, b: Word, c: Imm12) -> SimpleRes
     Ok(())
 }
 
-macro_rules! generate_memory_instance_grow_by_heap_test {
+macro_rules! generate_test__memory_instance__grow_heap_by_after_reset__does_not_retain_dirty_memory_size {
     ($size:expr) => {
         paste::paste! {
             #[test]
@@ -326,17 +326,14 @@ macro_rules! generate_memory_instance_grow_by_heap_test {
 }
 
 // Generate tests with different sizes
-macro_rules! generate_memory_instance_grow_by_heap_tests {
+macro_rules! generate_tests__memory_instance__grow_heap_by_after_reset__does_not_retain_dirty_memory_size {
     ($($size:expr),*) => {
         $(
-            generate_memory_instance_grow_by_heap_test!($size);
+            generate_test__memory_instance__grow_heap_by_after_reset__does_not_retain_dirty_memory_size!($size);
         )*
     };
 }
 
-generate_memory_instance_grow_by_heap_tests!(
-    0, 1, 16, 32, 64, 128,
-    256, 512, 1024, 2048,
-    4096, 8192, 16384,
-    32768, 65536, 131072
+generate_tests__memory_instance__grow_heap_by_after_reset__does_not_retain_dirty_memory_size!(
+    0, 1, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072
 );


### PR DESCRIPTION
[Link to related issue(s) here, if any]
- none

[Short description of the changes.]
- we zero out the dirty memory when reallocating the heap. this is only detectable after a reset.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [ ] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
	- we need to do this
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
