### PR TITLE
Allow setting ECAL for predicate exection

### DIFF
--- a/.changes/breaking/963.md
+++ b/.changes/breaking/963.md
@@ -1,0 +1,1 @@
+Adds `ECAL` state parameter to some predicate-related APIs. Allows `ECAL` instruction during predicate execution. Exposes `Interpreter::context` function that can be used by the `ECAL` handler to determine if it's inside a predicate.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,18 +23,18 @@ rust-version = "1.85.0"
 version = "0.62.0"
 
 [workspace.dependencies]
+bincode = { version = "1.3", default-features = false }
+bitflags = "2"
+criterion = "0.5.0"
 fuel-asm = { version = "0.62.0", path = "fuel-asm", default-features = false }
-fuel-crypto = { version = "0.62.0", path = "fuel-crypto", default-features = false }
 fuel-compression = { version = "0.62.0", path = "fuel-compression", default-features = false }
+fuel-crypto = { version = "0.62.0", path = "fuel-crypto", default-features = false }
 fuel-derive = { version = "0.62.0", path = "fuel-derive", default-features = false }
 fuel-merkle = { version = "0.62.0", path = "fuel-merkle", default-features = false }
 fuel-storage = { version = "0.62.0", path = "fuel-storage", default-features = false }
 fuel-tx = { version = "0.62.0", path = "fuel-tx", default-features = false }
 fuel-types = { version = "0.62.0", path = "fuel-types", default-features = false }
 fuel-vm = { version = "0.62.0", path = "fuel-vm", default-features = false }
-bitflags = "2"
-bincode = { version = "1.3", default-features = false }
-criterion = "0.5.0"
 
 [profile.web-release] # For minimal wasm binaries, use this profile
 inherits = "release"

--- a/fuel-asm/Cargo.toml
+++ b/fuel-asm/Cargo.toml
@@ -11,6 +11,21 @@ license = "Apache-2.0"
 repository = { workspace = true }
 description = "Atomic types of the FuelVM."
 
+# docs.rs-specific configuration
+# preview with `RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --open`
+[package.metadata.docs.rs]
+# document all features
+all-features = true
+# defines the configuration attribute `docsrs`
+rustdoc-args = ["--cfg", "docsrs"]
+
+[features]
+default = ["std"]
+typescript = ["wasm-bindgen"]
+std = ["alloc", "serde?/default", "fuel-types/std"]
+alloc = []
+serde = ["dep:serde"]
+
 [dependencies]
 bitflags = { workspace = true }
 fuel-types = { workspace = true, default-features = false }
@@ -22,18 +37,3 @@ wasm-bindgen = { version = "0.2.97", optional = true }
 bincode = { workspace = true }
 fuel-asm = { path = ".", features = ["serde"] }
 rstest = "0.16"
-
-[features]
-default = ["std"]
-typescript = ["wasm-bindgen"]
-std = ["alloc", "serde?/default", "fuel-types/std"]
-alloc = []
-serde = ["dep:serde"]
-
-# docs.rs-specific configuration
-# preview with `RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --open`
-[package.metadata.docs.rs]
-# document all features
-all-features = true
-# defines the configuration attribute `docsrs`
-rustdoc-args = ["--cfg", "docsrs"]

--- a/fuel-asm/src/lib.rs
+++ b/fuel-asm/src/lib.rs
@@ -1011,7 +1011,7 @@ fn check_predicate_allowed() {
             let should_allow = match repr {
                 BAL | BHEI | BHSH | BURN | CALL | CB | CCP | CROO | CSIZ | LOG | LOGD
                 | MINT | RETD | RVRT | SMO | SCWQ | SRW | SRWQ | SWW | SWWQ | TIME
-                | TR | TRO | ECAL => false,
+                | TR | TRO => false,
                 _ => true,
             };
             assert_eq!(should_allow, repr.is_predicate_allowed());

--- a/fuel-asm/src/lib.rs
+++ b/fuel-asm/src/lib.rs
@@ -719,7 +719,7 @@ impl Opcode {
             | MULI | MLDV | ORI | SLLI | SRLI | SUBI | XORI | JNEI | LB | LQW | LHW
             | LW | SB | SQW | SHW | SW | MCPI | MCLI | GM | MOVI | JNZI | JI | JMP
             | JNE | JMPF | JMPB | JNZF | JNZB | JNEF | JNEB | JAL | CFEI | CFSI | CFE
-            | CFS | GTF | LDC | BSIZ | BLDD | ECOP | EPAR => true,
+            | CFS | GTF | LDC | BSIZ | BLDD | ECAL | ECOP | EPAR => true,
             _ => false,
         }
     }

--- a/fuel-crypto/Cargo.toml
+++ b/fuel-crypto/Cargo.toml
@@ -11,6 +11,34 @@ license = "Apache-2.0"
 repository = { workspace = true }
 description = "Fuel cryptographic primitives."
 
+# docs.rs-specific configuration
+[package.metadata.docs.rs]
+# document all features
+all-features = true
+# defines the configuration attribute `docsrs`
+rustdoc-args = ["--cfg", "docsrs"]
+
+[features]
+default = ["fuel-types/default", "std"]
+alloc = ["rand?/alloc", "secp256k1?/alloc", "fuel-types/alloc"]
+random = ["fuel-types/random", "rand"]
+serde = ["dep:serde", "fuel-types/serde"]
+std = [
+    "alloc",
+    "coins-bip32",
+    "secp256k1",
+    "coins-bip39",
+    "fuel-types/std",
+    "rand?/std_rng",
+    "serde?/default",
+    "k256/std",
+    "ed25519-dalek/std",
+    "sha2/std",
+    "p256/std",
+    "ecdsa/std",
+]
+test-helpers = []
+
 [dependencies]
 base64ct = "=1.6" # HACK: transitive dependency breaking MSRV requirement
 coins-bip32 = { version = "0.8", default-features = false, optional = true }
@@ -35,14 +63,6 @@ fuel-crypto = { path = ".", features = ["random", "test-helpers"] }
 sha2 = "0.10"
 test-case = "3.3"
 
