### PR TITLE
fix(memory_instance): zero out heap memory when reallocating after reset (backport 0.60.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
   CARGO_TERM_COLOR: always
   RUST_VERSION: 1.81.0
   RUST_VERSION_FMT: nightly-2024-02-07
-  RUST_VERSION_COV: nightly-2024-06-05
+  RUST_VERSION_COV: nightly-2024-09-05
   GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
 
 jobs:
@@ -219,7 +219,7 @@ jobs:
           targets: "wasm32-unknown-unknown"
 
       - name: Installing required crates
-        run: cargo install wasm-bindgen-cli wasm-opt
+        run: cargo install wasm-bindgen-cli wasm-opt --locked
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
@@ -291,7 +291,7 @@ jobs:
           targets: "wasm32-unknown-unknown"
 
       - name: Installing required crates
-        run: cargo install wasm-bindgen-cli wasm-opt
+        run: cargo install wasm-bindgen-cli wasm-opt --locked
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- [942](https://github.com/FuelLabs/fuel-vm/pull/942): Fix heap memory reallocation after reset.
+
 ## [Version 0.60.0]
 
 ### Added
@@ -33,6 +37,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [889](https://github.com/FuelLabs/fuel-vm/pull/889) and [908](https://github.com/FuelLabs/fuel-vm/pull/908): Debugger breakpoint caused receipts to be produced incorrectly.
 - [903](https://github.com/FuelLabs/fuel-vm/pull/903): Fixed warning being emitted when using packages with Node@22+.
 - [912](https://github.com/FuelLabs/fuel-vm/pull/912): Fix serialization/deserialization of `Policies` in compressed transactions to be backward compatible.
+
+## [Version 0.59.3]
+
+### Fixed
+
+- [941](https://github.com/FuelLabs/fuel-vm/pull/941): Fix heap memory reallocation after reset.
 
 ## [Version 0.59.2]
 


### PR DESCRIPTION
backport similar to https://github.com/FuelLabs/fuel-vm/pull/941
