### PR TITLE
Prepare for 0.66.3 release

### DIFF
--- a/.changes/fixed/1004.md
+++ b/.changes/fixed/1004.md
@@ -1,1 +1,0 @@
-SCLR now correctly validates that the U256 key will not overflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased (see .changes folder)]
 
+## [Version 0.66.3]
+
+### Fixed
+- [1004](https://github.com/FuelLabs/fuel-vm/pull/1004): SCLR now correctly validates that the U256 key will not overflow
+
 ## [Version 0.66.2]
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,22 +20,22 @@ homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
 rust-version = "1.93.0"
-version = "0.66.2"
+version = "0.66.3"
 
 [workspace.dependencies]
 bincode = { version = "1.3", default-features = false }
 bitflags = "2"
 criterion = "0.5.0"
 educe = { version = "0.6", default-features = false }
-fuel-asm = { version = "0.66.2", path = "fuel-asm", default-features = false }
-fuel-compression = { version = "0.66.2", path = "fuel-compression", default-features = false }
-fuel-crypto = { version = "0.66.2", path = "fuel-crypto", default-features = false }
-fuel-derive = { version = "0.66.2", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.66.2", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.66.2", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.66.2", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.66.2", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.66.2", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.66.3", path = "fuel-asm", default-features = false }
+fuel-compression = { version = "0.66.3", path = "fuel-compression", default-features = false }
+fuel-crypto = { version = "0.66.3", path = "fuel-crypto", default-features = false }
+fuel-derive = { version = "0.66.3", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.66.3", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.66.3", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.66.3", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.66.3", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.66.3", path = "fuel-vm", default-features = false }
 
 [profile.web-release] # For minimal wasm binaries, use this profile
 inherits = "release"


### PR DESCRIPTION
## Version 0.66.3

### Fixed
- [1004](https://github.com/FuelLabs/fuel-vm/pull/1004): SCLR now correctly validates that the U256 key will not overflow
