### PR TITLE
BURN: Skip zero-amount changes and clear empty asset slots

### DIFF
--- a/.changes/changed/1008.md
+++ b/.changes/changed/1008.md
@@ -1,0 +1,1 @@
+Skip zero-amount burns and clear empty asset slots

--- a/fuel-vm/src/interpreter/blockchain.rs
+++ b/fuel-vm/src/interpreter/blockchain.rs
@@ -631,21 +631,29 @@ impl<S> BurnCtx<'_, S>
 where
     S: ContractsAssetsStorage,
 {
-    pub(crate) fn burn(self, a: Word, b: Word) -> IoResult<(), S::Error> {
+    pub(crate) fn burn(self, amount: Word, sub_id_addr: Word) -> IoResult<(), S::Error> {
         let contract_id = internal_contract(self.context, self.fp, self.memory)?;
-        let sub_id = SubAssetId::new(self.memory.read_bytes(b)?);
+        let sub_id = SubAssetId::new(self.memory.read_bytes(sub_id_addr)?);
         let asset_id = contract_id.asset_id(&sub_id);
 
-        let balance = balance(self.storage, &contract_id, &asset_id)?;
-        let balance = balance
-            .checked_sub(a)
-            .ok_or(PanicReason::NotEnoughBalance)?;
+        if amount != 0 {
+            let balance = balance(self.storage, &contract_id, &asset_id)?;
+            let balance = balance
+                .checked_sub(amount)
+                .ok_or(PanicReason::NotEnoughBalance)?;
 
-        self.storage
-            .contract_asset_id_balance_insert(&contract_id, &asset_id, balance)
-            .map_err(RuntimeError::Storage)?;
+            if balance == 0 {
+                self.storage
+                    .contract_asset_id_balance_remove(&contract_id, &asset_id)
+                    .map_err(RuntimeError::Storage)?;
+            } else {
+                self.storage
+                    .contract_asset_id_balance_insert(&contract_id, &asset_id, balance)
+                    .map_err(RuntimeError::Storage)?;
+            }
+        }
 
-        let receipt = Receipt::burn(sub_id, contract_id, a, *self.pc, *self.is);
+        let receipt = Receipt::burn(sub_id, contract_id, amount, *self.pc, *self.is);
 
         self.receipts.push(receipt)?;
 

--- a/fuel-vm/src/interpreter/blockchain/other_tests.rs
+++ b/fuel-vm/src/interpreter/blockchain/other_tests.rs
@@ -73,7 +73,7 @@ fn test_burn(
     let result = storage
         .contract_asset_id_balance(&contract_id, &asset_id)
         .unwrap()
-        .unwrap();
+        .unwrap_or(0);
     assert_eq!(result, initialize.unwrap_or(0) - amount);
     assert_eq!(receipts.len(), 1);
     assert_eq!(

--- a/fuel-vm/src/storage/interpreter.rs
+++ b/fuel-vm/src/storage/interpreter.rs
@@ -253,6 +253,15 @@ pub trait ContractsAssetsStorage: StorageMutate<ContractsAssets> {
             &value,
         )
     }
+
+    /// Remove the balance of an asset ID in a contract storage.
+    fn contract_asset_id_balance_remove(
+        &mut self,
+        contract: &ContractId,
+        asset_id: &AssetId,
+    ) -> Result<(), Self::Error> {
+        StorageMutate::<ContractsAssets>::remove(self, &(contract, asset_id).into())
+    }
 }
 
 impl<S> ContractsAssetsStorage for &mut S where S: ContractsAssetsStorage {}


### PR DESCRIPTION
Previously, burning zero units of a nonexisting asset would write that to the storage. This PR ignores zero-amount burns, although it still produces a receipt for them. In addition, when all assets with some specific have been burned, clears the slot instead of writing a zero there.


## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [ ] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here
