### PR TITLE
feat: refactor check_unique_rules to be more modular

### DIFF
--- a/fuel-tx/src/transaction/types/blob.rs
+++ b/fuel-tx/src/transaction/types/blob.rs
@@ -97,17 +97,30 @@ impl UniqueFormatValidityChecks for Blob {
         &self,
         consensus_params: &ConsensusParameters,
     ) -> Result<(), ValidityError> {
+        self.verify_blob_id()?;
+        self.verify_inputs(consensus_params)?;
+        self.verify_outputs(consensus_params)?;
+        Ok(())
+    }
+
+    fn verify_blob_id(&self) -> Result<(), ValidityError> {
         let index = self.body.witness_index as usize;
         let witness = self
             .witnesses
             .get(index)
             .ok_or(ValidityError::InputWitnessIndexBounds { index })?;
 
-        // Verify that blob id is correct
         if BlobId::compute(witness.as_ref()) != self.body.id {
             return Err(ValidityError::TransactionBlobIdVerificationFailed);
+        } else {
+            return Ok(());
         }
+    }
 
+    fn verify_inputs(
+        &self,
+        consensus_params: &ConsensusParameters,
+    ) -> Result<(), ValidityError> {
         self.inputs
             .iter()
             .enumerate()
@@ -132,7 +145,13 @@ impl UniqueFormatValidityChecks for Blob {
                     _ => Ok(()),
                 }
             })?;
+        Ok(())
+    }
 
+    fn verify_outputs(
+        &self,
+        consensus_params: &ConsensusParameters,
+    ) -> Result<(), ValidityError> {
         self.outputs
             .iter()
             .enumerate()

--- a/fuel-tx/src/transaction/types/chargeable_transaction.rs
+++ b/fuel-tx/src/transaction/types/chargeable_transaction.rs
@@ -171,6 +171,16 @@ pub(crate) trait UniqueFormatValidityChecks {
         &self,
         consensus_params: &ConsensusParameters,
     ) -> Result<(), ValidityError>;
+
+    fn verify_blob_id(&self) -> Result<(), ValidityError>;
+    fn verify_inputs(
+        &self,
+        consensus_params: &ConsensusParameters,
+    ) -> Result<(), ValidityError>;
+    fn verify_outputs(
+        &self,
+        consensus_params: &ConsensusParameters,
+    ) -> Result<(), ValidityError>;
 }
 
 impl<Body, MetadataBody> FormatValidityChecks

--- a/fuel-tx/src/transaction/types/create.rs
+++ b/fuel-tx/src/transaction/types/create.rs
@@ -135,7 +135,6 @@ impl UniqueFormatValidityChecks for Create {
         consensus_params: &ConsensusParameters,
     ) -> Result<(), ValidityError> {
         let contract_params = consensus_params.contract_params();
-        let base_asset_id = consensus_params.base_asset_id();
 
         let bytecode_witness_len = self
             .witnesses
@@ -164,6 +163,26 @@ impl UniqueFormatValidityChecks for Create {
             return Err(ValidityError::TransactionCreateStorageSlotOrder);
         }
 
+        debug_assert!(
+            self.metadata.is_some(),
+            "`check_without_signatures` is called without cached metadata"
+        );
+
+        self.verify_blob_id()?;
+        self.verify_inputs(consensus_params)?;
+        self.verify_outputs(consensus_params)?;
+
+        Ok(())
+    }
+
+    fn verify_blob_id(&self) -> Result<(), ValidityError> {
+        todo!()
+    }
+
+    fn verify_inputs(
+        &self,
+        consensus_params: &ConsensusParameters,
+    ) -> Result<(), ValidityError> {
         self.inputs
             .iter()
             .enumerate()
@@ -189,10 +208,15 @@ impl UniqueFormatValidityChecks for Create {
                 }
             })?;
 