-[features]
-default = ["fuel-types/default", "std"]
-alloc = ["rand?/alloc", "secp256k1?/alloc", "fuel-types/alloc"]
-random = ["fuel-types/random", "rand"]
-serde = ["dep:serde", "fuel-types/serde"]
-std = ["alloc", "coins-bip32", "secp256k1", "coins-bip39", "fuel-types/std", "rand?/std_rng", "serde?/default", "k256/std", "ed25519-dalek/std", "sha2/std", "p256/std", "ecdsa/std"]
-test-helpers = []
-
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
 
@@ -50,10 +70,3 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
 name = "signature"
 harness = false
 required-features = ["std"]
-
-# docs.rs-specific configuration
-[package.metadata.docs.rs]
-# document all features
-all-features = true
-# defines the configuration attribute `docsrs`
-rustdoc-args = ["--cfg", "docsrs"]

--- a/fuel-merkle/Cargo.toml
+++ b/fuel-merkle/Cargo.toml
@@ -11,6 +11,12 @@ license = "Apache-2.0"
 repository = { workspace = true }
 description = "Fuel Merkle tree libraries."
 
+[features]
+default = ["std"]
+std = ["digest/default", "hex/default", "sha2/default"]
+test-helpers = []
+serde = ["dep:serde"]
+
 [dependencies]
 derive_more = { version = "0.99", default-features = false, features = ["display"] }
 digest = { version = "0.10", default-features = false }
@@ -30,14 +36,6 @@ proptest-derive = "0.5.1"
 rand = "0.8"
 serde_json = "1.0"
 serde_yaml = "0.9"
-
-[features]
-default = ["std"]
-std = ["digest/default", "hex/default", "sha2/default"]
-test-helpers = []
-serde = [
-    "dep:serde",
-]
 
 [[test]]
 name = "tests-data"

--- a/fuel-tx/Cargo.toml
+++ b/fuel-tx/Cargo.toml
@@ -11,6 +11,53 @@ license = "Apache-2.0"
 repository = { workspace = true }
 description = "FuelVM transaction."
 
+[features]
+default = [
+    "fuel-asm/default",
+    "fuel-crypto/default",
+    "fuel-merkle/default",
+    "fuel-types/default",
+    "std",
+]
+test-helpers = ["alloc", "internals"]
+internals = []
+typescript = [
+    "dep:serde_json",
+    "alloc",
+    "js-sys",
+    "wasm-bindgen",
+    "serde-wasm-bindgen",
+    "fuel-types/typescript",
+]
+random = ["fuel-crypto/random", "fuel-types/random", "rand"]
+std = [
+    "alloc",
+    "fuel-asm/std",
+    "fuel-crypto/std",
+    "fuel-merkle/std",
+    "fuel-types/std",
+    "itertools/default",
+    "rand?/default",
+    "serde/default",
+    "hex/std",
+]
+alloc = [
+    "hashbrown",
+    "fuel-types/alloc",
+    "itertools/use_alloc",
+    "fuel-merkle",
+    "strum",
+    "strum_macros",
+    "bitflags",
+    "postcard",
+    "educe",
+    "derive_more",
+    "fuel-asm/serde",
+    "fuel-types/serde",
+]
+da-compression = ["fuel-compression"]
+u32-tx-pointer = []
+
 [dependencies]
 bitflags = { workspace = true, features = ["serde"], optional = true }
 derive_more = { version = "1", default-features = false, features = ["display"], optional = true }
@@ -49,17 +96,6 @@ rstest = "0.15"
 serde_json = { version = "1.0" }
 serde_test = { version = "1.0" }
 tokio = { version = "1.27", features = ["full"] }
-
-[features]
-default = ["fuel-asm/default", "fuel-crypto/default", "fuel-merkle/default", "fuel-types/default", "std"]
-test-helpers = ["alloc", "internals"]
-internals = []
-typescript = ["dep:serde_json", "alloc", "js-sys", "wasm-bindgen", "serde-wasm-bindgen", "fuel-types/typescript"]
-random = ["fuel-crypto/random", "fuel-types/random", "rand"]
-std = ["alloc", "fuel-asm/std", "fuel-crypto/std", "fuel-merkle/std", "fuel-types/std", "itertools/default", "rand?/default", "serde/default", "hex/std"]
-alloc = ["hashbrown", "fuel-types/alloc", "itertools/use_alloc", "fuel-merkle", "strum", "strum_macros", "bitflags", "postcard", "educe", "derive_more", "fuel-asm/serde", "fuel-types/serde"]
-da-compression = ["fuel-compression"]
-u32-tx-pointer = []
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }

--- a/fuel-types/Cargo.toml
+++ b/fuel-types/Cargo.toml
@@ -11,6 +11,15 @@ license = "Apache-2.0"
 repository = { workspace = true }
 description = "Atomic types of the FuelVM."
 
+[features]
+default = ["std", "serde?/default"]
+typescript = ["wasm-bindgen"]
+alloc = ["hex/alloc"]
+random = ["rand"]
+serde = ["dep:serde", "alloc"]
+std = ["alloc", "serde?/std", "hex/std"]
+unsafe = []
+
 [dependencies]
 fuel-derive = { workspace = true }
 hex = { version = "0.4", default-features = false }
@@ -25,15 +34,6 @@ fuel-types = { path = ".", features = ["random", "serde"] }
 postcard = { version = "1.0", features = ["use-std"] }
 rand = { version = "0.8", default-features = false, features = ["std_rng"] }
 serde_json = "1.0"
-
-[features]
-default = ["std", "serde?/default"]
-typescript = ["wasm-bindgen"]
-alloc = ["hex/alloc"]
-random = ["rand"]
-serde = ["dep:serde", "alloc"]
-std = ["alloc", "serde?/std", "hex/std"]
-unsafe = []
 
 [[bench]]
 name = "bench"

--- a/fuel-vm/Cargo.toml
+++ b/fuel-vm/Cargo.toml
@@ -11,10 +11,39 @@ license = "BUSL-1.1"
 repository = { workspace = true }
 description = "FuelVM interpreter."
 
