### PR TITLE
Release v0.66.4

### DIFF
--- a/.changes/changed/1008.md
+++ b/.changes/changed/1008.md
@@ -1,1 +1,0 @@
-Skip zero-amount burns and clear empty asset slots

--- a/.changes/changed/1009.md
+++ b/.changes/changed/1009.md
@@ -1,1 +1,0 @@
-Do not modify storage for zero-amount mints

--- a/.changes/changed/1010.md
+++ b/.changes/changed/1010.md
@@ -1,1 +1,0 @@
-Storage cache: Use HashMap, group by ContractId

--- a/.changes/changed/1011.md
+++ b/.changes/changed/1011.md
@@ -1,1 +1,0 @@
-Rename default_gas_costs to default_gas_costs_for_tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased (see .changes folder)]
 
+## [Version 0.66.4]
+
+### Changed
+- [1008](https://github.com/FuelLabs/fuel-vm/pull/1008): Skip zero-amount burns and clear empty asset slots
+- [1009](https://github.com/FuelLabs/fuel-vm/pull/1009): Do not modify storage for zero-amount mints
+- [1010](https://github.com/FuelLabs/fuel-vm/pull/1010): Storage cache: Use HashMap, group by ContractId
+- [1011](https://github.com/FuelLabs/fuel-vm/pull/1011): Rename default_gas_costs to default_gas_costs_for_tests
+
 ## [Version 0.66.3]
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,22 +20,22 @@ homepage = "https://fuel.network/"
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-vm"
 rust-version = "1.93.0"
-version = "0.66.3"
+version = "0.66.4"
 
 [workspace.dependencies]
 bincode = { version = "1.3", default-features = false }
 bitflags = "2"
 criterion = "0.5.0"
 educe = { version = "0.6", default-features = false }
-fuel-asm = { version = "0.66.3", path = "fuel-asm", default-features = false }
-fuel-compression = { version = "0.66.3", path = "fuel-compression", default-features = false }
-fuel-crypto = { version = "0.66.3", path = "fuel-crypto", default-features = false }
-fuel-derive = { version = "0.66.3", path = "fuel-derive", default-features = false }
-fuel-merkle = { version = "0.66.3", path = "fuel-merkle", default-features = false }
-fuel-storage = { version = "0.66.3", path = "fuel-storage", default-features = false }
-fuel-tx = { version = "0.66.3", path = "fuel-tx", default-features = false }
-fuel-types = { version = "0.66.3", path = "fuel-types", default-features = false }
-fuel-vm = { version = "0.66.3", path = "fuel-vm", default-features = false }
+fuel-asm = { version = "0.66.4", path = "fuel-asm", default-features = false }
+fuel-compression = { version = "0.66.4", path = "fuel-compression", default-features = false }
+fuel-crypto = { version = "0.66.4", path = "fuel-crypto", default-features = false }
+fuel-derive = { version = "0.66.4", path = "fuel-derive", default-features = false }
+fuel-merkle = { version = "0.66.4", path = "fuel-merkle", default-features = false }
+fuel-storage = { version = "0.66.4", path = "fuel-storage", default-features = false }
+fuel-tx = { version = "0.66.4", path = "fuel-tx", default-features = false }
+fuel-types = { version = "0.66.4", path = "fuel-types", default-features = false }
+fuel-vm = { version = "0.66.4", path = "fuel-vm", default-features = false }
 
 [profile.web-release] # For minimal wasm binaries, use this profile
 inherits = "release"


### PR DESCRIPTION
## Version 0.66.4

### Changed
- [1008](https://github.com/FuelLabs/fuel-vm/pull/1008): Skip zero-amount burns and clear empty asset slots
- [1009](https://github.com/FuelLabs/fuel-vm/pull/1009): Do not modify storage for zero-amount mints
- [1010](https://github.com/FuelLabs/fuel-vm/pull/1010): Storage cache: Use HashMap, group by ContractId
- [1011](https://github.com/FuelLabs/fuel-vm/pull/1011): Rename default_gas_costs to default_gas_costs_for_tests