-        debug_assert!(
-            self.metadata.is_some(),
-            "`check_without_signatures` is called without cached metadata"
-        );
+        Ok(())
+    }
+
+    fn verify_outputs(
+        &self,
+        consensus_params: &ConsensusParameters,
+    ) -> Result<(), ValidityError> {
+        let base_asset_id = consensus_params.base_asset_id();
+
         let (state_root_calculated, contract_id_calculated) =
             if let Some(metadata) = &self.metadata {
                 (metadata.body.state_root, metadata.body.contract_id)
@@ -200,54 +224,46 @@ impl UniqueFormatValidityChecks for Create {
                 let metadata = CreateMetadata::compute(self)?;
                 (metadata.state_root, metadata.contract_id)
             };
-
         let mut contract_created = false;
         self.outputs
-            .iter()
-            .enumerate()
-            .try_for_each(|(index, output)| match output {
-                Output::Contract(_) => {
-                    Err(ValidityError::TransactionOutputContainsContract { index })
-                }
-
-                Output::Variable { .. } => {
-                    Err(ValidityError::TransactionOutputContainsVariable { index })
-                }
-
-                Output::Change { asset_id, .. } if asset_id != base_asset_id => {
-                    Err(ValidityError::TransactionChangeChangeUsesNotBaseAsset { index })
-                }
-
-                Output::ContractCreated {
-                    contract_id,
-                    state_root,
-                } if contract_id != &contract_id_calculated
-                    || state_root != &state_root_calculated =>
-                    {
-                        Err(
-                            ValidityError::TransactionCreateOutputContractCreatedDoesntMatch {
-                                index,
-                            },
-                        )
+                .iter()
+                .enumerate()
+                .try_for_each(|(index, output)| match output {
+                    Output::Contract(_) => {
+                        Err(ValidityError::TransactionOutputContainsContract { index })
                     }
-
-                // TODO: Output::ContractCreated { contract_id, state_root } if
-                // contract_id == &id && state_root == &storage_root
-                //  maybe move from `fuel-vm` to here
-                Output::ContractCreated { .. } if contract_created => {
-                    Err(ValidityError::TransactionCreateOutputContractCreatedMultiple {
-                        index,
-                    })
-                }
-
-                Output::ContractCreated { .. } => {
-                    contract_created = true;
-
-                    Ok(())
-                }
-
-                _ => Ok(()),
-            })?;
+                    Output::Variable { .. } => {
+                        Err(ValidityError::TransactionOutputContainsVariable { index })
+                    }
+                    Output::Change { asset_id, .. } if asset_id != base_asset_id => {
+                        Err(ValidityError::TransactionChangeChangeUsesNotBaseAsset { index })
+                    }
+                    Output::ContractCreated {
+                        contract_id,
+                        state_root,
+                    } if contract_id != &contract_id_calculated
+                        || state_root != &state_root_calculated =>
+                        {
+                            Err(
+                                ValidityError::TransactionCreateOutputContractCreatedDoesntMatch {
+                                    index,
+                                },
+                            )
+                        }
+                    // TODO: Output::ContractCreated { contract_id, state_root } if
+                    // contract_id == &id && state_root == &storage_root
+                    //  maybe move from `fuel-vm` to here
+                    Output::ContractCreated { .. } if contract_created => {
+                        Err(ValidityError::TransactionCreateOutputContractCreatedMultiple {
+                            index,
+                        })
+                    }
+                    Output::ContractCreated { .. } => {
+                        contract_created = true;
+                        Ok(())
+                    }
+                    _ => Ok(()),
+                })?;
 
         if !contract_created {
             return Err(ValidityError::TransactionOutputDoesntContainContractCreated);

--- a/fuel-tx/src/transaction/types/script.rs
+++ b/fuel-tx/src/transaction/types/script.rs
@@ -191,6 +191,28 @@ impl UniqueFormatValidityChecks for Script {
             Err(ValidityError::TransactionScriptDataLength)?;
         }
 
+        self.verify_blob_id()?;
+        self.verify_inputs(consensus_params)?;
+        self.verify_outputs(consensus_params)?;
+
+        Ok(())
+    }
+
+    fn verify_blob_id(&self) -> Result<(), ValidityError> {
+        !todo!()
+    }
+
+    fn verify_inputs(
+        &self,
+        consensus_params: &ConsensusParameters,
+    ) -> Result<(), ValidityError> {
+        !todo!()
+    }
+
+    fn verify_outputs(
+        &self,
+        consensus_params: &ConsensusParameters,
+    ) -> Result<(), ValidityError> {
         self.outputs
             .iter()
             .enumerate()

--- a/fuel-tx/src/transaction/types/upload.rs
+++ b/fuel-tx/src/transaction/types/upload.rs
@@ -220,6 +220,21 @@ impl UniqueFormatValidityChecks for Upload {
             return Err(ValidityError::TransactionUploadRootVerificationFailed);
         }
 
+        self.verify_blob_id()?;
+        self.verify_inputs(consensus_params)?;
+        self.verify_outputs(consensus_params)?;
+
+        Ok(())
+    }
+
+    fn verify_blob_id(&self) -> Result<(), ValidityError> {
+        todo!()
+    }
+
+    fn verify_inputs(
+        &self,
+        consensus_params: &ConsensusParameters,
+    ) -> Result<(), ValidityError> {
         self.inputs
             .iter()
             .enumerate()
@@ -245,6 +260,13 @@ impl UniqueFormatValidityChecks for Upload {
                 }
             })?;
 
+        Ok(())
+    }
+
+    fn verify_outputs(
+        &self,
+        consensus_params: &ConsensusParameters,
+    ) -> Result<(), ValidityError> {
         self.outputs
             .iter()
             .enumerate()


### PR DESCRIPTION
Fixes #800 

Currently some implementations of `verify_blob_id` of are left empty because the code did not fit the name (please correct me if im wrong)...I was wondering if it needs some other name like `verify_data` or something
Please correct me if i'm misunderstanding that.