### PR TITLE
feat: read-only contract inputs (contract input without contract output)

### DIFF
--- a/.changes/added/1014.md
+++ b/.changes/added/1014.md
@@ -1,0 +1,10 @@
+Support read-only contract inputs: a contract input without the corresponding
+contract output is now valid and denotes a read-only access to the contract.
+Its code can be executed and its state and balances read, but any modification
+(`SWW`, `SWWQ`, `SCWQ`, `SWRD`/`SWRI`, `SUPD`/`SUPI`, non-zero `MINT`/`BURN`,
+`TR`/`TRO` debits or credits, `SMO` with coins, or `CALL` with forwarded coins)
+panics with the new `PanicReason::ContractIsReadOnly`. Since a read-only
+contract's state root and balance root cannot change, no output slot is needed
+to commit new roots, which allows schedulers to run transactions that only read
+a shared contract concurrently. This is automatic in this version — it is not
+gated behind a consensus parameter.

--- a/.changes/breaking/1014.md
+++ b/.changes/breaking/1014.md
@@ -1,0 +1,7 @@
+Transaction validity is relaxed: a contract input without the corresponding
+contract output is now accepted (as a read-only contract access) instead of
+being rejected with `ValidityError::InputContractAssociatedOutputContract`.
+This is a consensus-breaking change in transaction validity and is active for
+every transaction on this version — it is not gated behind a consensus
+parameter. More than one contract output per contract input is still rejected.
+Also added `PanicReason::ContractIsReadOnly = 0x43`.

--- a/fuel-asm/src/panic_reason.rs
+++ b/fuel-asm/src/panic_reason.rs
@@ -172,6 +172,9 @@ enum_from! {
         OwnerIsUnknown = 0x41,
         /// Storage operation out of bounds or exceeds maximum allowed size
         StorageOutOfBounds = 0x42,
+        /// Attempt to modify the state or balances of a read-only contract
+        /// input (a contract input without the corresponding contract output).
+        ContractIsReadOnly = 0x43,
     }
 }
 

