### PR TITLE
Prepare for 0.63.0 release

### DIFF
--- a/.changes/breaking/963.md
+++ b/.changes/breaking/963.md
@@ -1,1 +1,0 @@
-Adds `ECAL` state parameter to some predicate-related APIs. Allows `ECAL` instruction during predicate execution. Exposes `Interpreter::context` function that can be used by the `ECAL` handler to determine if it's inside a predicate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased (see .changes folder)]
 
+## [Version 0.63.0]
+
+### Breaking
+- [963](https://github.com/FuelLabs/fuel-vm/pull/963): Adds `ECAL` state parameter to some predicate-related APIs. Allows `ECAL` instruction during predicate execution. Exposes `Interpreter::context` function that can be used by the `ECAL` handler to determine if it's inside a predicate.
+
 ## [Version 0.62.0]
 
 ### Breaking

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,21 +20,21 @@ homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
 rust-version = "1.85.0"
-version = "0.62.0"
+version = "0.63.0"
 
 [workspace.dependencies]
 bincode = { version = "1.3", default-features = false }
 bitflags = "2"
 criterion = "0.5.0"
-fuel-asm = { version = "0.62.0", path = "fuel-asm", default-features = false }
-fuel-compression = { version = "0.62.0", path = "fuel-compression", default-features = false }
-fuel-crypto = { version = "0.62.0", path = "fuel-crypto", default-features = false }
-fuel-derive = { version = "0.62.0", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.62.0", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.62.0", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.62.0", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.62.0", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.62.0", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.63.0", path = "fuel-asm", default-features = false }
+fuel-compression = { version = "0.63.0", path = "fuel-compression", default-features = false }
+fuel-crypto = { version = "0.63.0", path = "fuel-crypto", default-features = false }
+fuel-derive = { version = "0.63.0", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.63.0", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.63.0", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.63.0", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.63.0", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.63.0", path = "fuel-vm", default-features = false }
 
 [profile.web-release] # For minimal wasm binaries, use this profile
 inherits = "release"


### PR DESCRIPTION
## Version 0.63.0

### Breaking
- [963](https://github.com/FuelLabs/fuel-vm/pull/963): Adds `ECAL` state parameter to some predicate-related APIs. Allows `ECAL` instruction during predicate execution. Exposes `Interpreter::context` function that can be used by the `ECAL` handler to determine if it's inside a predicate.