### PR TITLE
Bump version to `0.60.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.60.2]
+
 ### Added
 
 - Added new `GetGasPrice` `GM` opcode argument to retrieve the gas price of the base asset id in scripts/contracts.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,18 +19,18 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
-version = "0.60.1"
+version = "0.60.2"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.60.1", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.60.1", path = "fuel-crypto", default-features = false }
-fuel-compression = { version = "0.60.1", path = "fuel-compression", default-features = false }
-fuel-derive = { version = "0.60.1", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.60.1", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.60.1", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.60.1", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.60.1", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.60.1", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.60.2", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.60.2", path = "fuel-crypto", default-features = false }
+fuel-compression = { version = "0.60.2", path = "fuel-compression", default-features = false }
+fuel-derive = { version = "0.60.2", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.60.2", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.60.2", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.60.2", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.60.2", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.60.2", path = "fuel-vm", default-features = false }
 bitflags = "2"
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
Bump version of `fuel-vm` to `0.60.2`