-[[bench]]
-name = "execution"
-harness = false
-required-features = ["std"]
+[features]
+default = ["std"]
+std = [
+    "alloc",
+    "fuel-crypto/std",
+    "fuel-types/std",
+    "fuel-asm/std",
+    "fuel-tx/std",
+    "itertools/use_std",
+    "sha3/std",
+]
+alloc = ["fuel-asm/alloc", "fuel-tx/alloc", "fuel-crypto/alloc"]
+random = ["fuel-crypto/random", "fuel-types/random", "fuel-tx/random", "rand"]
+da-compression = ["fuel-compression", "fuel-tx/da-compression"]
+serde = [
+    "dep:serde",
+    "dep:serde_with",
+    "hashbrown/serde",
+    "fuel-asm/serde",
+    "fuel-types/serde",
+    "fuel-merkle/serde",
+    "fuel-crypto/serde",
+    "backtrace?/serde",
+]
+test-helpers = [
+    "fuel-tx/test-helpers",
+    "alloc",
+    "random",
+    "dep:anyhow",
+    "tai64",
+    "fuel-crypto/test-helpers",
+]
+u32-tx-pointer = ["fuel-tx/u32-tx-pointer"]
 
 [dependencies]
 anyhow = { version = "1.0", optional = true }
@@ -73,39 +102,10 @@ test-case = "3.3"
 tokio = { version = "1.27", features = ["full"] }
 tokio-rayon = "2.1.0"
 
-[features]
-default = ["std"]
-std = [
-    "alloc",
-    "fuel-crypto/std",
-    "fuel-types/std",
-    "fuel-asm/std",
-    "fuel-tx/std",
-    "itertools/use_std",
-    "sha3/std"
-]
-alloc = ["fuel-asm/alloc", "fuel-tx/alloc", "fuel-crypto/alloc"]
-random = ["fuel-crypto/random", "fuel-types/random", "fuel-tx/random", "rand"]
-da-compression = ["fuel-compression", "fuel-tx/da-compression"]
-serde = [
-    "dep:serde",
-    "dep:serde_with",
-    "hashbrown/serde",
-    "fuel-asm/serde",
-    "fuel-types/serde",
-    "fuel-merkle/serde",
-    "fuel-crypto/serde",
-    "backtrace?/serde",
-]
-test-helpers = [
-    "fuel-tx/test-helpers",
-    "alloc",
-    "random",
-    "dep:anyhow",
-    "tai64",
-    "fuel-crypto/test-helpers",
-]
-u32-tx-pointer = ["fuel-tx/u32-tx-pointer"]
+[[bench]]
+name = "execution"
+harness = false
+required-features = ["std"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }

--- a/fuel-vm/src/checked_transaction.rs
+++ b/fuel-vm/src/checked_transaction.rs
@@ -340,7 +340,7 @@ pub trait IntoChecked: FormatValidityChecks + Sized {
             consensus_params,
             memory,
             storage,
-            NotSupportedEcal::default(),
+            NotSupportedEcal,
         )
     }
 
@@ -482,13 +482,7 @@ pub trait EstimatePredicates: Sized {
         memory: impl Memory,
         storage: &impl PredicateStorageRequirements,
     ) -> Result<(), CheckError> {
-        Self::estimate_predicates_ecal(
-            self,
-            params,
-            memory,
-            storage,
-            NotSupportedEcal::default(),
-        )
+        Self::estimate_predicates_ecal(self, params, memory, storage, NotSupportedEcal)
     }
 
     /// Estimates predicates of the transaction in parallel.
@@ -503,7 +497,7 @@ pub trait EstimatePredicates: Sized {
             params,
             pool,
             storage,
-            NotSupportedEcal::default(),
+            NotSupportedEcal,
         )
         .await
     }
@@ -2139,7 +2133,7 @@ mod tests {
             )
             .unwrap()
             // Sets Checks::Predicates
