### PR TITLE
hotfix: Check changelog job should only run on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,12 @@ jobs:
 
       - name: Check for a file with the PR number in a sub-directory of the .changes directory" or "no changelog" label.
         run: |
+          # Only check the changelog if we're on a PR
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "Not a pull request."
+            exit 0
+          fi
+          
           # Check if we are on master
           if [ "$GITHUB_REF" = "refs/heads/master" ]; then
             echo "On master branch, skipping changelog check."


### PR DESCRIPTION
Problem discovered during last release, where this job causes CI to fail:

https://github.com/FuelLabs/fuel-vm/actions/runs/14853766345