### PR TITLE
feat: Add `Borrow` trait bounds to owned types in `Mappable` trait

### DIFF
--- a/.changes/breaking/959.md
+++ b/.changes/breaking/959.md
@@ -1,0 +1,1 @@
+Add Borrow trait bounds to owned types in Mappable trait.

--- a/fuel-storage/src/lib.rs
+++ b/fuel-storage/src/lib.rs
@@ -13,6 +13,8 @@ mod impls;
 
 extern crate alloc;
 
+use core::borrow::Borrow;
+
 use alloc::{
     borrow::{
         Cow,
@@ -46,13 +48,13 @@ pub trait Mappable {
     /// same as `Self::OwnedKey`.
     type Key: ?Sized + ToOwned;
     /// The owned type of the `Key` retrieving from the storage.
-    type OwnedKey: From<<Self::Key as ToOwned>::Owned> + Clone;
+    type OwnedKey: From<<Self::Key as ToOwned>::Owned> + Borrow<Self::Key> + Clone;
     /// The value type is used while setting the value to the storage. In most cases, it
     /// is the same as `Self::OwnedValue`, but it is without restriction and can be
     /// used for performance optimizations.
     type Value: ?Sized + ToOwned;
     /// The owned type of the `Value` retrieving from the storage.
-    type OwnedValue: From<<Self::Value as ToOwned>::Owned> + Clone;
+    type OwnedValue: From<<Self::Value as ToOwned>::Owned> + Borrow<Self::Value> + Clone;
 }
 
 /// Base read storage trait for Fuel infrastructure.

--- a/fuel-tx/src/contract.rs
+++ b/fuel-tx/src/contract.rs
@@ -21,7 +21,10 @@ use fuel_types::{
 };
 
 use alloc::vec::Vec;
-use core::iter;
+use core::{
+    borrow::Borrow,
+    iter,
+};
 
 /// The target size of Merkle tree leaves in bytes. Contract code will will be divided
 /// into chunks of this size and pushed to the Merkle tree.
@@ -147,6 +150,12 @@ impl From<&mut [u8]> for Contract {
 impl From<Contract> for Vec<u8> {
     fn from(c: Contract) -> Vec<u8> {
         c.0
+    }
+}
+
+impl Borrow<[u8]> for Contract {
+    fn borrow(&self) -> &[u8] {
+        self.0.borrow()
     }
 }
 

--- a/fuel-vm/src/storage/blob_data.rs
+++ b/fuel-vm/src/storage/blob_data.rs
@@ -1,3 +1,5 @@
+use core::borrow::Borrow;
+
 use fuel_storage::Mappable;
 use fuel_types::{
     BlobId,
@@ -53,6 +55,12 @@ impl From<&mut [u8]> for BlobBytes {
 impl From<BlobBytes> for Vec<u8> {
     fn from(c: BlobBytes) -> Vec<u8> {
         c.0
+    }
+}
+
+impl Borrow<[u8]> for BlobBytes {
+    fn borrow(&self) -> &[u8] {
+        &self.0
     }
 }
 

--- a/fuel-vm/src/storage/contracts_state.rs
+++ b/fuel-vm/src/storage/contracts_state.rs
@@ -1,3 +1,5 @@
+use core::borrow::Borrow;
+
 use crate::double_key;
 use fuel_storage::Mappable;
 use fuel_types::{
@@ -79,6 +81,12 @@ impl From<&mut [u8]> for ContractsStateData {
 impl From<ContractsStateData> for Vec<u8> {
     fn from(c: ContractsStateData) -> Vec<u8> {
         c.0
+    }
+}
+
+impl Borrow<[u8]> for ContractsStateData {
+    fn borrow(&self) -> &[u8] {
+        &self.0
     }
 }
 


### PR DESCRIPTION
closes #958 

This PR adds a `Borrow` trait bound to the owned types in the `Mappable` trait. This should improve ergonomics in generic code where we want to use the non-owned value types from the owned ones.

Since this is a limitation in the public interface of a pretty fundamental type, we should be cautious to merge it. However, since we already have an inverse `ToOwned` bound (albeit indirectly with an intermediate `From` conversion), it should be safe to assume that all existing instances are of types where they either already implement the required `Borrow` or should implement it but haven't already.

I have verified that the latest `fuel-core` compiles with this additional bound.