### PR TITLE
Release v0.61.0

### DIFF
--- a/.changes/added/899.md
+++ b/.changes/added/899.md
@@ -1,1 +1,0 @@
-Add a feature that propose `u32` `tx_pointer` instead of `u16` in `fuel-tx` and `fuel-vm`.

--- a/.changes/added/939.md
+++ b/.changes/added/939.md
@@ -1,1 +1,0 @@
-Add new `GetGasPrice` `GM` opcode argument

--- a/.changes/breaking/778.md
+++ b/.changes/breaking/778.md
@@ -1,1 +1,0 @@
-Add `SubAssetId` newtype that's used instead of `Bytes32`.

--- a/.changes/breaking/933.md
+++ b/.changes/breaking/933.md
@@ -1,1 +1,0 @@
-Don't perform balance update if the change is zero

--- a/.changes/breaking/934.md
+++ b/.changes/breaking/934.md
@@ -1,1 +1,0 @@
-Add `input_index` of the failed predicate to `CheckError::PredicateVerificationFailed`.

--- a/.changes/breaking/935.md
+++ b/.changes/breaking/935.md
@@ -1,1 +1,0 @@
-Bump Rust version to `1.85.0`.

--- a/.changes/breaking/936.md
+++ b/.changes/breaking/936.md
@@ -1,1 +1,0 @@
-Update Rust edition to 2024.

--- a/.changes/breaking/938.md
+++ b/.changes/breaking/938.md
@@ -1,1 +1,0 @@
-Rename `update` method to `insert` on sparse merkle tree, and allow inserting empty values.

--- a/.changes/changed/913.md
+++ b/.changes/changed/913.md
@@ -1,1 +1,0 @@
-Change the way we are building the changelog to avoids conflicts.

--- a/.changes/fixed/940.md
+++ b/.changes/fixed/940.md
@@ -1,1 +1,0 @@
-Zero out heap memory when reallocating after reset.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.61.0]
+
+### Added
+- [899](https://github.com/FuelLabs/fuel-vm/pull/899): Add a feature that propose `u32` `tx_pointer` instead of `u16` in `fuel-tx` and `fuel-vm`.
+- [939](https://github.com/FuelLabs/fuel-vm/pull/939): Add new `GetGasPrice` `GM` opcode argument
+
+### Breaking
+- [778](https://github.com/FuelLabs/fuel-vm/pull/778): Add `SubAssetId` newtype that's used instead of `Bytes32`.
+- [933](https://github.com/FuelLabs/fuel-vm/pull/933): Don't perform balance update if the change is zero
+- [934](https://github.com/FuelLabs/fuel-vm/pull/934): Add `input_index` of the failed predicate to `CheckError::PredicateVerificationFailed`.
+- [935](https://github.com/FuelLabs/fuel-vm/pull/935): Bump Rust version to `1.85.0`.
+- [936](https://github.com/FuelLabs/fuel-vm/pull/936): Update Rust edition to 2024.
+- [938](https://github.com/FuelLabs/fuel-vm/pull/938): Rename `update` method to `insert` on sparse merkle tree, and allow inserting empty values.
+
+### Changed
+- [913](https://github.com/FuelLabs/fuel-vm/pull/913): Change the way we are building the changelog to avoids conflicts.
+
+### Fixed
+- [940](https://github.com/FuelLabs/fuel-vm/pull/940): Zero out heap memory when reallocating after reset.
+
 ## [Version 0.60.1]
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,18 +20,18 @@ homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
 rust-version = "1.85.0"
-version = "0.60.0"
+version = "0.61.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.60.0", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.60.0", path = "fuel-crypto", default-features = false }
-fuel-compression = { version = "0.60.0", path = "fuel-compression", default-features = false }
-fuel-derive = { version = "0.60.0", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.60.0", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.60.0", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.60.0", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.60.0", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.60.0", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.61.0", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.61.0", path = "fuel-crypto", default-features = false }
+fuel-compression = { version = "0.61.0", path = "fuel-compression", default-features = false }
+fuel-derive = { version = "0.61.0", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.61.0", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.61.0", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.61.0", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.61.0", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.61.0", path = "fuel-vm", default-features = false }
 bitflags = "2"
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
## Version 0.61.0

### Breaking
- [778](https://github.com/FuelLabs/fuel-vm/pull/778): Add `SubAssetId` newtype that's used instead of `Bytes32`.
- [933](https://github.com/FuelLabs/fuel-vm/pull/933): Don't perform balance update if the change is zero
- [934](https://github.com/FuelLabs/fuel-vm/pull/934): Add `input_index` of the failed predicate to `CheckError::PredicateVerificationFailed`.
- [935](https://github.com/FuelLabs/fuel-vm/pull/935): Bump Rust version to `1.85.0`.
- [936](https://github.com/FuelLabs/fuel-vm/pull/936): Update Rust edition to 2024.
- [938](https://github.com/FuelLabs/fuel-vm/pull/938): Rename `update` method to `insert` on sparse merkle tree, and allow inserting empty values.

### Added
- [899](https://github.com/FuelLabs/fuel-vm/pull/899): Add a feature that propose `u32` `tx_pointer` instead of `u16` in `fuel-tx` and `fuel-vm`.
- [939](https://github.com/FuelLabs/fuel-vm/pull/939): Add new `GetGasPrice` `GM` opcode argument

### Changed
- [913](https://github.com/FuelLabs/fuel-vm/pull/913): Change the way we are building the changelog to avoids conflicts.

### Fixed
- [940](https://github.com/FuelLabs/fuel-vm/pull/940): Zero out heap memory when reallocating after reset.
