### PR TITLE
Update requirements in ci_checks.sh

### DIFF
--- a/ci_checks.sh
+++ b/ci_checks.sh
@@ -3,11 +3,12 @@
 # The script runs almost all CI checks locally.
 #
 # Requires installed:
-# - Rust `1.79.0`
+# - Rust `1.85.0`
 # - Nightly rust formatter
 # - `rustup target add thumbv6m-none-eabi`
 # - `rustup target add wasm32-unknown-unknown`
 # - `cargo install cargo-sort`
+# - `cargo install cargo-make`
 
 cargo +nightly fmt --all -- --check &&
 cargo sort -w --check &&


### PR DESCRIPTION
The CI script (`ci_checks.sh`) incorrectly specified Rust `1.79.0` as a requirement, but this version is incompatible with the project's current configuration:

- The workspace `Cargo.toml` specifies `rust-version = "1.85.0"`
- The project uses `edition = "2024"` which requires Rust 1.85.0 or later
- Running CI checks with Rust 1.79.0 fails with: ``` feature `edition2024` is required The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.79.0) ```

### Changes
- Updated the CI script comment to require Rust `1.85.0` instead of `1.79.0`
- Added missing dependency `cargo-make` to the requirements list

This aligns the CI script with the actual project requirements defined in `Cargo.toml`

Please go to the `Preview` tab and select the appropriate sub-template:

* [Classic PR](?expand=1&template=default.md)
* [Bump version](?expand=1&template=bump_version.md)