--- a/fuel-tx/src/tests/valid_cases/input.rs
+++ b/fuel-tx/src/tests/valid_cases/input.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::cast_possible_truncation)]
+#![allow(non_snake_case)]
 
 use super::PREDICATE_PARAMS;
 use crate::{
@@ -259,85 +260,113 @@ fn coin_predicate() {
 }
 
 #[test]
-fn contract() {
+fn contract__check__contract_input_with_associated_output_is_valid() {
     let rng = &mut StdRng::seed_from_u64(8586);
 
     let txhash: Bytes32 = rng.r#gen();
 
-    Input::contract(
+    // Given: a contract input at index 1 with the associated contract output
+    let input = Input::contract(
         rng.r#gen(),
         rng.r#gen(),
         rng.r#gen(),
         rng.r#gen(),
         rng.r#gen(),
-    )
-    .check(
-        1,
-        &txhash,
-        &[Output::contract(1, rng.r#gen(), rng.r#gen())],
-        &[],
-        &Default::default(),
-        &mut None,
-    )
-    .unwrap();
-
-    let err = Input::contract(
-        rng.r#gen(),
-        rng.r#gen(),
-        rng.r#gen(),
-        rng.r#gen(),
-        rng.r#gen(),
-    )
-    .check(1, &txhash, &[], &[], &Default::default(), &mut None)
-    .err()
-    .unwrap();
-
-    assert_eq!(
-        ValidityError::InputContractAssociatedOutputContract { index: 1 },
-        err
     );
 
-    let err = Input::contract(
-        rng.r#gen(),
-        rng.r#gen(),
-        rng.r#gen(),
-        rng.r#gen(),
-        rng.r#gen(),
-    )
-    .check(
-        1,
-        &txhash,
-        &[Output::coin(rng.r#gen(), rng.r#gen(), rng.r#gen())],
-        &[],
-        &Default::default(),
-        &mut None,
-    )
-    .err()
-    .unwrap();
+    // When / Then: the usual read-write contract input/output pair is valid
+    input
+        .check(
+            1,
+            &txhash,
+            &[Output::contract(1, rng.r#gen(), rng.r#gen())],
+            &[],
+            &Default::default(),
+            &mut None,
+        )
+        .expect("contract input with associated output should be valid");
+}
 
-    assert_eq!(
-        ValidityError::InputContractAssociatedOutputContract { index: 1 },
-        err
+#[test]
+fn contract__check__contract_input_without_output_is_read_only_and_valid() {
+    let rng = &mut StdRng::seed_from_u64(8586);
+
+    let txhash: Bytes32 = rng.r#gen();
+
+    // Given: a contract input at index 1 and no contract output referring to it
+    let input = Input::contract(
+        rng.r#gen(),
+        rng.r#gen(),
+        rng.r#gen(),
+        rng.r#gen(),
+        rng.r#gen(),
     );
 
-    let err = Input::contract(
-        rng.r#gen(),
-        rng.r#gen(),
-        rng.r#gen(),
-        rng.r#gen(),
-        rng.r#gen(),
-    )
-    .check(
-        1,
-        &txhash,
-        &[Output::contract(2, rng.r#gen(), rng.r#gen())],
-        &[],
-        &Default::default(),
-        &mut None,
-    )
-    .err()
-    .unwrap();
+    // When / Then: a contract input without the associated output is a
+    // read-only access and is always valid.
+    input
+        .check(1, &txhash, &[], &[], &Default::default(), &mut None)
+        .expect("read-only contract input should be valid");
 
+    // A non-contract output does not associate with the contract input, so the
+    // input stays read-only and valid.
+    input
+        .check(
+            1,
+            &txhash,
+            &[Output::coin(rng.r#gen(), rng.r#gen(), rng.r#gen())],
+            &[],
+            &Default::default(),
+            &mut None,
+        )
+        .expect("read-only contract input should be valid");
+
+    // A contract output referring to a different input index does not associate
+    // with this input either.
+    input
+        .check(
+            1,
+            &txhash,
+            &[Output::contract(2, rng.r#gen(), rng.r#gen())],
+            &[],
+            &Default::default(),
+            &mut None,
+        )
+        .expect("read-only contract input should be valid");
+}
+
+#[test]
+fn contract__check__duplicate_contract_outputs_are_invalid() {
+    let rng = &mut StdRng::seed_from_u64(8586);
+
+    let txhash: Bytes32 = rng.r#gen();
+
+    // Given: a contract input at index 1
+    let input = Input::contract(
+        rng.r#gen(),
+        rng.r#gen(),
+        rng.r#gen(),
+        rng.r#gen(),
+        rng.r#gen(),
+    );
+
+    // When: two contract outputs point at the same input index
+    let err = input
+        .check(
+            1,
+            &txhash,
+            &[
+                Output::contract(1, rng.r#gen(), rng.r#gen()),
+                Output::contract(1, rng.r#gen(), rng.r#gen()),
+            ],
+            &[],
+            &Default::default(),
+            &mut None,
+        )
+        .err()
+        .unwrap();
+
+    // Then: more than one associated output is still invalid
     assert_eq!(
         ValidityError::InputContractAssociatedOutputContract { index: 1 },
         err
@@ -720,4 +749,82 @@ fn transaction_with_duplicate_contract_utxo_id_is_valid() {
         .finalize()
         .check_without_signatures(Default::default(), &ConsensusParameters::standard())
         .expect("Duplicated UTXO id is valid for contract input");
+}
+
+fn script_with_read_only_contract_input(rng: &mut StdRng) -> Script {
+    let fee = Input::coin_signed(
+        rng.r#gen(),
+        rng.r#gen(),
+        rng.r#gen(),
+        rng.r#gen(),
+        rng.r#gen(),
+        0,
+    );
+    let contract = Input::contract(
+        rng.r#gen(),
+        rng.r#gen(),
+        rng.r#gen(),
+        rng.r#gen(),
+        rng.r#gen(),
+    );
+
+    TransactionBuilder::script(vec![], vec![])
+        .add_input(fee)
+        .add_input(contract)
+        .add_witness(rng.r#gen())
+        .finalize()
+}
+
+#[test]
+fn transaction__check__read_only_contract_input_is_valid() {
+    let rng = &mut StdRng::seed_from_u64(8586);
+
+    // Given: a contract input without the corresponding contract output
+    let tx = script_with_read_only_contract_input(rng);
+
+    // When / Then: a contract input without an output is a read-only access and
+    // is accepted by the standard consensus parameters.
+    tx.check_without_signatures(Default::default(), &ConsensusParameters::standard())
+        .expect("read-only contract input should be valid");
+}
+
+#[test]
+fn transaction__check__duplicate_contract_outputs_are_invalid() {
+    let rng = &mut StdRng::seed_from_u64(8586);
+
+    let fee = Input::coin_signed(
+        rng.r#gen(),
+        rng.r#gen(),
+        rng.r#gen(),
+        rng.r#gen(),
+        rng.r#gen(),
+        0,
+    );
+    let contract = Input::contract(
+        rng.r#gen(),
+        rng.r#gen(),
+        rng.r#gen(),
+        rng.r#gen(),
+        rng.r#gen(),
+    );
+
+    // Given: two contract outputs pointing at the same contract input
+    let tx = TransactionBuilder::script(vec![], vec![])
+        .add_input(fee)
+        .add_input(contract)
+        .add_output(Output::contract(1, rng.r#gen(), rng.r#gen()))
+        .add_output(Output::contract(1, rng.r#gen(), rng.r#gen()))
+        .add_witness(rng.r#gen())
+        .finalize();
+
+    // When
+    let err = tx
+        .check_without_signatures(Default::default(), &ConsensusParameters::standard())
+        .expect_err("Expected checkable failure");
+
+    // Then
+    assert_eq!(
+        err,
+        ValidityError::InputContractAssociatedOutputContract { index: 1 }
+    );
 }

--- a/fuel-tx/src/transaction/validity.rs
+++ b/fuel-tx/src/transaction/validity.rs
@@ -188,19 +188,28 @@ impl Input {
                 Err(ValidityError::InputWitnessIndexBounds { index })
             }
 
-            // ∀ inputContract ∃! outputContract : outputContract.inputIndex =
-            // inputContract.index
+            // A contract input has at most one associated contract output:
+            // outputContract.inputIndex = inputContract.index.
+            //
+            // A contract input *with* the associated output is a read-write
+            // access whose new state/balance roots are committed to that output.
+            // A contract input *without* the associated output is a read-only
+            // access: the VM forbids any modification of the state or balances
+            // of such a contract during execution, so its roots stay unchanged
+            // and no output is required to commit new ones. More than one
+            // associated output is always invalid.
             Self::Contract { .. }
-                if 1 != outputs
+                if outputs
                     .iter()
-                    .filter_map(|output| match output {
+                    .filter(|output| match output {
                         Output::Contract(output::contract::Contract {
                             input_index,
                             ..
-                        }) if *input_index as usize == index => Some(()),
-                        _ => None,
+                        }) => *input_index as usize == index,
+                        _ => false,
                     })
-                    .count() =>
+                    .count()
+                    > 1 =>
             {
                 Err(ValidityError::InputContractAssociatedOutputContract { index })
             }

--- a/fuel-vm/src/interpreter.rs
+++ b/fuel-vm/src/interpreter.rs
@@ -124,6 +124,10 @@ pub struct Interpreter<M, S, Tx = (), Ecal = NotSupportedEcal, V = verification:
     initial_balances: InitialBalances,
     input_contracts: BTreeSet<ContractId>,
     input_contracts_index_to_output_index: alloc::collections::BTreeMap<u16, u16>,
+    /// Contracts of the inputs without the corresponding contract outputs.
+    /// Their state and balances are read-only during execution: there is no
+    /// output to commit updated roots, so any modification is forbidden.
+    read_only_contracts: BTreeSet<ContractId>,
     storage: S,
     debugger: Debugger,
     context: Context,

--- a/fuel-vm/src/interpreter/blockchain.rs
+++ b/fuel-vm/src/interpreter/blockchain.rs
@@ -25,6 +25,7 @@ use crate::{
         },
         internal::{
             base_asset_balance_sub,
+            check_contract_is_not_read_only,
             inc_pc,
             internal_contract,
             tx_id,
@@ -159,6 +160,8 @@ where
             context: &self.context,
             memory: self.memory.as_ref(),
             receipts: &mut self.receipts,
+            read_only_contracts: &self.read_only_contracts,
+            panic_context: &mut self.panic_context,
             fp: fp.as_ref(),
             pc,
             is: is.as_ref(),
@@ -184,6 +187,8 @@ where
             context: &self.context,
             memory: self.memory.as_ref(),
             receipts: &mut self.receipts,
+            read_only_contracts: &self.read_only_contracts,
+            panic_context: &mut self.panic_context,
 
             new_storage_gas_per_byte,
             cgas,
@@ -321,6 +326,8 @@ where
             balances: &mut self.balances,
             storage: &mut self.storage,
             current_contract: self.frames.last().map(|frame| frame.to()).copied(),
+            read_only_contracts: &self.read_only_contracts,
+            panic_context: &mut self.panic_context,
             fp: fp.as_ref(),
             pc,
             recipient_mem_address: a,
@@ -374,11 +381,11 @@ impl<S, V> LoadContractCodeCtx<'_, S, V> {
 
         // only blobs are allowed in predicates
         if self.context.is_predicate() {
-            return Err(PanicReason::ContractInstructionNotAllowed.into())
+            return Err(PanicReason::ContractInstructionNotAllowed.into());
         }
 
         if ssp != sp {
-            return Err(PanicReason::ExpectedUnallocatedStack.into())
+            return Err(PanicReason::ExpectedUnallocatedStack.into());
         }
 
         let contract_id = ContractId::from(self.memory.read_bytes(contract_id_addr)?);
@@ -387,7 +394,7 @@ impl<S, V> LoadContractCodeCtx<'_, S, V> {
             padded_len_word(length_unpadded).ok_or(PanicReason::MemoryOverflow)?;
 
         if length > self.contract_max_size {
-            return Err(PanicReason::ContractMaxSize.into())
+            return Err(PanicReason::ContractMaxSize.into());
         }
 
         self.verifier.check_contract_in_inputs(
@@ -471,7 +478,7 @@ impl<S, V> LoadContractCodeCtx<'_, S, V> {
         let region_start = ssp;
 
         if ssp != sp {
-            return Err(PanicReason::ExpectedUnallocatedStack.into())
+            return Err(PanicReason::ExpectedUnallocatedStack.into());
         }
 
         let blob_id = BlobId::from(self.memory.read_bytes(blob_id_addr)?);
@@ -554,12 +561,12 @@ impl<S, V> LoadContractCodeCtx<'_, S, V> {
         let dst = ssp;
 
         if ssp != sp {
-            return Err(PanicReason::ExpectedUnallocatedStack.into())
+            return Err(PanicReason::ExpectedUnallocatedStack.into());
         }
 
         if length_unpadded == 0 {
             inc_pc(self.pc);
-            return Ok(())
+            return Ok(());
         }
 
         let length = bytes::padded_len_word(length_unpadded).unwrap_or(Word::MAX);
@@ -622,6 +629,8 @@ struct BurnCtx<'vm, S> {
     context: &'vm Context,
     memory: &'vm MemoryInstance,
     receipts: &'vm mut ReceiptsCtx,
+    read_only_contracts: &'vm BTreeSet<ContractId>,
+    panic_context: &'vm mut PanicContext,
     fp: Reg<'vm, FP>,
     pc: RegMut<'vm, PC>,
     is: Reg<'vm, IS>,
@@ -637,6 +646,11 @@ where
         let asset_id = contract_id.asset_id(&sub_id);
 
         if amount != 0 {
+            check_contract_is_not_read_only(
+                self.panic_context,
+                self.read_only_contracts,
+                &contract_id,
+            )?;
             let balance = balance(self.storage, &contract_id, &asset_id)?;
             let balance = balance
                 .checked_sub(amount)
@@ -668,6 +682,8 @@ struct MintCtx<'vm, S> {
     memory: &'vm MemoryInstance,
 
     receipts: &'vm mut ReceiptsCtx,
+    read_only_contracts: &'vm BTreeSet<ContractId>,
+    panic_context: &'vm mut PanicContext,
     new_storage_gas_per_byte: Word,
     cgas: RegMut<'vm, CGAS>,
     ggas: RegMut<'vm, GGAS>,
@@ -690,6 +706,11 @@ where
         let asset_id = contract_id.asset_id(&sub_id);
 
         if amount != 0 {
+            check_contract_is_not_read_only(
+                self.panic_context,
+                self.read_only_contracts,
+                &contract_id,
+            )?;
             let balance = balance(self.storage, &contract_id, &asset_id)?;
             let balance = balance
                 .checked_add(amount)
@@ -952,6 +973,8 @@ where
     balances: &'vm mut RuntimeBalances,
     storage: &'vm mut S,
     current_contract: Option<ContractId>,
+    read_only_contracts: &'vm BTreeSet<ContractId>,
+    panic_context: &'vm mut PanicContext,
     fp: Reg<'vm, FP>,
     pc: RegMut<'vm, PC>,
     /// A
@@ -983,6 +1006,13 @@ where
         // validations passed, perform the mutations
 
         if let Some(source_contract) = self.current_contract {
+            if self.amount_coins_to_send > 0 {
+                check_contract_is_not_read_only(
+                    self.panic_context,
+                    self.read_only_contracts,
+                    &source_contract,
+                )?;
+            }
             balance_decrease(
                 self.storage,
                 &source_contract,

--- a/fuel-vm/src/interpreter/blockchain/other_tests.rs
+++ b/fuel-vm/src/interpreter/blockchain/other_tests.rs
@@ -59,11 +59,15 @@ fn test_burn(
     let is = 0;
     const ORIGINAL_PC: Word = 4;
     let mut pc = ORIGINAL_PC;
+    let mut panic_context = PanicContext::None;
+    let read_only_contracts = Default::default();
     BurnCtx {
         storage: &mut storage,
         context: &context,
         receipts: &mut receipts,
         memory: &mut memory,
+        read_only_contracts: &read_only_contracts,
+        panic_context: &mut panic_context,
         fp: Reg::new(&fp),
         pc: RegMut::new(&mut pc),
         is: Reg::new(&is),
@@ -140,11 +144,15 @@ fn test_mint(
     let mut pc = ORIGINAL_PC;
     let mut cgas = 10_000;
     let mut ggas = 10_000;
+    let mut panic_context = PanicContext::None;
+    let read_only_contracts = Default::default();
     MintCtx {
         storage: &mut storage,
         context: &context,
         receipts: &mut receipts,
         memory: &mut memory,
+        read_only_contracts: &read_only_contracts,
+        panic_context: &mut panic_context,
 
         new_storage_gas_per_byte: 1,
         cgas: RegMut::new(&mut cgas),

--- a/fuel-vm/src/interpreter/blockchain/smo_tests.rs
+++ b/fuel-vm/src/interpreter/blockchain/smo_tests.rs
@@ -228,6 +228,8 @@ fn test_smo(
         .expect("Should be valid balance");
     let fp = 0;
     let mut pc = 0;
+    let mut panic_context = PanicContext::None;
+    let read_only_contracts = Default::default();
 
     let input = MessageOutputCtx {
         base_asset_id,
@@ -241,6 +243,8 @@ fn test_smo(
         } else {
             None
         },
+        read_only_contracts: &read_only_contracts,
+        panic_context: &mut panic_context,
         fp: Reg::new(&fp),
         pc: RegMut::new(&mut pc),
         recipient_mem_address,

--- a/fuel-vm/src/interpreter/constructors.rs
+++ b/fuel-vm/src/interpreter/constructors.rs
@@ -72,6 +72,7 @@ where
             tx: Default::default(),
             input_contracts: Default::default(),
             input_contracts_index_to_output_index: Default::default(),
+            read_only_contracts: Default::default(),
             initial_balances: Default::default(),
             storage,
             debugger: Debugger::default(),

--- a/fuel-vm/src/interpreter/contract.rs
+++ b/fuel-vm/src/interpreter/contract.rs
@@ -11,6 +11,7 @@ use super::{
     RuntimeBalances,
     gas::gas_charge,
     internal::{
+        check_contract_is_not_read_only,
         external_asset_id_balance_sub,
         inc_pc,
         internal_contract,
@@ -108,6 +109,7 @@ where
             new_storage_gas_per_byte,
             tx: &mut self.tx,
             input_contracts: &self.input_contracts,
+            read_only_contracts: &self.read_only_contracts,
             panic_context: &mut self.panic_context,
             tx_offset,
             cgas,
@@ -149,6 +151,7 @@ where
             new_storage_gas_per_byte,
             tx: &mut self.tx,
             input_contracts: &self.input_contracts,
+            read_only_contracts: &self.read_only_contracts,
             panic_context: &mut self.panic_context,
             tx_offset,
             cgas,
@@ -218,6 +221,7 @@ struct TransferCtx<'vm, S, Tx, V> {
     new_storage_gas_per_byte: Word,
     tx: &'vm mut Tx,
     input_contracts: &'vm BTreeSet<ContractId>,
+    read_only_contracts: &'vm BTreeSet<ContractId>,
     panic_context: &'vm mut PanicContext,
     tx_offset: usize,
     cgas: RegMut<'vm, CGAS>,
@@ -256,8 +260,14 @@ impl<S, Tx, V> TransferCtx<'_, S, Tx, V> {
             &destination,
         )?;
 
+        check_contract_is_not_read_only(
+            self.panic_context,
+            self.read_only_contracts,
+            &destination,
+        )?;
+
         if amount == 0 {
-            return Err(PanicReason::TransferZeroCoins.into())
+            return Err(PanicReason::TransferZeroCoins.into());
         }
 
         let internal_context = match internal_contract(self.context, self.fp, self.memory)
@@ -272,6 +282,11 @@ impl<S, Tx, V> TransferCtx<'_, S, Tx, V> {
 
         if let Some(source_contract) = internal_context {
             // debit funding source (source contract balance)
+            check_contract_is_not_read_only(
+                self.panic_context,
+                self.read_only_contracts,
+                &source_contract,
+            )?;
             balance_decrease(self.storage, &source_contract, &asset_id, amount)?;
         } else {
             // debit external funding source (i.e. free balance)
@@ -330,7 +345,7 @@ impl<S, Tx, V> TransferCtx<'_, S, Tx, V> {
         let amount = transfer_amount;
 
         if amount == 0 {
-            return Err(PanicReason::TransferZeroCoins.into())
+            return Err(PanicReason::TransferZeroCoins.into());
         }
 
         let internal_context = match internal_contract(self.context, self.fp, self.memory)
@@ -345,6 +360,11 @@ impl<S, Tx, V> TransferCtx<'_, S, Tx, V> {
 
         if let Some(source_contract) = internal_context {
             // debit funding source (source contract balance)
+            check_contract_is_not_read_only(
+                self.panic_context,
+                self.read_only_contracts,
+                &source_contract,
+            )?;
             balance_decrease(self.storage, &source_contract, &asset_id, amount)?;
         } else {
             // debit external funding source (i.e. UTXOs)
@@ -424,7 +444,7 @@ where
 {
     if amount == 0 {
         // Don't update the balance if the amount is zero
-        return Ok(false)
+        return Ok(false);
     }
 
     let balance = balance(storage, contract, asset_id)?;
@@ -449,7 +469,7 @@ where
 {
     if amount == 0 {
         // Don't update the balance if the amount is zero
-        return Ok(())
+        return Ok(());
     }
 
     let balance = balance(storage, contract, asset_id)?;

--- a/fuel-vm/src/interpreter/diff/storage.rs
+++ b/fuel-vm/src/interpreter/diff/storage.rs
@@ -104,6 +104,7 @@ where
             input_contracts: self.input_contracts,
             input_contracts_index_to_output_index: self
                 .input_contracts_index_to_output_index,
+            read_only_contracts: self.read_only_contracts,
             storage: self.storage.0,
             debugger: self.debugger,
             context: self.context,
@@ -196,6 +197,7 @@ where
             input_contracts: self.input_contracts,
             input_contracts_index_to_output_index: self
                 .input_contracts_index_to_output_index,
+            read_only_contracts: self.read_only_contracts,
             storage: Record::new(self.storage),
             debugger: self.debugger,
             context: self.context,

--- a/fuel-vm/src/interpreter/flow.rs
+++ b/fuel-vm/src/interpreter/flow.rs
@@ -28,6 +28,7 @@ use crate::{
             gas_charge,
         },
         internal::{
+            check_contract_is_not_read_only,
             current_contract,
             external_asset_id_balance_sub,
             inc_pc,
@@ -336,7 +337,7 @@ impl JumpArgs {
         };
 
         if target_addr >= VM_MAX_RAM {
-            return Err(PanicReason::MemoryOverflow.into())
+            return Err(PanicReason::MemoryOverflow.into());
         }
 
         *pc = target_addr;
@@ -398,6 +399,7 @@ where
             runtime_balances: &mut self.balances,
             storage: &mut self.storage,
             input_contracts: &self.input_contracts,
+            read_only_contracts: &self.read_only_contracts,
             panic_context: &mut self.panic_context,
             new_storage_gas_per_byte,
             receipts: &mut self.receipts,
@@ -465,6 +467,7 @@ struct PrepareCallCtx<'vm, S, V> {
     new_storage_gas_per_byte: Word,
     storage: &'vm mut S,
     input_contracts: &'vm BTreeSet<ContractId>,
+    read_only_contracts: &'vm BTreeSet<ContractId>,
     panic_context: &'vm mut PanicContext,
     receipts: &'vm mut ReceiptsCtx,
     frames: &'vm mut Vec<CallFrame>,
@@ -501,6 +504,24 @@ impl<S, V> PrepareCallCtx<'_, S, V> {
         )?;
 
         let amount = self.params.amount_of_coins_to_forward;
+
+        // Forwarding coins modifies the balances of both the funding source
+        // and the callee, which is forbidden for read-only contracts.
+        if amount > 0 {
+            if let Some(source_contract) = self.current_contract {
+                check_contract_is_not_read_only(
+                    self.panic_context,
+                    self.read_only_contracts,
+                    &source_contract,
+                )?;
+            }
+            check_contract_is_not_read_only(
+                self.panic_context,
+                self.read_only_contracts,
+                call.to(),
+            )?;
+        }
+
         if let Some(source_contract) = self.current_contract {
             balance_decrease(self.storage, &source_contract, &asset_id, amount)?;
         } else {

--- a/fuel-vm/src/interpreter/flow/tests.rs
+++ b/fuel-vm/src/interpreter/flow/tests.rs
@@ -392,6 +392,7 @@ fn test_prepare_call(input: Input) -> Result<Output, RuntimeError<Infallible>> {
         runtime_balances: &mut runtime_balances,
         storage: &mut storage,
         input_contracts: &input_contracts,
+        read_only_contracts: &Default::default(),
         panic_context: &mut panic_context,
         new_storage_gas_per_byte: 0,
         receipts: &mut receipts,

--- a/fuel-vm/src/interpreter/initialization.rs
+++ b/fuel-vm/src/interpreter/initialization.rs
@@ -141,6 +141,27 @@ where
             })
             .collect();
 
+        // Contract inputs without the corresponding contract output are
+        // read-only: there is no output to commit updated roots, so their
+        // state and balances must not be modified during execution.
+        self.read_only_contracts = self
+            .tx
+            .inputs()
+            .iter()
+            .enumerate()
+            .filter_map(|(input_idx, i)| match i {
+                Input::Contract(contract) => {
+                    let input_idx = u16::try_from(input_idx)
+                        .expect("The maximum number of inputs is `u16::MAX`");
+                    (!self
+                        .input_contracts_index_to_output_index
+                        .contains_key(&input_idx))
+                    .then_some(contract.contract_id)
+                }
+                _ => None,
+            })
+            .collect();
+
         self.initial_balances = initial_balances.clone();
 
         self.frames.clear();

--- a/fuel-vm/src/interpreter/internal.rs
+++ b/fuel-vm/src/interpreter/internal.rs
@@ -170,7 +170,7 @@ pub(crate) fn set_flag(
     a: Word,
 ) -> SimpleResult<()> {
     let Some(flags) = Flags::from_bits(a) else {
-        return Err(PanicReason::InvalidFlags.into())
+        return Err(PanicReason::InvalidFlags.into());
     };
 
     *flag = flags.bits();
@@ -239,4 +239,21 @@ pub(crate) fn set_frame_pointer(
     context.update_from_frame_pointer(fp);
 
     *register = fp;
+}
+
+/// Returns `PanicReason::ContractIsReadOnly` if the contract is declared as a
+/// read-only input (a contract input without the corresponding contract
+/// output). Used to guard every operation that modifies the state or balances
+/// of a contract.
+pub(crate) fn check_contract_is_not_read_only(
+    panic_context: &mut super::PanicContext,
+    read_only_contracts: &alloc::collections::BTreeSet<ContractId>,
+    contract_id: &ContractId,
+) -> Result<(), PanicReason> {
+    if read_only_contracts.contains(contract_id) {
+        *panic_context = super::PanicContext::ContractId(*contract_id);
+        Err(PanicReason::ContractIsReadOnly)
+    } else {
+        Ok(())
+    }
 }

--- a/fuel-vm/src/interpreter/storage.rs
+++ b/fuel-vm/src/interpreter/storage.rs
@@ -12,6 +12,7 @@ use crate::{
         IoResult,
         RuntimeError,
     },
+    interpreter::internal::check_contract_is_not_read_only,
     prelude::{
         Interpreter,
         Memory,
@@ -122,6 +123,11 @@ where
         key: Bytes32,
         value: Vec<u8>,
     ) -> Result<(), RuntimeError<S::DataError>> {
+        check_contract_is_not_read_only(
+            &mut self.panic_context,
+            &self.read_only_contracts,
+            &contract_id,
+        )?;
         let old_len = self.storage_slot_len_no_gas(contract_id, key)?;
         let max_size = self.interpreter_params.max_storage_slot_length;
         if (value.len() as u64) > max_size {
@@ -170,6 +176,11 @@ where
         key: Bytes32,
         range: usize,
     ) -> Result<(), RuntimeError<S::DataError>> {
+        check_contract_is_not_read_only(
+            &mut self.panic_context,
+            &self.read_only_contracts,
+            &contract_id,
+        )?;
         // Ensure the key range doesn't overflow U256. A range of 0 or 1 starting at
         // any key is always valid; for larger ranges we check that
         // start_key + (range - 1) doesn't wrap around.

--- a/fuel-vm/src/tests/mod.rs
+++ b/fuel-vm/src/tests/mod.rs
@@ -31,6 +31,7 @@ mod memory;
 mod metadata;
 mod outputs;
 mod predicate;
+mod read_only_contract_inputs;
 mod receipts;
 mod spec;
 mod storage;

--- a/fuel-vm/src/tests/read_only_contract_inputs.rs
+++ b/fuel-vm/src/tests/read_only_contract_inputs.rs
@@ -1,0 +1,352 @@
+//! Tests for read-only contract inputs: contract inputs without the
+//! corresponding contract output. Reading the contract's state and balances
+//! (and executing its code) is allowed, while any modification panics with
+//! [`PanicReason::ContractIsReadOnly`].
+
+use alloc::{
+    vec,
+    vec::Vec,
+};
+
+use crate::{
+    prelude::*,
+    script_with_data_offset,
+    tests::test_helpers::{
+        assert_panics,
+        assert_success,
+    },
+    util::test_helpers::TestBuilder,
+};
+use fuel_asm::{
+    GTFArgs,
+    RegId,
+    op,
+};
+use fuel_types::{
+    AssetId,
+    ContractId,
+    Immediate18,
+    canonical::Serialize,
+};
+
+/// Deploys a contract with the given program and calls it (without forwarding
+/// any coins) through a read-only contract input.
+fn call_read_only_contract(program: Vec<Instruction>) -> Vec<Receipt> {
+    call_read_only_contract_with_balance(program, None)
+}
+
+/// Same as [`call_read_only_contract`], but the deployed contract starts with
+/// the given asset balance.
+fn call_read_only_contract_with_balance(
+    program: Vec<Instruction>,
+    initial_balance: Option<(AssetId, Word)>,
+) -> Vec<Receipt> {
+    let mut test_context = TestBuilder::new(2322u64);
+
+    let contract_id = test_context
+        .setup_contract(program, initial_balance, None)
+        .contract_id;
+
+    let (script_call, _) = script_with_data_offset!(
+        data_offset,
+        vec![
+            op::movi(0x10, data_offset as Immediate18),
+            op::call(0x10, RegId::ZERO, 0x10, RegId::CGAS),
+            op::ret(RegId::ONE),
+        ],
+        test_context.get_tx_params().tx_offset()
+    );
+    let script_call_data = Call::new(contract_id, 0, 0).to_bytes();
+
+    let result = test_context
+        .start_script(script_call, script_call_data)
+        .script_gas_limit(1_000_000)
+        .contract_input(contract_id)
+        .fee_input()
+        .execute();
+
+    result.receipts().to_vec()
+}
+
+#[test]
+fn read_only_contract_input__state_read__succeeds() {
+    let receipts = call_read_only_contract(vec![
+        // Allocate a zeroed 32-byte key
+        op::movi(0x15, 32),
+        op::aloc(0x15),
+        // Read a word from the contract's own state
+        op::srw(0x10, 0x11, RegId::HP, 0),
+        op::log(0x10, 0x11, RegId::ZERO, RegId::ZERO),
+        op::ret(RegId::ONE),
+    ]);
+
+    assert_success(&receipts);
+}
+
+#[test]
+fn read_only_contract_input__balance_read__succeeds() {
+    let receipts = call_read_only_contract(vec![
+        // Allocate a zeroed 32-byte asset id
+        op::movi(0x15, 32),
+        op::aloc(0x15),
+        // Read the contract's own balance: BAL(dst, asset_ptr, contract_ptr)
+        op::bal(0x10, RegId::HP, RegId::FP),
+        op::log(0x10, RegId::ZERO, RegId::ZERO, RegId::ZERO),
+        op::ret(RegId::ONE),
+    ]);
+
+    assert_success(&receipts);
+}
+
+#[test]
+fn read_only_contract_input__state_write__panics() {
+    let receipts = call_read_only_contract(vec![
+        // Allocate a zeroed 32-byte key
+        op::movi(0x15, 32),
+        op::aloc(0x15),
+        // Attempt to write a word to the contract's own state
+        op::sww(RegId::HP, 0x11, RegId::ONE),
+        op::ret(RegId::ONE),
+    ]);
+
+    assert_panics(&receipts, PanicReason::ContractIsReadOnly);
+}
+
+#[test]
+fn read_only_contract_input__state_clear__panics() {
+    let receipts = call_read_only_contract(vec![
+        // Allocate a zeroed 32-byte key
+        op::movi(0x15, 32),
+        op::aloc(0x15),
+        // Attempt to clear a slot of the contract's own state
+        op::scwq(RegId::HP, 0x11, RegId::ONE),
+        op::ret(RegId::ONE),
+    ]);
+
+    assert_panics(&receipts, PanicReason::ContractIsReadOnly);
+}
+
+#[test]
+fn read_only_contract_input__mint__panics() {
+    let receipts = call_read_only_contract(vec![
+        // Allocate a zeroed 32-byte sub asset id
+        op::movi(0x15, 32),
+        op::aloc(0x15),
+        // Attempt to mint coins of the contract's own asset
+        op::mint(RegId::ONE, RegId::HP),
+        op::ret(RegId::ONE),
+    ]);
+
+    assert_panics(&receipts, PanicReason::ContractIsReadOnly);
+}
+
+#[test]
+fn read_only_contract_input__burn__panics() {
+    let receipts = call_read_only_contract(vec![
+        // Allocate a zeroed 32-byte sub asset id
+        op::movi(0x15, 32),
+        op::aloc(0x15),
+        // Attempt to burn coins of the contract's own asset
+        op::burn(RegId::ONE, RegId::HP),
+        op::ret(RegId::ONE),
+    ]);
+
+    assert_panics(&receipts, PanicReason::ContractIsReadOnly);
+}
+
+#[test]
+fn read_only_contract_input__zero_amount_mint__succeeds() {
+    // Minting zero tokens does not touch the storage, so it is allowed
+    // even for a read-only contract.
+    let receipts = call_read_only_contract(vec![
+        // Allocate a zeroed 32-byte sub asset id
+        op::movi(0x15, 32),
+        op::aloc(0x15),
+        op::mint(RegId::ZERO, RegId::HP),
+        op::ret(RegId::ONE),
+    ]);
+
+    assert_success(&receipts);
+}
+
+#[test]
+fn read_only_contract_input__zero_amount_burn__succeeds() {
+    // Burning zero tokens does not touch the storage, so it is allowed
+    // even for a read-only contract.
+    let receipts = call_read_only_contract(vec![
+        // Allocate a zeroed 32-byte sub asset id
+        op::movi(0x15, 32),
+        op::aloc(0x15),
+        op::burn(RegId::ZERO, RegId::HP),
+        op::ret(RegId::ONE),
+    ]);
+
+    assert_success(&receipts);
+}
+
+#[test]
+fn read_only_contract_input__smo_with_coins__panics() {
+    let receipts = call_read_only_contract_with_balance(
+        vec![
+            // Allocate a zeroed 32-byte recipient address
+            op::movi(0x15, 32),
+            op::aloc(0x15),
+            // Attempt to send a message with coins from the contract's balance
+            op::smo(RegId::HP, RegId::HP, RegId::ZERO, RegId::ONE),
+            op::ret(RegId::ONE),
+        ],
+        Some((AssetId::zeroed(), 100)),
+    );
+
+    assert_panics(&receipts, PanicReason::ContractIsReadOnly);
+}
+
+#[test]
+fn read_only_contract_input__transfer_to_contract__panics() {
+    let contract_id_ptr = 0x11;
+    let asset_id_ptr = 0x12;
+
+    let ops = vec![
+        op::gtf_args(contract_id_ptr, RegId::ZERO, GTFArgs::ScriptData),
+        op::addi(
+            asset_id_ptr,
+            contract_id_ptr,
+            ContractId::LEN.try_into().unwrap(),
+        ),
+        // Attempt to transfer coins to the read-only contract
+        op::tr(contract_id_ptr, RegId::ONE, asset_id_ptr),
+        op::ret(RegId::ONE),
+    ];
+
+    let mut test_context = TestBuilder::new(2322u64);
+    let asset_id = AssetId::zeroed();
+
+    let contract_id = test_context
+        .setup_contract(vec![op::ret(RegId::ONE)], None, None)
+        .contract_id;
+
+    let script_data: Vec<u8> = contract_id
+        .to_bytes()
+        .into_iter()
+        .chain(asset_id.to_bytes())
+        .collect();
+
+    let result = test_context
+        .start_script(ops, script_data)
+        .script_gas_limit(1_000_000)
+        .contract_input(contract_id)
+        .coin_input(asset_id, 100)
+        .fee_input()
+        .change_output(asset_id)
+        .execute();
+
+    assert_panics(result.receipts(), PanicReason::ContractIsReadOnly);
+}
+
+#[test]
+fn read_only_contract_input__call_with_forwarded_coins__panics() {
+    let mut test_context = TestBuilder::new(2322u64);
+    let asset_id = AssetId::zeroed();
+
+    let contract_id = test_context
+        .setup_contract(vec![op::ret(RegId::ONE)], None, None)
+        .contract_id;
+
+    let (script_call, _) = script_with_data_offset!(
+        data_offset,
+        vec![
+            op::movi(0x10, data_offset as Immediate18),
+            op::movi(0x12, data_offset as Immediate18 + Call::LEN as Immediate18),
+            op::movi(0x13, 10),
+            // Attempt to forward coins to the read-only contract
+            op::call(0x10, 0x13, 0x12, RegId::CGAS),
+            op::ret(RegId::ONE),
+        ],
+        test_context.get_tx_params().tx_offset()
+    );
+    let script_call_data: Vec<u8> = Call::new(contract_id, 0, 0)
+        .to_bytes()
+        .into_iter()
+        .chain(asset_id.to_bytes())
+        .collect();
+
+    let result = test_context
+        .start_script(script_call, script_call_data)
+        .script_gas_limit(1_000_000)
+        .contract_input(contract_id)
+        .coin_input(asset_id, 100)
+        .fee_input()
+        .change_output(asset_id)
+        .execute();
+
+    assert_panics(result.receipts(), PanicReason::ContractIsReadOnly);
+}
+
+#[test]
+fn read_only_contract_input__sibling_writable_contract__can_still_write() {
+    let mut test_context = TestBuilder::new(2322u64);
+
+    let writable_id = test_context
+        .setup_contract(
+            vec![
+                // Allocate a zeroed 32-byte key and write to own state
+                op::movi(0x15, 32),
+                op::aloc(0x15),
+                op::sww(RegId::HP, 0x11, RegId::ONE),
+                op::ret(RegId::ONE),
+            ],
+            None,
+            None,
+        )
+        .contract_id;
+    let read_only_id = test_context
+        .setup_contract(vec![op::ret(RegId::ONE)], None, None)
+        .contract_id;
+
+    let (script_call, _) = script_with_data_offset!(
+        data_offset,
+        vec![
+            op::movi(0x10, data_offset as Immediate18),
+            op::call(0x10, RegId::ZERO, 0x10, RegId::CGAS),
+            op::ret(RegId::ONE),
+        ],
+        test_context.get_tx_params().tx_offset()
+    );
+    let script_call_data = Call::new(writable_id, 0, 0).to_bytes();
+
+    let result = test_context
+        .start_script(script_call, script_call_data)
+        .script_gas_limit(1_000_000)
+        .contract_input(writable_id)
+        .contract_input(read_only_id)
+        .fee_input()
+        .contract_output(&writable_id)
+        .execute();
+
+    assert_success(result.receipts());
+}
+
+#[test]
+fn read_only_contract_input__gtf_output_index__panics() {
+    let mut test_context = TestBuilder::new(2322u64);
+
+    let contract_id = test_context
+        .setup_contract(vec![op::ret(RegId::ONE)], None, None)
+        .contract_id;
+
+    // The contract input is at index 0 and has no corresponding output.
+    let ops = vec![
+        op::movi(0x11, 0),
+        op::gtf(0x10, 0x11, GTFArgs::InputContractOutputIndex as u16),
+        op::ret(RegId::ONE),
+    ];
+
+    let result = test_context
+        .start_script(ops, vec![])
+        .script_gas_limit(1_000_000)
+        .contract_input(contract_id)
+        .fee_input()
+        .execute();
+
+    assert_panics(result.receipts(), PanicReason::InputNotFound);
+}


### PR DESCRIPTION
Groundwork for concurrent execution of read-heavy contract transactions (fuel-core's lane-scheduler txpool integration derives `Read` access for contract inputs without a matching output).

## Description

Relaxes transaction validity so that a **contract input without the corresponding contract output** is valid and denotes a **read-only contract access**. The contract's code can be executed and its state and balances read, but any modification panics. Since a read-only contract's state root and balance root cannot change, no output slot is needed to commit new roots — which lets block producers/schedulers run transactions that only read a shared contract (oracles, config registries) concurrently. Simulation on read-heavy traffic measured up to ~7x throughput once such inputs exist.

**This is automatic on the new version — it is not gated behind a consensus parameter.** Every transaction on a node running this version supports read-only contract inputs; activation is coordinated by node/VM version, not by an on-chain flag.

### fuel-tx

* A contract input may now have **zero or one** associated contract output. Zero = read-only; one = the usual read-write case whose new roots are committed to that output. **More than one is still rejected** (`InputContractAssociatedOutputContract`).
* The output-side check (`OutputContractInputIndex`) is unchanged: a contract output must still point at a contract input.
* `Input::check` / `Input::check_without_signature` and the TypeScript `check_input` binding **keep their original signatures** — no consensus-parameter plumbing.

### fuel-vm

* The interpreter computes `read_only_contracts` at init: contract inputs with no entry in the input→output index map.
* Every state/balance mutation path panics with the new `PanicReason::ContractIsReadOnly = 0x43` when targeting such a contract:
  * storage writes and clears (`SWW`, `SWWQ`, `SWRD`/`SWRI`, `SUPD`/`SUPI`, `SCWQ`) — guarded at the two central chokepoints `storage_write_slot` / `storage_clear_slot_range`;
  * `MINT` / `BURN` with a non-zero amount (zero-amount is a storage no-op and stays allowed);
  * `TR` / `TRO` debits and credits;
  * `SMO` with coins;
  * `CALL` with forwarded coins (coin-less calls work, so read-only contracts remain fully executable).
* `GTF InputContractOutputIndex` panics with `InputNotFound` for a read-only input (no mapping exists), as the map-based lookup already did.

### Audit notes

The VM does not otherwise rely on every contract input having an output: the input→output index map is consumed only by the GTF opcode above, and all `ContractsState`/`ContractsAssets` writers route through the guarded paths (the only unguarded writers are Create-tx deployment of the newly created contract and test/diff-revert helpers).

## Breaking changes

* **Consensus-breaking** transaction-validity change: a contract input without a contract output is now accepted (previously `InputContractAssociatedOutputContract`). Active for every transaction on this version — not gated behind a consensus parameter.
* New `PanicReason` variant `ContractIsReadOnly = 0x43` (`PanicReason` is `#[non_exhaustive]`).

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] If performance characteristic of an instruction change, update gas costs as well or make a follow-up PR for that (no gas changes; guards are set lookups)
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (spec update PR needed — follow-up)

### Before requesting review
- [x] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here (fuel-specs update; fuel-core integration)

### After merging, notify other teams

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/) (contract input without output is now valid)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
