### PR TITLE
feat: Expose SubAssetId in fuel-tx

### DIFF
--- a/.changes/added/953.md
+++ b/.changes/added/953.md
@@ -1,0 +1,1 @@
+feat: Expose SubAssetId in fuel-tx

--- a/fuel-tx/src/lib.rs
+++ b/fuel-tx/src/lib.rs
@@ -27,7 +27,6 @@ pub use fuel_asm::{
     PanicInstruction,
     PanicReason,
 };
-use fuel_types::SubAssetId;
 pub use fuel_types::{
     Address,
     AssetId,
@@ -39,6 +38,7 @@ pub use fuel_types::{
     ContractId,
     MessageId,
     Salt,
+    SubAssetId,
     Word,
 };
 pub use tx_pointer::TxPointer;


### PR DESCRIPTION
Should have been included in https://github.com/FuelLabs/fuel-vm/pull/778 but we missed it then. Discovered while updating fuel-core to use the new 0.61.0 release.