-            .check_predicates(&check_predicate_params, MemoryInstance::new(), &EmptyStorage, NotSupportedEcal::default())
+            .check_predicates(&check_predicate_params, MemoryInstance::new(), &EmptyStorage, NotSupportedEcal)
             .unwrap();
         assert!(
             checked

--- a/fuel-vm/src/interpreter.rs
+++ b/fuel-vm/src/interpreter.rs
@@ -76,10 +76,7 @@ mod debug;
 mod ecal;
 
 pub use balances::RuntimeBalances;
-pub use ecal::{
-    EcalHandler,
-    PredicateErrorEcal,
-};
+pub use ecal::EcalHandler;
 pub use executors::predicates;
 pub use memory::{
     Memory,

--- a/fuel-vm/src/interpreter/ecal.rs
+++ b/fuel-vm/src/interpreter/ecal.rs
@@ -20,7 +20,11 @@ use super::{
     internal::inc_pc,
 };
 
-/// ECAL opcode handler
+/// ECAL opcode handler.
+///
+/// This can be cloned...
+/// * when the whole VM instance is cloned, for any reason
+/// * for each predicate when running predicates for a tx
 pub trait EcalHandler: Clone
 where
     Self: Sized,
@@ -51,23 +55,6 @@ impl EcalHandler for NotSupportedEcal {
         _: RegId,
     ) -> SimpleResult<()> {
         Err(PanicReason::EcalError)?
-    }
-}
-
-/// ECAL is not allowed in predicates
-#[derive(Debug, Clone, Copy, Default)]
-pub struct PredicateErrorEcal;
-
-/// ECAL is not allowed in predicates
-impl EcalHandler for PredicateErrorEcal {
-    fn ecal<M, S, Tx, V>(
-        _vm: &mut Interpreter<M, S, Tx, Self, V>,
-        _: RegId,
-        _: RegId,
-        _: RegId,
-        _: RegId,
-    ) -> SimpleResult<()> {
-        Err(PanicReason::ContractInstructionNotAllowed)?
     }
 }
 

--- a/fuel-vm/src/interpreter/executors/main.rs
+++ b/fuel-vm/src/interpreter/executors/main.rs
@@ -373,6 +373,7 @@ pub mod predicates {
         finalize_check_predicate(kind, checks, params)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn check_predicate<Tx, Ecal>(
         tx: Tx,
         index: usize,

--- a/fuel-vm/src/interpreter/executors/main.rs
+++ b/fuel-vm/src/interpreter/executors/main.rs
@@ -153,15 +153,17 @@ pub mod predicates {
     ///
     /// The storage provider is not used since contract opcodes are not allowed for
     /// predicates.
-    pub fn check_predicates<Tx>(
+    pub fn check_predicates<Tx, Ecal>(
         checked: &Checked<Tx>,
         params: &CheckPredicateParams,
         mut memory: impl Memory,
         storage: &impl PredicateStorageRequirements,
+        ecal_state: Ecal,
     ) -> Result<PredicatesChecked, PredicateVerificationFailed>
     where
         Tx: ExecutableTransaction,
         <Tx as IntoChecked>::Metadata: CheckedMetadata,
+        Ecal: EcalHandler,
     {
         let tx = checked.transaction();
         run_predicates(
@@ -169,6 +171,7 @@ pub mod predicates {
             params,
             memory.as_mut(),
             storage,
+            ecal_state,
         )
     }
 
@@ -177,24 +180,27 @@ pub mod predicates {
     ///
     /// The storage provider is not used since contract opcodes are not allowed for
     /// predicates.
-    pub async fn check_predicates_async<Tx, E>(
+    pub async fn check_predicates_async<Tx, Ecal, E>(
         checked: &Checked<Tx>,
         params: &CheckPredicateParams,
         pool: &impl VmMemoryPool,
         storage: &impl PredicateStorageProvider,
+        ecal_state: Ecal,
     ) -> Result<PredicatesChecked, PredicateVerificationFailed>
     where
         Tx: ExecutableTransaction + Send + 'static,
         <Tx as IntoChecked>::Metadata: CheckedMetadata,
         E: ParallelExecutor,
+        Ecal: EcalHandler + Send + 'static,
     {
         let tx = checked.transaction();
 
-        let predicates_checked = run_predicate_async::<Tx, E>(
+        let predicates_checked = run_predicate_async::<Tx, Ecal, E>(
             PredicateRunKind::Verifying(tx),
             params,
             pool,
             storage,
+            ecal_state,
         )
         .await?;
 
@@ -207,20 +213,23 @@ pub mod predicates {
     ///
     /// The storage provider is not used since contract opcodes are not allowed for
     /// predicates.
-    pub fn estimate_predicates<Tx>(
+    pub fn estimate_predicates<Tx, Ecal>(
         transaction: &mut Tx,
         params: &CheckPredicateParams,
         mut memory: impl Memory,
         storage: &impl PredicateStorageRequirements,
+        ecal_state: Ecal,
     ) -> Result<PredicatesChecked, PredicateVerificationFailed>
     where
         Tx: ExecutableTransaction,
+        Ecal: EcalHandler,
     {
         let predicates_checked = run_predicates(
             PredicateRunKind::Estimating(transaction),
             params,
             memory.as_mut(),
             storage,
+            ecal_state,
         )?;
         Ok(predicates_checked)
     }
@@ -231,36 +240,41 @@ pub mod predicates {
     ///
     /// The storage provider is not used since contract opcodes are not allowed for
     /// predicates.
-    pub async fn estimate_predicates_async<Tx, E>(
+    pub async fn estimate_predicates_async<Tx, Ecal, E>(
         transaction: &mut Tx,
         params: &CheckPredicateParams,
         pool: &impl VmMemoryPool,
         storage: &impl PredicateStorageProvider,
+        ecal_state: Ecal,
     ) -> Result<PredicatesChecked, PredicateVerificationFailed>
     where
         Tx: ExecutableTransaction + Send + 'static,
         E: ParallelExecutor,
+        Ecal: EcalHandler + Send + 'static,
     {
-        let predicates_checked = run_predicate_async::<Tx, E>(
+        let predicates_checked = run_predicate_async::<Tx, Ecal, E>(
             PredicateRunKind::Estimating(transaction),
             params,
             pool,
             storage,
+            ecal_state,
         )
         .await?;
 
         Ok(predicates_checked)
     }
 
-    async fn run_predicate_async<Tx, E>(
+    async fn run_predicate_async<Tx, Ecal, E>(
         kind: PredicateRunKind<'_, Tx>,
         params: &CheckPredicateParams,
         pool: &impl VmMemoryPool,
         storage: &impl PredicateStorageProvider,
+        ecal_state: Ecal,
     ) -> Result<PredicatesChecked, PredicateVerificationFailed>
     where
         Tx: ExecutableTransaction + Send + 'static,
         E: ParallelExecutor,
+        Ecal: EcalHandler + Send + 'static,
     {
         let mut checks = vec![];
         let tx_offset = params.tx_offset;
@@ -284,6 +298,7 @@ pub mod predicates {
                 let my_params = params.clone();
                 let mut memory = pool.get_new().await;
                 let storage_instance = storage.storage();
+                let ecal_state = ecal_state.clone();
 
                 let verify_task = E::create_task(move || {
                     let (used_gas, result) = check_predicate(
@@ -294,6 +309,7 @@ pub mod predicates {
                         my_params,
                         memory.as_mut(),
                         &storage_instance,
+                        ecal_state,
                     );
 
                     (index, result.map(|()| used_gas))
@@ -308,14 +324,16 @@ pub mod predicates {
         finalize_check_predicate(kind, checks, params)
     }
 
-    fn run_predicates<Tx>(
+    fn run_predicates<Tx, Ecal>(
         kind: PredicateRunKind<'_, Tx>,
         params: &CheckPredicateParams,
         mut memory: impl Memory,
         storage: &impl PredicateStorageRequirements,
+        ecal_state: Ecal,
     ) -> Result<PredicatesChecked, PredicateVerificationFailed>
     where
         Tx: ExecutableTransaction,
+        Ecal: EcalHandler,
     {
         let mut checks = vec![];
 
@@ -345,6 +363,7 @@ pub mod predicates {
                     params.clone(),
                     memory.as_mut(),
                     storage,
+                    ecal_state.clone(),
                 );
                 global_available_gas = global_available_gas.saturating_sub(gas_used);
                 checks.push((index, result.map(|()| gas_used)));
@@ -354,7 +373,7 @@ pub mod predicates {
         finalize_check_predicate(kind, checks, params)
     }
 
-    fn check_predicate<Tx>(
+    fn check_predicate<Tx, Ecal>(
         tx: Tx,
         index: usize,
         predicate_action: PredicateAction,
@@ -362,9 +381,11 @@ pub mod predicates {
         params: CheckPredicateParams,
         memory: &mut MemoryInstance,
         storage: &impl PredicateStorageRequirements,
+        ecal_state: Ecal,
     ) -> (Word, Result<(), PredicateVerificationFailed>)
     where
         Tx: ExecutableTransaction,
+        Ecal: EcalHandler,
     {
         if predicate_action == PredicateAction::Verifying {
             match &tx.inputs()[index] {
@@ -397,10 +418,11 @@ pub mod predicates {
         let zero_gas_price = 0;
         let interpreter_params = InterpreterParams::new(zero_gas_price, params);
 
-        let mut vm = Interpreter::<_, _, _>::with_storage(
+        let mut vm = Interpreter::<_, _, _, Ecal>::with_storage_and_ecal(
             memory,
             PredicateStorage::new(storage),
             interpreter_params,
+            ecal_state,
         );
 
         let (context, available_gas) = match predicate_action {

--- a/fuel-vm/src/interpreter/executors/main.rs
+++ b/fuel-vm/src/interpreter/executors/main.rs
@@ -158,7 +158,7 @@ pub mod predicates {
         params: &CheckPredicateParams,
         mut memory: impl Memory,
         storage: &impl PredicateStorageRequirements,
-        ecal_state: Ecal,
+        ecal_handler: Ecal,
     ) -> Result<PredicatesChecked, PredicateVerificationFailed>
     where
         Tx: ExecutableTransaction,
@@ -171,7 +171,7 @@ pub mod predicates {
             params,
             memory.as_mut(),
             storage,
-            ecal_state,
+            ecal_handler,
         )
     }
 
@@ -185,7 +185,7 @@ pub mod predicates {
         params: &CheckPredicateParams,
         pool: &impl VmMemoryPool,
         storage: &impl PredicateStorageProvider,
-        ecal_state: Ecal,
+        ecal_handler: Ecal,
     ) -> Result<PredicatesChecked, PredicateVerificationFailed>
     where
         Tx: ExecutableTransaction + Send + 'static,
@@ -200,7 +200,7 @@ pub mod predicates {
             params,
             pool,
             storage,
-            ecal_state,
+            ecal_handler,
         )
         .await?;
 
@@ -218,7 +218,7 @@ pub mod predicates {
         params: &CheckPredicateParams,
         mut memory: impl Memory,
         storage: &impl PredicateStorageRequirements,
-        ecal_state: Ecal,
+        ecal_handler: Ecal,
     ) -> Result<PredicatesChecked, PredicateVerificationFailed>
     where
         Tx: ExecutableTransaction,
@@ -229,7 +229,7 @@ pub mod predicates {
             params,
             memory.as_mut(),
             storage,
-            ecal_state,
+            ecal_handler,
         )?;
         Ok(predicates_checked)
     }
@@ -245,7 +245,7 @@ pub mod predicates {
         params: &CheckPredicateParams,
         pool: &impl VmMemoryPool,
         storage: &impl PredicateStorageProvider,
-        ecal_state: Ecal,
+        ecal_handler: Ecal,
     ) -> Result<PredicatesChecked, PredicateVerificationFailed>
     where
         Tx: ExecutableTransaction + Send + 'static,
@@ -257,7 +257,7 @@ pub mod predicates {
             params,
             pool,
             storage,
-            ecal_state,
+            ecal_handler,
         )
         .await?;
 
@@ -269,7 +269,7 @@ pub mod predicates {
         params: &CheckPredicateParams,
         pool: &impl VmMemoryPool,
         storage: &impl PredicateStorageProvider,
-        ecal_state: Ecal,
+        ecal_handler: Ecal,
     ) -> Result<PredicatesChecked, PredicateVerificationFailed>
     where
         Tx: ExecutableTransaction + Send + 'static,
@@ -298,7 +298,7 @@ pub mod predicates {
                 let my_params = params.clone();
                 let mut memory = pool.get_new().await;
                 let storage_instance = storage.storage();
-                let ecal_state = ecal_state.clone();
+                let ecal_handler = ecal_handler.clone();
 
                 let verify_task = E::create_task(move || {
                     let (used_gas, result) = check_predicate(
@@ -309,7 +309,7 @@ pub mod predicates {
                         my_params,
                         memory.as_mut(),
                         &storage_instance,
-                        ecal_state,
+                        ecal_handler,
                     );
 
                     (index, result.map(|()| used_gas))
@@ -329,7 +329,7 @@ pub mod predicates {
         params: &CheckPredicateParams,
         mut memory: impl Memory,
         storage: &impl PredicateStorageRequirements,
-        ecal_state: Ecal,
+        ecal_handler: Ecal,
     ) -> Result<PredicatesChecked, PredicateVerificationFailed>
     where
         Tx: ExecutableTransaction,
@@ -363,7 +363,7 @@ pub mod predicates {
                     params.clone(),
                     memory.as_mut(),
                     storage,
-                    ecal_state.clone(),
+                    ecal_handler.clone(),
                 );
                 global_available_gas = global_available_gas.saturating_sub(gas_used);
                 checks.push((index, result.map(|()| gas_used)));
@@ -382,7 +382,7 @@ pub mod predicates {
         params: CheckPredicateParams,
         memory: &mut MemoryInstance,
         storage: &impl PredicateStorageRequirements,
-        ecal_state: Ecal,
+        ecal_handler: Ecal,
     ) -> (Word, Result<(), PredicateVerificationFailed>)
     where
         Tx: ExecutableTransaction,
@@ -423,7 +423,7 @@ pub mod predicates {
             memory,
             PredicateStorage::new(storage),
             interpreter_params,
-            ecal_state,
+            ecal_handler,
         );
 
         let (context, available_gas) = match predicate_action {

--- a/fuel-vm/src/interpreter/executors/main/tests.rs
+++ b/fuel-vm/src/interpreter/executors/main/tests.rs
@@ -69,7 +69,7 @@ fn estimate_gas_gives_proper_gas_used() {
             &params.into(),
             MemoryInstance::new(),
             &EmptyStorage,
-            NotSupportedEcal::default(),
+            NotSupportedEcal,
         )
         .expect("Predicate check failed even if we don't have any predicates");
 
@@ -117,7 +117,7 @@ fn estimate_gas_gives_proper_gas_used() {
         &params.into(),
         MemoryInstance::new(),
         &EmptyStorage,
-        NotSupportedEcal::default(),
+        NotSupportedEcal,
     )
     .expect("Should successfully estimate predicates");
 

--- a/fuel-vm/src/interpreter/executors/main/tests.rs
+++ b/fuel-vm/src/interpreter/executors/main/tests.rs
@@ -5,7 +5,10 @@ use crate::{
         CheckPredicates,
         Checked,
     },
-    interpreter::MemoryInstance,
+    interpreter::{
+        MemoryInstance,
+        NotSupportedEcal,
+    },
     prelude::{
         predicates::estimate_predicates,
         *,
@@ -62,7 +65,12 @@ fn estimate_gas_gives_proper_gas_used() {
 
     let transaction_without_predicate = builder
         .finalize_checked_basic(Default::default())
-        .check_predicates(&params.into(), MemoryInstance::new(), &EmptyStorage)
+        .check_predicates(
+            &params.into(),
+            MemoryInstance::new(),
+            &EmptyStorage,
+            NotSupportedEcal::default(),
+        )
         .expect("Predicate check failed even if we don't have any predicates");
 
     let mut client = MemoryClient::default();
@@ -109,6 +117,7 @@ fn estimate_gas_gives_proper_gas_used() {
         &params.into(),
         MemoryInstance::new(),
         &EmptyStorage,
+        NotSupportedEcal::default(),
     )
     .expect("Should successfully estimate predicates");
 

--- a/fuel-vm/src/interpreter/internal.rs
+++ b/fuel-vm/src/interpreter/internal.rs
@@ -123,7 +123,8 @@ where
         set_flag(flag, pc, a)
     }
 
-    pub(crate) const fn context(&self) -> &Context {
+    /// Get the current execution context
+    pub const fn context(&self) -> &Context {
         &self.context
     }
 

--- a/fuel-vm/src/predicate.rs
+++ b/fuel-vm/src/predicate.rs
@@ -300,7 +300,7 @@ mod tests {
                     &CheckPredicateParams::default(),
                     MemoryInstance::new(),
                     &storage,
-                    NotSupportedEcal::default(),
+                    NotSupportedEcal,
                 );
 
                 assert_eq!(result.map(|_| ()), expected, "failed at input {}", i);

--- a/fuel-vm/src/predicate.rs
+++ b/fuel-vm/src/predicate.rs
@@ -81,7 +81,10 @@ mod tests {
             ZERO,
         },
         error::PredicateVerificationFailed,
-        interpreter::InterpreterParams,
+        interpreter::{
+            InterpreterParams,
+            NotSupportedEcal,
+        },
         prelude::{
             predicates::check_predicates,
             *,
@@ -297,6 +300,7 @@ mod tests {
                     &CheckPredicateParams::default(),
                     MemoryInstance::new(),
                     &storage,
+                    NotSupportedEcal::default(),
                 );
 
                 assert_eq!(result.map(|_| ()), expected, "failed at input {}", i);

--- a/fuel-vm/src/tests/external.rs
+++ b/fuel-vm/src/tests/external.rs
@@ -1,3 +1,8 @@
+use crate::{
+    error::SimpleResult,
+    interpreter::EcalHandler,
+    prelude::*,
+};
 use alloc::vec;
 use fuel_asm::{
     GTFArgs,
@@ -14,7 +19,6 @@ use fuel_tx::{
     ScriptExecutionResult,
     TransactionBuilder,
 };
-use fuel_vm::prelude::*;
 use itertools::Itertools;
 use test_case::test_case;
 
@@ -39,14 +43,14 @@ fn attempt_ecal_without_handler() {
 #[derive(Debug, Default, Clone, Copy)]
 pub struct NoopEcal;
 
-impl ::fuel_vm::interpreter::EcalHandler for NoopEcal {
+impl EcalHandler for NoopEcal {
     fn ecal<M, S, Tx, V>(
-        vm: &mut ::fuel_vm::prelude::Interpreter<M, S, Tx, Self, V>,
+        vm: &mut Interpreter<M, S, Tx, Self, V>,
         _: RegId,
         _: RegId,
         _: RegId,
         _: RegId,
-    ) -> ::fuel_vm::error::SimpleResult<()> {
+    ) -> SimpleResult<()> {
         vm.gas_charge(vm.gas_costs().noop())
     }
 }
@@ -62,7 +66,7 @@ fn noop_ecal() {
 
     let mut client = MemoryClient::<_, NoopEcal>::new(
         MemoryInstance::new(),
-        fuel_vm::prelude::MemoryStorage::default(),
+        MemoryStorage::default(),
         Default::default(),
     );
     let consensus_params = ConsensusParameters::standard();
@@ -85,16 +89,16 @@ fn noop_ecal() {
 #[derive(Debug, Default, Clone, Copy)]
 pub struct SumProdEcal;
 
-impl ::fuel_vm::interpreter::EcalHandler for SumProdEcal {
+impl EcalHandler for SumProdEcal {
     /// This ecal fn computes saturating sum and product of inputs (a,b,c,d),
     /// and stores them in a and b respectively. It charges only a single gas.
     fn ecal<M, S, Tx, V>(
-        vm: &mut ::fuel_vm::prelude::Interpreter<M, S, Tx, Self, V>,
+        vm: &mut Interpreter<M, S, Tx, Self, V>,
         a: RegId,
         b: RegId,
         c: RegId,
         d: RegId,
-    ) -> ::fuel_vm::error::SimpleResult<()> {
+    ) -> SimpleResult<()> {
         vm.gas_charge(1)?;
 
         let args = [
@@ -165,17 +169,17 @@ pub struct ComplexEcal {
     state: u64,
 }
 
-impl ::fuel_vm::interpreter::EcalHandler for ComplexEcal {
+impl EcalHandler for ComplexEcal {
     const INC_PC: bool = false;
 
     /// Ecal meant for testing cornercase behavior of the handler.
     fn ecal<M, S, Tx, V>(
-        vm: &mut ::fuel_vm::prelude::Interpreter<M, S, Tx, Self, V>,
+        vm: &mut Interpreter<M, S, Tx, Self, V>,
         a: RegId,
         _b: RegId,
         _c: RegId,
         _d: RegId,
-    ) -> ::fuel_vm::error::SimpleResult<()> {
+    ) -> SimpleResult<()> {
         vm.gas_charge(1)?;
 
         if vm.ecal_state().state > 10 {

--- a/fuel-vm/src/tests/predicate.rs
+++ b/fuel-vm/src/tests/predicate.rs
@@ -333,7 +333,7 @@ async fn predicate_with_ecal_disallowed_fails() {
 }
 
 #[tokio::test]
-async fn predicate_allows_ecal() {
+async fn execute_predicate__ecal_uses_custom_handler() {
     // given
     let accept_data = 1 as Word;
     let accept_data = accept_data.to_be_bytes().to_vec();

--- a/fuel-vm/src/tests/predicate.rs
+++ b/fuel-vm/src/tests/predicate.rs
@@ -138,7 +138,7 @@ where
             &check_params,
             &DummyPool,
             &EmptyStorage,
-            NotSupportedEcal::default(),
+            NotSupportedEcal,
         )
         .await
         .map(|checked| checked.gas_used())
@@ -149,7 +149,7 @@ where
         &check_params,
         MemoryInstance::new(),
         &EmptyStorage,
-        NotSupportedEcal::default(),
+        NotSupportedEcal,
     )
     .map(|checked| checked.gas_used());
 
@@ -398,7 +398,7 @@ async fn execute_gas_metered_predicates(
             &params,
             &DummyPool,
             &EmptyStorage,
-            NotSupportedEcal::default(),
+            NotSupportedEcal,
         )
         .await
         .map(|r| r.gas_used())
@@ -419,7 +419,7 @@ async fn execute_gas_metered_predicates(
         &params,
         MemoryInstance::new(),
         &EmptyStorage,
-        NotSupportedEcal::default(),
+        NotSupportedEcal,
     )
     .map(|r| r.gas_used())
     .map_err(|_| ())?;
@@ -515,7 +515,7 @@ async fn gas_used_by_predicates_not_causes_out_of_gas_during_script() {
                 &params,
                 &DummyPool,
                 &EmptyStorage,
-                NotSupportedEcal::default(),
+                NotSupportedEcal,
             )
             .await
             .expect("Predicate check failed even if we don't have any predicates");
@@ -527,7 +527,7 @@ async fn gas_used_by_predicates_not_causes_out_of_gas_during_script() {
             &params,
             MemoryInstance::new(),
             &EmptyStorage,
-            NotSupportedEcal::default(),
+            NotSupportedEcal,
         )
         .expect("Predicate check failed even if we don't have any predicates");
 
@@ -577,7 +577,7 @@ async fn gas_used_by_predicates_not_causes_out_of_gas_during_script() {
                 &params,
                 &DummyPool,
                 &EmptyStorage,
-                NotSupportedEcal::default(),
+                NotSupportedEcal,
             )
             .await
             .expect("Predicate check failed");
@@ -600,7 +600,7 @@ async fn gas_used_by_predicates_not_causes_out_of_gas_during_script() {
             &params,
             MemoryInstance::new(),
             &EmptyStorage,
-            NotSupportedEcal::default(),
+            NotSupportedEcal,
         )
         .expect("Predicate check failed");
 
@@ -658,7 +658,7 @@ async fn gas_used_by_predicates_more_than_limit() {
                 &params,
                 &DummyPool,
                 &EmptyStorage,
-                NotSupportedEcal::default(),
+                NotSupportedEcal,
             )
             .await
             .expect("Predicate check failed even if we don't have any predicates");
@@ -670,7 +670,7 @@ async fn gas_used_by_predicates_more_than_limit() {
             &params,
             MemoryInstance::new(),
             &EmptyStorage,
-            NotSupportedEcal::default(),
+            NotSupportedEcal,
         )
         .expect("Predicate check failed even if we don't have any predicates");
 
@@ -718,7 +718,7 @@ async fn gas_used_by_predicates_more_than_limit() {
                 &params,
                 &DummyPool,
                 &EmptyStorage,
-                NotSupportedEcal::default(),
+                NotSupportedEcal,
             )
             .await;
 
@@ -734,7 +734,7 @@ async fn gas_used_by_predicates_more_than_limit() {
             &params,
             MemoryInstance::new(),
             &EmptyStorage,
-            NotSupportedEcal::default(),
+            NotSupportedEcal,
         );
 
     assert!(matches!(

--- a/fuel-vm/src/tests/predicate.rs
+++ b/fuel-vm/src/tests/predicate.rs
@@ -344,7 +344,7 @@ async fn predicate_allows_ecal() {
         // Load data
         op::gtf_args(0x11, RegId::ZERO, GTFArgs::InputCoinPredicateData),
         op::lw(0x10, 0x11, 0),
-        // Incremnet by one
+        // Increment by one
         op::movi(0x11, 1),
         op::ecal(0x10, 0x11, RegId::ZERO, RegId::ZERO), /* Sets reg[0x10] +=
                                                          * reg[0x11], reg[0x11] = 0 */

--- a/fuel-vm/src/tests/predicate.rs
+++ b/fuel-vm/src/tests/predicate.rs
@@ -353,13 +353,17 @@ async fn predicate_allows_ecal() {
         op::eq(0x10, 0x10, 0x11),
         op::ret(0x10),
     ];
-
-    assert!(
-        execute_predicate(predicate.iter().copied(), accept_data, 0, SumProdEcal).await
-    );
-    assert!(
-        !execute_predicate(predicate.iter().copied(), decline_data, 0, SumProdEcal).await
-    );
+    // given
+    let should_pass = execute_predicate(predicate.iter().copied(), accept_data, 0, SumProdEcal).await;
+    
+    // then
+    assert!(should_pass);
+    
+    // given
+    let should_fail = execute_predicate(predicate.iter().copied(), decline_data, 0, SumProdEcal).await;
+    
+    // then
+    assert!(!should_fail);
 }
 
 #[tokio::test]

--- a/fuel-vm/src/tests/predicate.rs
+++ b/fuel-vm/src/tests/predicate.rs
@@ -334,6 +334,7 @@ async fn predicate_with_ecal_disallowed_fails() {
 
 #[tokio::test]
 async fn predicate_allows_ecal() {
+    // given
     let accept_data = 1 as Word;
     let accept_data = accept_data.to_be_bytes().to_vec();
 

--- a/fuel-vm/src/tests/predicate.rs
+++ b/fuel-vm/src/tests/predicate.rs
@@ -74,7 +74,7 @@ async fn execute_predicate<P, Ecal>(
     predicate: P,
     predicate_data: Vec<u8>,
     dummy_inputs: usize,
-    ecal_state: Ecal,
+    ecal_handler: Ecal,
 ) -> bool
 where
     P: IntoIterator<Item = Instruction>,
@@ -135,7 +135,7 @@ where
             &check_params,
             MemoryInstance::new(),
             &EmptyStorage,
-            ecal_state.clone(),
+            ecal_handler.clone(),
         )
         .expect("Should estimate predicate");
 
@@ -149,7 +149,7 @@ where
             &check_params,
             &DummyPool,
             &EmptyStorage,
-            ecal_state.clone(),
+            ecal_handler.clone(),
         )
         .await
         .map(|checked| checked.gas_used())
@@ -160,7 +160,7 @@ where
         &check_params,
         MemoryInstance::new(),
         &EmptyStorage,
-        ecal_state.clone(),
+        ecal_handler.clone(),
     )
     .map(|checked| checked.gas_used());
 

--- a/fuel-vm/src/tests/predicate.rs
+++ b/fuel-vm/src/tests/predicate.rs
@@ -330,7 +330,7 @@ async fn execute_predicate__if_ecal_disabled_predicate_fails() {
     ];
     
     // when
-    let predicate_passed = execute_predicate(predicate.iter().copied(), vec![], 0, NotSupportedEcal).await
+    let predicate_passed = execute_predicate(predicate.iter().copied(), vec![], 0, NotSupportedEcal).await;
     
     // then
     assert!(!predicate_passed);

--- a/fuel-vm/src/tests/predicate.rs
+++ b/fuel-vm/src/tests/predicate.rs
@@ -328,10 +328,11 @@ async fn execute_predicate__if_ecal_disabled_predicate_fails() {
         op::ecal(RegId::ZERO, RegId::ZERO, RegId::ZERO, RegId::ZERO),
         op::ret(0x10),
     ];
-    
+
     // when
-    let predicate_passed = execute_predicate(predicate.iter().copied(), vec![], 0, NotSupportedEcal).await;
-    
+    let predicate_passed =
+        execute_predicate(predicate.iter().copied(), vec![], 0, NotSupportedEcal).await;
+
     // then
     assert!(!predicate_passed);
 }
@@ -359,14 +360,16 @@ async fn execute_predicate__ecal_uses_custom_handler() {
         op::ret(0x10),
     ];
     // given
-    let should_pass = execute_predicate(predicate.iter().copied(), accept_data, 0, SumProdEcal).await;
-    
+    let should_pass =
+        execute_predicate(predicate.iter().copied(), accept_data, 0, SumProdEcal).await;
+
     // then
     assert!(should_pass);
-    
+
     // given
-    let should_fail = execute_predicate(predicate.iter().copied(), decline_data, 0, SumProdEcal).await;
-    
+    let should_fail =
+        execute_predicate(predicate.iter().copied(), decline_data, 0, SumProdEcal).await;
+
     // then
     assert!(!should_fail);
 }

--- a/fuel-vm/src/tests/predicate.rs
+++ b/fuel-vm/src/tests/predicate.rs
@@ -322,14 +322,18 @@ async fn predicate() {
 }
 
 #[tokio::test]
-async fn predicate_with_ecal_disallowed_fails() {
+async fn execute_predicate__if_ecal_disabled_predicate_fails() {
+    // given
     let predicate = [
         op::ecal(RegId::ZERO, RegId::ZERO, RegId::ZERO, RegId::ZERO),
         op::ret(0x10),
     ];
-    assert!(
-        !execute_predicate(predicate.iter().copied(), vec![], 0, NotSupportedEcal).await
-    );
+    
+    // when
+    let predicate_passed = execute_predicate(predicate.iter().copied(), vec![], 0, NotSupportedEcal).await
+    
+    // then
+    assert!(!predicate_passed);
 }
 
 #[tokio::test]

--- a/version-compatibility/Cargo.toml
+++ b/version-compatibility/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2024"
 license = "BUSL-1.1"
 publish = false
 
+[features]
+default = ["da-compression"]
+da-compression = ["fuel-tx-0-58-2/da-compression", "latest-fuel-tx/da-compression"]
+
 [dev-dependencies]
 fuel-compression-0-58-2 = { package = "fuel-compression", version = "0.58.2" }
 fuel-tx-0-58-2 = { package = "fuel-tx", version = "0.58.2", features = ["random", "test-helpers"] }
@@ -13,7 +17,3 @@ latest-fuel-compression = { package = "fuel-compression", path = "../fuel-compre
 latest-fuel-tx = { package = "fuel-tx", path = "../fuel-tx", features = ["random", "test-helpers"] }
 postcard = { version = "1.0", features = ["use-std"] }
 tokio = { version = "1.27", features = ["full"] }
-
-[features]
-default = ["da-compression"]
-da-compression = ["fuel-tx-0-58-2/da-compression", "latest-fuel-tx/da-compression"]


### PR DESCRIPTION
See https://github.com/FuelLabs/fuel-vm/pull/945#issuecomment-2829271997

Adds `ECAL` state parameter to some predicate-related APIs. Allows `ECAL` instruction during predicate execution. Exposes `Interpreter::context` that can be used by the `ECAL` handler to determine if it's inside a predicate.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here
