### PR TITLE
Prepare for 0.62.0 release

### DIFF
--- a/.changes/added/922.md
+++ b/.changes/added/922.md
@@ -1,1 +1,0 @@
-Add NIOP instruction to perform overflow-checked calculations on u8, u16, and u32 integers

--- a/.changes/added/923.md
+++ b/.changes/added/923.md
@@ -1,1 +1,0 @@
-Load and store instructions for u16 and u32

--- a/.changes/added/925.md
+++ b/.changes/added/925.md
@@ -1,1 +1,0 @@
-Add jump-and-link instruction `JAL $retaddr $targetptr offset` that can be used to implement efficient subroutine calls.

--- a/.changes/added/953.md
+++ b/.changes/added/953.md
@@ -1,1 +1,0 @@
-feat: Expose SubAssetId in fuel-tx

--- a/.changes/breaking/959.md
+++ b/.changes/breaking/959.md
@@ -1,1 +1,0 @@
-Add Borrow trait bounds to owned types in Mappable trait.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased (see .changes folder)]
 
+## [Version 0.62.0]
+
+### Breaking
+- [959](https://github.com/FuelLabs/fuel-vm/pull/959): Add Borrow trait bounds to owned types in Mappable trait.
+
+### Added
+- [922](https://github.com/FuelLabs/fuel-vm/pull/922): Add NIOP instruction to perform overflow-checked calculations on u8, u16, and u32 integers
+- [923](https://github.com/FuelLabs/fuel-vm/pull/923): Load and store instructions for u16 and u32
+- [925](https://github.com/FuelLabs/fuel-vm/pull/925): Add jump-and-link instruction `JAL   offset` that can be used to implement efficient subroutine calls.
+- [953](https://github.com/FuelLabs/fuel-vm/pull/953): feat: Expose SubAssetId in fuel-tx
+
 ## [Version 0.61.0]
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,18 +20,18 @@ homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
 rust-version = "1.85.0"
-version = "0.61.0"
+version = "0.62.0"
 
 [workspace.dependencies]
-fuel-asm = { version = "0.61.0", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.61.0", path = "fuel-crypto", default-features = false }
-fuel-compression = { version = "0.61.0", path = "fuel-compression", default-features = false }
-fuel-derive = { version = "0.61.0", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.61.0", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.61.0", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.61.0", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.61.0", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.61.0", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.62.0", path = "fuel-asm", default-features = false }
+fuel-crypto = { version = "0.62.0", path = "fuel-crypto", default-features = false }
+fuel-compression = { version = "0.62.0", path = "fuel-compression", default-features = false }
+fuel-derive = { version = "0.62.0", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.62.0", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.62.0", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.62.0", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.62.0", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.62.0", path = "fuel-vm", default-features = false }
 bitflags = "2"
 bincode = { version = "1.3", default-features = false }
 criterion = "0.5.0"


### PR DESCRIPTION
## Version 0.62.0

### Breaking
- [959](https://github.com/FuelLabs/fuel-vm/pull/959): Add Borrow trait bounds to owned types in Mappable trait.

### Added
- [922](https://github.com/FuelLabs/fuel-vm/pull/922): Add NIOP instruction to perform overflow-checked calculations on u8, u16, and u32 integers
- [923](https://github.com/FuelLabs/fuel-vm/pull/923): Load and store instructions for u16 and u32
- [925](https://github.com/FuelLabs/fuel-vm/pull/925): Add jump-and-link instruction `JAL` that can be used to implement efficient subroutine calls.
- [953](https://github.com/FuelLabs/fuel-vm/pull/953): feat: Expose SubAssetId in fuel-tx
