### PR TITLE
Fix storage key overflow in SCLR instruction

### DIFF
--- a/.changes/fixed/1004.md
+++ b/.changes/fixed/1004.md
@@ -1,0 +1,1 @@
+SCLR now correctly validates that the U256 key will not overflow

--- a/fuel-vm/src/interpreter/storage.rs
+++ b/fuel-vm/src/interpreter/storage.rs
@@ -157,6 +157,15 @@ where
         key: Bytes32,
         range: usize,
     ) -> Result<(), RuntimeError<S::DataError>> {
+        // Ensure the key range doesn't overflow U256. A range of 0 or 1 starting at
+        // any key is always valid; for larger ranges we check that
+        // start_key + (range - 1) doesn't wrap around.
+        if range > 1 {
+            let start = primitive_types::U256::from_big_endian(&*key);
+            start
+                .checked_add(primitive_types::U256::from(range - 1))
+                .ok_or(PanicReason::TooManySlots)?;
+        }
         self.dependent_gas_charge(
             self.gas_costs()
                 .storage_clear()

--- a/fuel-vm/src/interpreter/storage.rs
+++ b/fuel-vm/src/interpreter/storage.rs
@@ -162,6 +162,8 @@ where
         // start_key + (range - 1) doesn't wrap around.
         if range > 1 {
             let start = primitive_types::U256::from_big_endian(&*key);
+            // Safety: checked above in if condition
+            #[allow(clippy::arithmetic_side_effects)]
             start
                 .checked_add(primitive_types::U256::from(range - 1))
                 .ok_or(PanicReason::TooManySlots)?;

--- a/fuel-vm/src/tests/storage.rs
+++ b/fuel-vm/src/tests/storage.rs
@@ -411,6 +411,61 @@ fn sclr_clears_correct_number_of_slots(
     assert_eq!(slots_after, expected);
 }
 
+/// Builds a program that sets the key buffer at $hp to all 0xFF bytes (U256::MAX).
+fn set_key_to_max(program: &mut Vec<Instruction>) {
+    program.extend([op::movi(0x15, 32), op::aloc(0x15), op::movi(0x11, 0xFF)]);
+    for i in 0..32u16 {
+        program.push(op::sb(RegId::HP, 0x11, i));
+    }
+}
+
+#[test]
+fn sclr_with_max_key_and_overflowing_range_panics_with_too_many_slots() {
+    // key = U256::MAX, range = 2 → key+1 overflows U256
+    let mut program = vec![];
+    set_key_to_max(&mut program);
+    program.extend([
+        op::movi(0x10, 2),
+        op::sclr(RegId::HP, 0x10),
+        op::ret(RegId::ONE),
+    ]);
+
+    let receipts = call_contract_once(program);
+    assert_panics(&receipts, PanicReason::TooManySlots);
+}
+
+#[test]
+fn sclr_with_max_key_and_range_one_succeeds() {
+    // key = U256::MAX, range = 1 → only slot U256::MAX itself, no overflow
+    let mut program = vec![];
+    set_key_to_max(&mut program);
+    program.extend([
+        op::movi(0x10, 1),
+        op::sclr(RegId::HP, 0x10),
+        op::ret(RegId::ONE),
+    ]);
+
+    let receipts = call_contract_once(program);
+    assert_success(&receipts);
+}
+
+#[test]
+fn scwq_with_max_key_and_overflowing_range_panics_with_too_many_slots() {
+    // Verify SCWQ has the same consistent behaviour as SCLR once the fix is in place.
+    // key = U256::MAX, range = 2 → key+1 overflows U256
+    const DISCARD: RegId = RegId::new(0x39);
+    let mut program = vec![];
+    set_key_to_max(&mut program);
+    program.extend([
+        op::movi(0x10, 2),
+        op::scwq(RegId::HP, DISCARD, 0x10),
+        op::ret(RegId::ONE),
+    ]);
+
+    let receipts = call_contract_once(program);
+    assert_panics(&receipts, PanicReason::TooManySlots);
+}
+
 /// Allocates and initalizes a 256 byte array with elements from 0 to 255.
 fn create_example_buffer() -> Vec<Instruction> {
     let mut ops = vec![op::movi(0x39, 256), op::aloc(0x39)];


### PR DESCRIPTION
## Problem

The new SCLR (storage clear) instruction did not validate that the key range stays within the U256 address space. When called with a key of U256::MAX and a range ≥ 2, it would result in `contract_state_remove_range` encountering an overflow internally. In the current configuration this means that the tx would get discarded from the txpool, making this a potential yet minor DoS factor.

## Fix

Add an overflow check in interpreter_storage before the gas charge and storage operation. If start_key + (range - 1) would exceed U256::MAX, the VM now panics with PanicReason::TooManySlots, which is the existing error used for analogous range-boundary violations in SCWQ.

Ranges of 0 or 1 are fast-pathed and always valid regardless of the starting key.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here
