### PR TITLE
Varun/input v1

### DIFF
--- a/fuel-tx/src/lib.rs
+++ b/fuel-tx/src/lib.rs
@@ -120,6 +120,7 @@ pub use transaction::{
     field,
     input,
     input::Input,
+    input::InputV1,
     input::InputRepr,
     output,
     output::Output,

--- a/fuel-tx/src/test_helper.rs
+++ b/fuel-tx/src/test_helper.rs
@@ -83,7 +83,7 @@ mod use_std {
         R: Rng + CryptoRng,
     {
         fn from(rng: R) -> Self {
-            let input_sampler = Uniform::from(0..Input::COUNT);
+            let input_sampler = Uniform::from(0..InputV1::COUNT);
             let output_sampler = Uniform::from(0..Output::COUNT);
 
             // Trick to enforce coverage of all variants in compile-time

--- a/fuel-tx/src/test_helper.rs
+++ b/fuel-tx/src/test_helper.rs
@@ -45,26 +45,7 @@ mod use_std {
         generate_nonempty_padded_bytes,
     };
     use crate::{
-        Blob,
-        BlobBody,
-        BlobIdExt,
-        Buildable,
-        ConsensusParameters,
-        Contract,
-        Create,
-        Finalizable,
-        Input,
-        Mint,
-        Output,
-        Script,
-        Transaction,
-        TransactionBuilder,
-        Upgrade,
-        UpgradePurpose,
-        Upload,
-        UploadBody,
-        UploadSubsection,
-        field,
+        field, Blob, BlobBody, BlobIdExt, Buildable, ConsensusParameters, Contract, Create, Finalizable, Input, InputV1, Mint, Output, Script, Transaction, TransactionBuilder, Upgrade, UpgradePurpose, Upload, UploadBody, UploadSubsection
     };
     use core::marker::PhantomData;
     use fuel_crypto::{
@@ -113,13 +94,13 @@ mod use_std {
             debug_assert!({
                 Input::decode(&mut &empty[..])
                     .map(|i| match i {
-                        Input::CoinSigned(_) => (),
-                        Input::CoinPredicate(_) => (),
-                        Input::Contract(_) => (),
-                        Input::MessageCoinSigned(_) => (),
-                        Input::MessageCoinPredicate(_) => (),
-                        Input::MessageDataSigned(_) => (),
-                        Input::MessageDataPredicate(_) => (),
+                        Input::V1(InputV1::CoinSigned(_)) => (),
+                        Input::V1(InputV1::CoinPredicate(_)) => (),
+                        Input::V1(InputV1::Contract(_)) => (),
+                        Input::V1(InputV1::MessageCoinSigned(_)) => (),
+                        Input::V1(InputV1::MessageCoinPredicate(_)) => (),
+                        Input::V1(InputV1::MessageDataSigned(_)) => (),
+                        Input::V1(InputV1::MessageDataPredicate(_)) => (),
                     })
                     .unwrap_or(());
 

--- a/fuel-tx/src/tests/offset.rs
+++ b/fuel-tx/src/tests/offset.rs
@@ -387,24 +387,25 @@ fn tx_offset_create() {
     assert!(cases.utxo_id);
     assert!(cases.owner);
     assert!(cases.asset_id);
+    println!("{}",cases.predicate_coin);
     assert!(cases.predicate_coin);
-    assert!(cases.predicate_message);
-    assert!(cases.predicate_data_coin);
-    assert!(cases.predicate_data_message);
-    assert!(cases.contract_balance_root);
-    assert!(cases.contract_state_root);
-    assert!(cases.contract_id);
-    assert!(cases.sender);
-    assert!(cases.recipient);
-    assert!(cases.message_data);
-    assert!(cases.message_predicate);
-    assert!(cases.message_predicate_data);
-    assert!(cases.output_to);
-    assert!(cases.output_asset_id);
-    assert!(cases.output_balance_root);
-    assert!(cases.output_contract_state_root);
-    assert!(cases.output_contract_created_state_root);
-    assert!(cases.output_contract_created_id);
+    // assert!(cases.predicate_message);
+    // assert!(cases.predicate_data_coin);
+    // assert!(cases.predicate_data_message);
+    // assert!(cases.contract_balance_root);
+    // assert!(cases.contract_state_root);
+    // assert!(cases.contract_id);
+    // assert!(cases.sender);
+    // assert!(cases.recipient);
+    // assert!(cases.message_data);
+    // assert!(cases.message_predicate);
+    // assert!(cases.message_predicate_data);
+    // assert!(cases.output_to);
+    // assert!(cases.output_asset_id);
+    // assert!(cases.output_balance_root);
+    // assert!(cases.output_contract_state_root);
+    // assert!(cases.output_contract_created_state_root);
+    // assert!(cases.output_contract_created_id);
 }
 
 #[test]

--- a/fuel-tx/src/tests/offset.rs
+++ b/fuel-tx/src/tests/offset.rs
@@ -387,25 +387,24 @@ fn tx_offset_create() {
     assert!(cases.utxo_id);
     assert!(cases.owner);
     assert!(cases.asset_id);
-    println!("{}",cases.predicate_coin);
     assert!(cases.predicate_coin);
-    // assert!(cases.predicate_message);
-    // assert!(cases.predicate_data_coin);
-    // assert!(cases.predicate_data_message);
-    // assert!(cases.contract_balance_root);
-    // assert!(cases.contract_state_root);
-    // assert!(cases.contract_id);
-    // assert!(cases.sender);
-    // assert!(cases.recipient);
-    // assert!(cases.message_data);
-    // assert!(cases.message_predicate);
-    // assert!(cases.message_predicate_data);
-    // assert!(cases.output_to);
-    // assert!(cases.output_asset_id);
-    // assert!(cases.output_balance_root);
-    // assert!(cases.output_contract_state_root);
-    // assert!(cases.output_contract_created_state_root);
-    // assert!(cases.output_contract_created_id);
+    assert!(cases.predicate_message);
+    assert!(cases.predicate_data_coin);
+    assert!(cases.predicate_data_message);
+    assert!(cases.contract_balance_root);
+    assert!(cases.contract_state_root);
+    assert!(cases.contract_id);
+    assert!(cases.sender);
+    assert!(cases.recipient);
+    assert!(cases.message_data);
+    assert!(cases.message_predicate);
+    assert!(cases.message_predicate_data);
+    assert!(cases.output_to);
+    assert!(cases.output_asset_id);
+    assert!(cases.output_balance_root);
+    assert!(cases.output_contract_state_root);
+    assert!(cases.output_contract_created_state_root);
+    assert!(cases.output_contract_created_id);
 }
 
 #[test]

--- a/fuel-tx/src/tests/valid_cases/input.rs
+++ b/fuel-tx/src/tests/valid_cases/input.rs
@@ -40,9 +40,9 @@ fn input_coin_message_signature() {
                 .iter()
                 .enumerate()
                 .try_for_each(|(index, input)| match input {
-                    Input::CoinSigned(_)
-                    | Input::MessageCoinSigned(_)
-                    | Input::MessageDataSigned(_) => input.check(
+                    Input::V1(InputV1::CoinSigned(_))
+                    | Input::V1(InputV1::MessageCoinSigned(_))
+                    | Input::V1(InputV1::MessageDataSigned(_)) => input.check(
                         index,
                         &txhash,
                         outputs,

--- a/fuel-tx/src/transaction/types/blob.rs
+++ b/fuel-tx/src/transaction/types/blob.rs
@@ -1,10 +1,5 @@
 use crate::{
-    ConsensusParameters,
-    FeeParameters,
-    GasCosts,
-    Input,
-    Output,
-    TransactionRepr,
+    ConsensusParameters, FeeParameters, GasCosts, Input, Output, TransactionRepr,
     ValidityError,
     transaction::{
         Chargeable,
@@ -12,20 +7,14 @@ use crate::{
         id::PrepareSign,
         metadata::CommonMetadata,
         types::chargeable_transaction::{
-            ChargeableMetadata,
-            ChargeableTransaction,
-            UniqueFormatValidityChecks,
+            ChargeableMetadata, ChargeableTransaction, UniqueFormatValidityChecks,
         },
     },
 };
 use educe::Educe;
-use fuel_types::{
-    BlobId,
-    ChainId,
-    Word,
-    bytes::WORD_SIZE,
-    canonical::Serialize,
-};
+use fuel_types::{BlobId, ChainId, Word, bytes::WORD_SIZE, canonical::Serialize};
+
+use super::input::InputV1;
 
 /// Adds method to `BlobId` to compute the it from blob data.
 pub trait BlobIdExt {
@@ -123,10 +112,11 @@ impl UniqueFormatValidityChecks for Blob {
                 }
 
                 match input {
-                    Input::Contract(_) => {
+                    Input::V1(InputV1::Contract(_)) => {
                         Err(ValidityError::TransactionInputContainsContract { index })
                     }
-                    Input::MessageDataSigned(_) | Input::MessageDataPredicate(_) => {
+                    Input::V1(InputV1::MessageCoinSigned(_))
+                    | Input::V1(InputV1::MessageDataPredicate(_)) => {
                         Err(ValidityError::TransactionInputContainsMessageData { index })
                     }
                     _ => Ok(()),
@@ -183,11 +173,7 @@ impl crate::Cacheable for Blob {
 
 mod field {
     use super::*;
-    use crate::field::{
-        self,
-        BlobId as BlobIdField,
-        BytecodeWitnessIndex,
-    };
+    use crate::field::{self, BlobId as BlobIdField, BytecodeWitnessIndex};
 
     impl field::BlobId for Blob {
         #[inline(always)]

--- a/fuel-tx/src/transaction/types/blob.rs
+++ b/fuel-tx/src/transaction/types/blob.rs
@@ -115,7 +115,7 @@ impl UniqueFormatValidityChecks for Blob {
                     Input::V1(InputV1::Contract(_)) => {
                         Err(ValidityError::TransactionInputContainsContract { index })
                     }
-                    Input::V1(InputV1::MessageCoinSigned(_))
+                    Input::V1(InputV1::MessageDataSigned(_))
                     | Input::V1(InputV1::MessageDataPredicate(_)) => {
                         Err(ValidityError::TransactionInputContainsMessageData { index })
                     }

--- a/fuel-tx/src/transaction/types/create.rs
+++ b/fuel-tx/src/transaction/types/create.rs
@@ -1,14 +1,4 @@
 use crate::{
-    Chargeable,
-    ConsensusParameters,
-    Contract,
-    GasCosts,
-    Input,
-    Output,
-    PrepareSign,
-    StorageSlot,
-    TransactionRepr,
-    ValidityError,
     transaction::{
         field::{
             BytecodeWitnessIndex,
@@ -21,7 +11,7 @@ use crate::{
             ChargeableTransaction,
             UniqueFormatValidityChecks,
         },
-    },
+    }, Chargeable, ConsensusParameters, Contract, GasCosts, Input, InputV1, Output, PrepareSign, StorageSlot, TransactionRepr, ValidityError
 };
 use educe::Educe;
 use fuel_types::{
@@ -179,10 +169,10 @@ impl UniqueFormatValidityChecks for Create {
                 }
 
                 match input {
-                    Input::Contract(_) => {
+                    Input::V1(InputV1::Contract(_)) => {
                         Err(ValidityError::TransactionInputContainsContract { index })
                     }
-                    Input::MessageDataSigned(_) | Input::MessageDataPredicate(_) => {
+                    Input::V1(InputV1::MessageDataSigned(_)) | Input::V1(InputV1::MessageDataPredicate(_)) => {
                         Err(ValidityError::TransactionInputContainsMessageData { index })
                     }
                     _ => Ok(()),

--- a/fuel-tx/src/transaction/types/input.rs
+++ b/fuel-tx/src/transaction/types/input.rs
@@ -1,9 +1,10 @@
-use crate::{Output as OutputType, PredicateParameters, TxPointer, UtxoId, ValidityError};
+use crate::{
+    Output as OutputType, PredicateParameters, TxPointer, UtxoId, ValidityError,
+};
 use alloc::{string::ToString, vec::Vec};
 use coin::*;
 use consts::*;
 use contract::*;
-use hashbrown::HashMap;
 use core::fmt::{self, Formatter};
 use fuel_crypto::{Hasher, PublicKey};
 use fuel_types::{
@@ -11,6 +12,7 @@ use fuel_types::{
     canonical::{Deserialize, Error, Output, Serialize},
     fmt_truncated_hex,
 };
+use hashbrown::HashMap;
 use message::*;
 
 pub mod coin;
@@ -23,7 +25,7 @@ mod repr;
 pub use predicate::PredicateCode;
 pub use repr::InputRepr;
 
-use super::{output, Witness};
+use super::{Witness, output};
 
 #[cfg(all(test, feature = "std"))]
 mod ser_de_tests;
@@ -720,7 +722,8 @@ impl InputV1 {
             // TODO: If h is the block height the UTXO being spent was created,
             // transaction is  invalid if `blockheight() < h + maturity`.
             _ => Ok(()),
-        }    }
+        }
+    }
 }
 
 impl Deserialize for InputV1 {

--- a/fuel-tx/src/transaction/types/input/repr.rs
+++ b/fuel-tx/src/transaction/types/input/repr.rs
@@ -1,7 +1,4 @@
-use super::{
-    Input,
-    consts::*,
-};
+use super::{consts::*, Input, InputV1};
 
 #[derive(
     Debug,
@@ -108,12 +105,18 @@ impl InputRepr {
 
     pub const fn from_input(input: &Input) -> Self {
         match input {
-            Input::CoinSigned(_) | Input::CoinPredicate(_) => InputRepr::Coin,
-            Input::Contract(_) => InputRepr::Contract,
-            Input::MessageCoinSigned(_)
-            | Input::MessageCoinPredicate(_)
-            | Input::MessageDataSigned(_)
-            | Input::MessageDataPredicate(_) => InputRepr::Message,
+            Input::V1(input) => Self::from_input_v1(input),
+        }
+    }
+
+    pub const fn from_input_v1(input: &InputV1) -> Self {
+        match input {
+            InputV1::CoinSigned(_) | InputV1::CoinPredicate(_) => InputRepr::Coin,
+            InputV1::Contract(_) => InputRepr::Contract,
+            InputV1::MessageCoinSigned(_)
+            | InputV1::MessageCoinPredicate(_)
+            | InputV1::MessageDataSigned(_)
+            | InputV1::MessageDataPredicate(_) => InputRepr::Message,
         }
     }
 }

--- a/fuel-tx/src/transaction/types/input/snapshot_tests.rs
+++ b/fuel-tx/src/transaction/types/input/snapshot_tests.rs
@@ -1,15 +1,12 @@
 //! snapshot tests to ensure the serialized format of inputs doesn't change
 
 use super::*;
-use crate::{
-    Transaction,
-    TransactionBuilder,
-};
+use crate::{Transaction, TransactionBuilder};
 use fuel_types::canonical::Serialize;
 
 fn tx_with_signed_coin_snapshot() -> Transaction {
     TransactionBuilder::script(vec![], vec![])
-        .add_input(Input::CoinSigned(CoinSigned {
+        .add_input(Input::V1(InputV1::CoinSigned(CoinSigned {
             utxo_id: UtxoId::new([1u8; 32].into(), 2),
             owner: [2u8; 32].into(),
             amount: 11,
@@ -19,7 +16,7 @@ fn tx_with_signed_coin_snapshot() -> Transaction {
             predicate_gas_used: Empty::new(),
             predicate: Empty::new(),
             predicate_data: Empty::new(),
-        }))
+        })))
         .tip(1)
         .maturity(123.into())
         .expiration(456.into())
@@ -56,7 +53,7 @@ fn tx_with_signed_coin_snapshot_postcard() {
 
 fn tx_with_predicate_coin_snapshot() -> Transaction {
     TransactionBuilder::script(vec![], vec![])
-        .add_input(Input::CoinPredicate(CoinPredicate {
+        .add_input(Input::V1(InputV1::CoinPredicate(CoinPredicate {
             utxo_id: UtxoId::new([1u8; 32].into(), 2),
             owner: [2u8; 32].into(),
             amount: 11,
@@ -66,7 +63,7 @@ fn tx_with_predicate_coin_snapshot() -> Transaction {
             predicate_gas_used: 100_000,
             predicate: vec![3u8; 10].into(),
             predicate_data: vec![4u8; 12],
-        }))
+        })))
         .tip(1)
         .maturity(123.into())
         .expiration(456.into())
@@ -102,13 +99,13 @@ fn tx_with_predicate_coin_snapshot_postcard() {
 
 fn tx_with_contract_snapshot() -> Transaction {
     TransactionBuilder::script(vec![], vec![])
-        .add_input(Input::Contract(Contract {
+        .add_input(Input::V1(InputV1::Contract(Contract {
             utxo_id: UtxoId::new([1u8; 32].into(), 2),
             balance_root: [2u8; 32].into(),
             state_root: [3u8; 32].into(),
             tx_pointer: TxPointer::new(46.into(), 5),
             contract_id: [5u8; 32].into(),
-        }))
+        })))
         .tip(1)
         .maturity(123.into())
         .expiration(456.into())
@@ -144,7 +141,7 @@ fn tx_with_contract_snapshot_postcard() {
 
 fn tx_with_signed_message_coin() -> Transaction {
     TransactionBuilder::script(vec![], vec![])
-        .add_input(Input::MessageCoinSigned(MessageCoinSigned {
+        .add_input(Input::V1(InputV1::MessageCoinSigned(MessageCoinSigned {
             sender: [2u8; 32].into(),
             recipient: [3u8; 32].into(),
             amount: 4,
@@ -154,7 +151,7 @@ fn tx_with_signed_message_coin() -> Transaction {
             data: Empty::new(),
             predicate: Empty::new(),
             predicate_data: Empty::new(),
-        }))
+        })))
         .tip(1)
         .maturity(123.into())
         .expiration(456.into())
@@ -191,17 +188,19 @@ fn tx_with_signed_message_coin_postcard() {
 
 fn tx_with_predicate_message_coin() -> Transaction {
     TransactionBuilder::script(vec![], vec![])
-        .add_input(Input::MessageCoinPredicate(MessageCoinPredicate {
-            sender: [2u8; 32].into(),
-            recipient: [3u8; 32].into(),
-            amount: 4,
-            nonce: [5u8; 32].into(),
-            witness_index: Empty::new(),
-            predicate_gas_used: 100_000,
-            data: Empty::new(),
-            predicate: vec![7u8; 11].into(),
-            predicate_data: vec![8u8; 12],
-        }))
+        .add_input(Input::V1(InputV1::MessageCoinPredicate(
+            MessageCoinPredicate {
+                sender: [2u8; 32].into(),
+                recipient: [3u8; 32].into(),
+                amount: 4,
+                nonce: [5u8; 32].into(),
+                witness_index: Empty::new(),
+                predicate_gas_used: 100_000,
+                data: Empty::new(),
+                predicate: vec![7u8; 11].into(),
+                predicate_data: vec![8u8; 12],
+            },
+        )))
         .tip(1)
         .maturity(123.into())
         .expiration(456.into())
@@ -236,7 +235,7 @@ fn tx_with_predicate_message_coin_postcard() {
 
 fn tx_with_signed_message_data() -> Transaction {
     TransactionBuilder::script(vec![], vec![])
-        .add_input(Input::MessageDataSigned(MessageDataSigned {
+        .add_input(Input::V1(InputV1::MessageDataSigned(MessageDataSigned {
             sender: [2u8; 32].into(),
             recipient: [3u8; 32].into(),
             amount: 4,
@@ -246,7 +245,7 @@ fn tx_with_signed_message_data() -> Transaction {
             data: vec![7u8; 10],
             predicate: Empty::new(),
             predicate_data: Empty::new(),
-        }))
+        })))
         .tip(1)
         .maturity(123.into())
         .expiration(456.into())
@@ -283,17 +282,19 @@ fn tx_with_signed_message_data_postcard() {
 
 fn tx_with_predicate_message_data() -> Transaction {
     TransactionBuilder::script(vec![], vec![])
-        .add_input(Input::MessageDataPredicate(MessageDataPredicate {
-            sender: [2u8; 32].into(),
-            recipient: [3u8; 32].into(),
-            amount: 4,
-            nonce: [5u8; 32].into(),
-            witness_index: Empty::new(),
-            predicate_gas_used: 100_000,
-            data: vec![6u8; 10],
-            predicate: vec![7u8; 11].into(),
-            predicate_data: vec![8u8; 12],
-        }))
+        .add_input(Input::V1(InputV1::MessageDataPredicate(
+            MessageDataPredicate {
+                sender: [2u8; 32].into(),
+                recipient: [3u8; 32].into(),
+                amount: 4,
+                nonce: [5u8; 32].into(),
+                witness_index: Empty::new(),
+                predicate_gas_used: 100_000,
+                data: vec![6u8; 10],
+                predicate: vec![7u8; 11].into(),
+                predicate_data: vec![8u8; 12],
+            },
+        )))
         .tip(1)
         .maturity(123.into())
         .expiration(456.into())

--- a/fuel-tx/src/transaction/types/upgrade.rs
+++ b/fuel-tx/src/transaction/types/upgrade.rs
@@ -1,29 +1,17 @@
 use crate::{
-    ConsensusParameters,
-    GasCosts,
-    Input,
-    Output,
-    TransactionRepr,
+    ConsensusParameters, GasCosts, Input, InputV1, Output, TransactionRepr,
     ValidityError,
     transaction::{
         Chargeable,
         id::PrepareSign,
         metadata::CommonMetadata,
         types::chargeable_transaction::{
-            ChargeableMetadata,
-            ChargeableTransaction,
-            UniqueFormatValidityChecks,
+            ChargeableMetadata, ChargeableTransaction, UniqueFormatValidityChecks,
         },
     },
 };
 use educe::Educe;
-use fuel_types::{
-    Bytes32,
-    ChainId,
-    Word,
-    bytes::WORD_SIZE,
-    canonical::Serialize,
-};
+use fuel_types::{Bytes32, ChainId, Word, bytes::WORD_SIZE, canonical::Serialize};
 
 use fuel_crypto::Hasher;
 
@@ -227,10 +215,11 @@ impl UniqueFormatValidityChecks for Upgrade {
                 }
 
                 match input {
-                    Input::Contract(_) => {
+                    Input::V1(InputV1::Contract(_)) => {
                         Err(ValidityError::TransactionInputContainsContract { index })
                     }
-                    Input::MessageDataSigned(_) | Input::MessageDataPredicate(_) => {
+                    Input::V1(InputV1::MessageDataSigned(_))
+                    | Input::V1(InputV1::MessageDataPredicate(_)) => {
                         Err(ValidityError::TransactionInputContainsMessageData { index })
                     }
                     _ => Ok(()),
@@ -283,10 +272,7 @@ impl crate::Cacheable for Upgrade {
 
 mod field {
     use super::*;
-    use crate::field::{
-        ChargeableBody,
-        UpgradePurpose as UpgradePurposeTrait,
-    };
+    use crate::field::{ChargeableBody, UpgradePurpose as UpgradePurposeTrait};
 
     impl UpgradePurposeTrait for Upgrade {
         #[inline(always)]

--- a/fuel-tx/src/transaction/types/upload.rs
+++ b/fuel-tx/src/transaction/types/upload.rs
@@ -1,32 +1,19 @@
 use crate::{
-    ConsensusParameters,
-    FeeParameters,
-    GasCosts,
-    Input,
-    Output,
-    TransactionRepr,
-    ValidityError,
+    ConsensusParameters, FeeParameters, GasCosts, Input, InputV1, Output,
+    TransactionRepr, ValidityError,
     transaction::{
         Chargeable,
         fee::min_gas,
         id::PrepareSign,
         metadata::CommonMetadata,
         types::chargeable_transaction::{
-            ChargeableMetadata,
-            ChargeableTransaction,
-            UniqueFormatValidityChecks,
+            ChargeableMetadata, ChargeableTransaction, UniqueFormatValidityChecks,
         },
     },
 };
 use core::ops::Deref;
 use educe::Educe;
-use fuel_types::{
-    Bytes32,
-    ChainId,
-    Word,
-    bytes::WORD_SIZE,
-    canonical::Serialize,
-};
+use fuel_types::{Bytes32, ChainId, Word, bytes::WORD_SIZE, canonical::Serialize};
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
@@ -235,10 +222,11 @@ impl UniqueFormatValidityChecks for Upload {
                 }
 
                 match input {
-                    Input::Contract(_) => {
+                    Input::V1(InputV1::Contract(_)) => {
                         Err(ValidityError::TransactionInputContainsContract { index })
                     }
-                    Input::MessageDataSigned(_) | Input::MessageDataPredicate(_) => {
+                    Input::V1(InputV1::MessageDataSigned(_))
+                    | Input::V1(InputV1::MessageDataPredicate(_)) => {
                         Err(ValidityError::TransactionInputContainsMessageData { index })
                     }
                     _ => Ok(()),
@@ -291,11 +279,7 @@ impl crate::Cacheable for Upload {
 mod field {
     use super::*;
     use crate::field::{
-        BytecodeRoot,
-        BytecodeWitnessIndex,
-        ChargeableBody,
-        ProofSet,
-        SubsectionIndex,
+        BytecodeRoot, BytecodeWitnessIndex, ChargeableBody, ProofSet, SubsectionIndex,
         SubsectionsNumber,
     };
 

--- a/fuel-vm/src/checked_transaction/balances.rs
+++ b/fuel-vm/src/checked_transaction/balances.rs
@@ -1,26 +1,14 @@
 use fuel_tx::{
-    Chargeable,
-    Input,
-    Output,
-    ValidityError,
-    field,
+    Chargeable, Input, InputV1, Output, ValidityError, field,
     input::{
-        coin::{
-            CoinPredicate,
-            CoinSigned,
-        },
+        coin::{CoinPredicate, CoinSigned},
         message::{
-            MessageCoinPredicate,
-            MessageCoinSigned,
-            MessageDataPredicate,
+            MessageCoinPredicate, MessageCoinSigned, MessageDataPredicate,
             MessageDataSigned,
         },
     },
 };
-use fuel_types::{
-    AssetId,
-    Word,
-};
+use fuel_types::{AssetId, Word};
 
 use alloc::collections::BTreeMap;
 use fuel_tx::policies::PolicyType;
@@ -62,27 +50,37 @@ fn add_up_input_balances<T: field::Inputs>(
     for input in transaction.inputs().iter() {
         match input {
             // Sum coin inputs
-            Input::CoinPredicate(CoinPredicate {
+            Input::V1(InputV1::CoinPredicate(CoinPredicate {
                 asset_id, amount, ..
-            })
-            | Input::CoinSigned(CoinSigned {
+            }))
+            | Input::V1(InputV1::CoinSigned(CoinSigned {
                 asset_id, amount, ..
-            }) => {
+            })) => {
                 let balance = non_retryable_balances.entry(*asset_id).or_default();
                 *balance = (*balance).checked_add(*amount)?;
             }
             // Sum message coin inputs
-            Input::MessageCoinSigned(MessageCoinSigned { amount, .. })
-            | Input::MessageCoinPredicate(MessageCoinPredicate { amount, .. }) => {
+            Input::V1(InputV1::MessageCoinSigned(MessageCoinSigned {
+                amount, ..
+            }))
+            | Input::V1(InputV1::MessageCoinPredicate(MessageCoinPredicate {
+                amount,
+                ..
+            })) => {
                 let balance = non_retryable_balances.entry(*base_asset_id).or_default();
                 *balance = (*balance).checked_add(*amount)?;
             }
             // Sum data messages
-            Input::MessageDataSigned(MessageDataSigned { amount, .. })
-            | Input::MessageDataPredicate(MessageDataPredicate { amount, .. }) => {
+            Input::V1(InputV1::MessageDataSigned(MessageDataSigned {
+                amount, ..
+            }))
+            | Input::V1(InputV1::MessageDataPredicate(MessageDataPredicate {
+                amount,
+                ..
+            })) => {
                 retryable_balance = retryable_balance.checked_add(*amount)?;
             }
-            Input::Contract(_) => {}
+            Input::V1(InputV1::Contract(_)) => {}
         }
     }
 

--- a/fuel-vm/src/interpreter/initialization.rs
+++ b/fuel-vm/src/interpreter/initialization.rs
@@ -18,12 +18,10 @@ use crate::{
 };
 use fuel_asm::RegId;
 use fuel_tx::{
-    Input,
-    Output,
     field::{
         Script,
         ScriptGasLimit,
-    },
+    }, Input, InputV1, Output
 };
 use fuel_types::Word;
 
@@ -50,7 +48,7 @@ where
             .inputs()
             .iter()
             .filter_map(|i| match i {
-                Input::Contract(contract) => Some(contract.contract_id),
+                Input::V1(InputV1::Contract(contract)) => Some(contract.contract_id),
                 _ => None,
             })
             .collect();

--- a/fuel-vm/src/tests/validation.rs
+++ b/fuel-vm/src/tests/validation.rs
@@ -215,9 +215,9 @@ fn malleable_fields_do_not_affect_validity_of_create() {
         let mut tx = tx.clone();
 
         match tx.inputs_mut()[0] {
-            Input::CoinPredicate(CoinPredicate {
+            Input::V1(InputV1::CoinPredicate(CoinPredicate {
                 ref mut tx_pointer, ..
-            }) => {
+            })) => {
                 #[cfg(not(feature = "u32-tx-pointer"))]
                 {
                     *tx_pointer = TxPointer::from_str("123456780001").unwrap()
@@ -326,9 +326,9 @@ fn malleable_fields_do_not_affect_validity_of_script() {
         *tx.receipts_root_mut() = [1u8; 32].into();
 
         match tx.inputs_mut()[0] {
-            Input::CoinPredicate(CoinPredicate {
+            Input::V1(InputV1::CoinPredicate(CoinPredicate {
                 ref mut tx_pointer, ..
-            }) => {
+            })) => {
                 #[cfg(not(feature = "u32-tx-pointer"))]
                 {
                     *tx_pointer = TxPointer::from_str("123456780001").unwrap()
@@ -342,13 +342,13 @@ fn malleable_fields_do_not_affect_validity_of_script() {
         };
 
         match tx.inputs_mut()[1] {
-            Input::Contract(input::contract::Contract {
+            Input::V1(InputV1::Contract(input::contract::Contract {
                 ref mut utxo_id,
                 ref mut balance_root,
                 ref mut state_root,
                 ref mut tx_pointer,
                 ..
-            }) => {
+            })) => {
                 *utxo_id = UtxoId::new([1; 32].into(), 0);
                 *balance_root = [2; 32].into();
                 *state_root = [3; 32].into();

--- a/fuel-vm/src/util.rs
+++ b/fuel-vm/src/util.rs
@@ -135,30 +135,10 @@ pub mod test_helpers {
         op,
     };
     use fuel_tx::{
-        BlobBody,
-        BlobIdExt,
-        ConsensusParameters,
-        Contract,
-        ContractParameters,
-        Create,
-        FeeParameters,
-        Finalizable,
-        GasCosts,
-        Input,
-        Output,
-        PredicateParameters,
-        Receipt,
-        Script,
-        ScriptParameters,
-        StorageSlot,
-        Transaction,
-        TransactionBuilder,
-        TxParameters,
-        Witness,
         field::{
             Outputs,
             ReceiptsRoot,
-        },
+        }, BlobBody, BlobIdExt, ConsensusParameters, Contract, ContractParameters, Create, FeeParameters, Finalizable, GasCosts, Input, InputV1, Output, PredicateParameters, Receipt, Script, ScriptParameters, StorageSlot, Transaction, TransactionBuilder, TxParameters, Witness
     };
     use fuel_types::{
         Address,
@@ -288,7 +268,7 @@ pub mod test_helpers {
                 .builder
                 .inputs()
                 .iter()
-                .find_position(|input| matches!(input, Input::Contract(contract) if &contract.contract_id == id))
+                .find_position(|input| matches!(input, Input::V1(InputV1::Contract(contract)) if &contract.contract_id == id))
                 .expect("expected contract input with matching contract id");
 
             self.builder.add_output(Output::contract(

--- a/version-compatibility/src/fuel_tx.rs
+++ b/version-compatibility/src/fuel_tx.rs
@@ -1,3 +1,5 @@
+use latest_fuel_tx::InputV1;
+
 #[test]
 fn latest_can_deserialize_0_58_2() {
     // Given
@@ -83,7 +85,7 @@ fn latest_can_deserialize_previous_tx_pointer_in_tx() {
         // Then
         if let latest_fuel_tx::Transaction::Script(tx) = latest_tx {
             let input = tx.inputs().first().unwrap();
-            if let latest_fuel_tx::Input::CoinPredicate(input) = input {
+            if let latest_fuel_tx::Input::V1(InputV1::CoinPredicate(input)) = input {
                 let tx_pointer = input.tx_pointer;
                 assert_eq!(tx_pointer.block_height(), 0u32.into());
                 assert_eq!(tx_pointer.tx_index() as u32, idx as u32);


### PR DESCRIPTION
Fixes #956 

- Creates a new `InputV1` enum which holds all `V1` types
- `Input` will now hold versioned inputs


## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [ ] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### After merging, notify other teams

[Add or remove entries as needed]

- [x] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
